### PR TITLE
chore(backend): improve DX scripts and dev deps

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "jest --passWithNoTests",
+"test": "jest --ci",
+     "typecheck": "tsc --noEmit",
     "start:compliance": "node dist/compliance/server.js"
   },
   "dependencies": {
@@ -21,5 +22,7 @@
     "@types/jest": "^29.5.12",
     "supertest": "^7.0.0",
     "@types/supertest": "^2.0.16"
+        "@types/express": "^4.17.21",
+    "@types/uuid": "^9.0.2"
   }
 }


### PR DESCRIPTION
Update backend package.json to improve developer experience:
- Change test script to use `jest --ci` for CI-mode tests.
- Add a `typecheck` script that runs `tsc --noEmit`.
- Add missing type definitions for Express and UUID (@types/express, @types/uuid) to devDependencies.

These changes ensure proper type checking and CI-friendly test execution.

## Endringsplan
- [x] Oppdatert `backend/package.json`: oppdatert test-script til `jest --ci`, lagt til `typecheck`-script, og lagt til `@types/express` og `@types/uuid` i `devDependencies`.

## Hva & hvorfor
For å forbedre utvikleropplevelsen (DX) oppdaterer denne PR-en script-konfigurasjonen slik at Jest kjøres i CI-modus og TypeScript-koden sjekkes uten å generere filer. Manglende type-definisjoner for Express og UUID er lagt til for bedre Intellisense og typekontroll.

## Tester
- [ ] Unit
- [ ] E2E (hvis relevant)

## Deploy / Helm
- [x] Ingen secrets i repo
