### PR TITLE
feat(frontend): bootstrap React + Electron shell

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workbuoy</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "electron": "^27.0.0"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
Legger til en package.json for den nye frontend-mappen med skript for dev og build ved bruk av Vite, samt avhengigheter for React og Electron.

## Endringsplan
- [ ] Fil lagt til: `frontend/package.json` med scripts for utvikling og bygging

## Hva & hvorfor
Dette setter opp grunnleggende pakkeinformasjon for frontend-skjell med React og Electron. Scripts gir `vite` for utvikling og bygging. Dette er første steg mot en fungerende web- og desktopklient.

## Tester
- [ ] Manuell: kjør `npm install` og `npm run dev` i `frontend/` og verifiser at ingenting feiler. (Foreløpig ingen enhetstester.)

## Deploy / Helm
- [ ] Ingen secrets i repo. Denne endringen påvirker ikke deploy.

## Sikkerhet
Ingen sensitive data berøres.