### PR TITLE
chore(ci): run full tests and typecheck in backend-ci

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -38,3 +38,11 @@ jobs:
       - name: Run smoke tests (temporary)
         working-directory: backend
         run: npx jest --ci --config jest.ci.config.cjs
+
+  - name: Run tests
+    working-directory: backend
+    run: npm test
+
+  - name: Run typecheck
+    working-directory: backend
+    run: npm run typecheck


### PR DESCRIPTION
Adds steps to run jest tests (npm test) and TypeScript typecheck after smoke tests in the backend CI pipeline.

## Endringsplan
- [ ] Filer endret/lagt til:
  - .github/workflows/backend-ci.yml

## Hva & hvorfor
Oppdaterer backend CI-workflow til å kjøre hele testpakken (npm test) og typechecking (npm run typecheck) etter smoke tests. Dette sikrer at CI fanger opp feil fra både jest-tests og TypeScript før PR merges.

## Tester
- [ ] Unit: CI workflow i denne PR-en kjører `npm test` (som bruker jest) og `npm run typecheck`. Skal gå grønt.
- [ ] E2E: Ikke relevant.

## Deploy / Helm
- [ ] Ingen secrets i repo
- [ ] Helm values oppdatert (ikke relevant)

## Sikkerhet
- RBAC: n/a
- Audit: n/a
- Tilsyn: n/a