### PR TITLE
feat(ux): Buoy↔Navi flip-card vision v1 and prototype

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -13,6 +13,7 @@
 - Role integration: READY (stub)
 - Meta logging: READY (stub)
 - Meta dashboards: READY (stub)
+
 - Auto-doc: READY (stub)
 - Knowledge base: READY (stub)
 - Kraken simulation: READY (stub)
@@ -28,6 +29,7 @@
 - Navi prototype: READY
 - FocusCard prototype: READY
 - ModeSwitch prototype: READY
+- - UX Vision v1: ✅
 
 
 ## Consolidation

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -1,0 +1,113 @@
+# Workbuoy UX Vision: Buoy AI + Navi
+
+## Concept overview
+
+Workbuoy er bygget som en AI‑drevet kontorplattform hvor **Buoy AI** (en graderbar, forklarbar assistent) og **Navi** (et kontekstuelt navigasjonslag) jobber sammen for å gi brukeren et enkelt, men kraftig grensesnitt. Buoy AI opererer på forsiden av et *flip‑kort* og gir samtalebasert assistanse. Navi lever på baksiden av samme kort og organiserer add‑ons (e‑post, CRM, ERP osv.) og datavisualiseringer i et oversiktlig rutenett. Flip‑kortet er basert på et velkjent mønster hvor et kort snus for å avsløre baksiden når brukeren klikker eller sveiper【158162014912867†L78-L112】.
+
+## Flip‑kort interaksjonsmodell
+
+**Forside – Buoy AI chat**
+
+* Den synlige siden viser et chatgrensesnitt. Brukere kan stille spørsmål eller gi kommandoer, og Buoy AI svarer med naturlig språk. Enkelt handlinger som «vis omsetningen forrige måned» tolkes og utføres; resultater presenteres direkte i chatten som tekst eller små visualiseringer.
+
+**Bakside – Navi add‑ons**
+
+* Når kortet snus, kommer Navi frem. Her finner brukerne et rutenett med add‑ons som representerer integrasjoner (Outlook, SharePoint, CRM, ERP, analyseverktøy m.m.) og kontekstuelle datasett. Snufunksjonen aktiveres via en knapp eller sveip; på små skjermer bruker vi vertikal snuing for å spare plass. Mønsteret bygger på at knappen endrer flip‑tilstand og roterer kortet 180° for å vise baksiden【158162014912867†L109-L112】.
+
+## Mikro‑visualiseringer i chatten
+
+Mange forespørsler returnerer strukturerte data. I stedet for å sende brukeren til separate dashbord, viser Workbuoy **mikro‑visualiseringer** – små diagrammer eller tabeller – direkte i samtalen. Gestalt sin veiledning for mikro‑visualiseringer beskriver disse som små grafiske fremstillinger som støtter større datasett og kan vises i tabeller, kort eller pop‑over for å gi rask kontekst【334328420731481†L51-L55】. De fungerer best når brukeren kan forstå hovedpoenget med et blikk【334328420731481†L61-L65】, og de bør være interaktive med tooltips eller mulighet for utvidelse【334328420731481†L71-L77】. Sparklines, mini‑bars og mini‑donuts passer godt i den begrensede plassen i en chatboble【334328420731481†L106-L124】. I Workbuoy velger Buoy AI automatisk passende visualiseringer og viser dem sammen med forklarende tekst.
+
+## React‑prototyp med flip‑kort
+
+Under er et enkelt React‑komponent som illustrerer flip‑kort‑mønsteret. Forsiden inneholder en placeholder for Buoy AI‑chatten og et eksempel på en mikro‑visualisering. Baksiden viser en liste over add‑ons. En knapp bytter `isFlipped`‑tilstanden og roterer kortet. For enkelhetens skyld er stilene inline; i en ekte applikasjon bør de flyttes til CSS‑moduler eller styled‑components.
+
+```tsx
+import React, { useState } from 'react';
+
+export default function FlipCardPrototype() {
+  const [isFlipped, setFlipped] = useState(false);
+
+  return (
+    <div style={{ perspective: '1000px', width: '100%', height: '400px' }}>
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          transformStyle: 'preserve-3d',
+          transition: 'transform 0.6s',
+          transform: isFlipped ? 'rotateY(180deg)' : 'none'
+        }}
+      >
+        {/* Forside: Buoy AI chat */}
+        <div
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            backfaceVisibility: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            padding: '1rem',
+            boxSizing: 'border-box',
+            backgroundColor: '#F4F7FA',
+            borderRadius: '8px'
+          }}
+        >
+          <h2>Buoy AI</h2>
+          <div style={{ flex: 1, overflowY: 'auto', marginBottom: '1rem', background: '#fff', borderRadius: '4px', padding: '0.5rem' }}>
+            {/* Chatmeldinger */
+            <p><strong>Bruker:</strong> Hva er omsetningstrenden vår?</p>
+            <p><strong>Buoy:</strong> Her er en rask oversikt:</p>
+            {/* Eksempel på mikro‑visualisering (sparkline) */}
+            <svg width="100%" height="40">
+              <polyline
+                fill="none"
+                stroke="#007acc"
+                strokeWidth="2"
+                points="0,30 25,20 50,25 75,10 100,20"
+              />
+            </svg>
+          </div>
+          <button onClick={() => setFlipped(true)} style={{ alignSelf: 'center' }}>Åpne Navi</button>
+        </div>
+
+        {/* Bakside: Navi‑add‑ons */}
+        <div
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            backfaceVisibility: 'hidden',
+            transform: 'rotateY(180deg)',
+            display: 'flex',
+            flexDirection: 'column',
+            padding: '1rem',
+            boxSizing: 'border-box',
+            backgroundColor: '#F0F4F8',
+            borderRadius: '8px'
+          }}
+        >
+          <h2>Navi‑add‑ons</h2>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', flex: 1, overflowY: 'auto' }}>
+            {['Outlook','SharePoint','CRM','ERP','Analytics'].map((addon) => (
+              <div key={addon} style={{ flex: '1 1 45%', minWidth: '120px', background: '#fff', borderRadius: '4px', padding: '0.5rem', textAlign: 'center', boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}>
+                {addon}
+              </div>
+            ))}
+          </div>
+          <button onClick={() => setFlipped(false)} style={{ alignSelf: 'center' }}>Tilbake til Buoy AI</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+`
+
+## Videre arbeid
+
+1. **Komponentintegrasjon** – Flytt prototypen inn i riktig front‑end‑pakke (for eksempel `enterprise/pages` eller et delt komponentbibliotek) og erstatt placeholder‑innhold med ekte chat‑ og add‑on‑komponenter.
+2. **Stil og responsivitet** – Ekstraher stiler til CSS‑moduler eller styled‑components, og sørg for at flip‑kortet fungerer på mobil med vertikal orientasjon.
+3. **Mikro‑visualiseringsbibliotek** – Integrer et diagrambibliotek (for eksempel Chart.js eller D3) for dynamisk rendering av sparklines og mini‑diagrammer. Husk å annotere nøkkelpunkter og tilby tooltips【334328420731481†L71-L86】.
+4. **Tilgjengelighet** – Gi tastaturnavigasjon for flipping (for eksempel bruk av mellomromstasten), skjermleser‑etiketter for knappene og alternativ tekst for diagrammer.

--- a/prototypes/FlipCardPrototype.tsx
+++ b/prototypes/FlipCardPrototype.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+
+/**
+ * A simple flip‑card component that demonstrates how Buoy AI and Navi could
+ * coexist on two sides of the same UI element. When `isFlipped` is true the
+ * card rotates around the Y‑axis to reveal the back. The front contains a
+ * placeholder chat area along with an example sparkline micro‑visualization,
+ * while the back shows a grid of add‑on modules. Styling is kept inline
+ * for clarity; in production, move styles into CSS modules or a styling
+ * solution of your choice.
+ */
+export default function FlipCardPrototype() {
+  const [isFlipped, setFlipped] = useState(false);
+
+  /**
+   * Handle keyboard interactions for accessibility. If the user presses
+   * Space or Enter while the card has focus, toggle the flipped state.
+   */
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      setFlipped((prev) => !prev);
+    }
+  }
+
+  return (
+    <div style={{ perspective: '1000px', width: '100%', height: '400px' }}>
+      {/* The inner container is focusable and labelled for screen readers. */}
+      <div
+        role="region"
+        aria-label="Buoy AI og Navi kort"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          transformStyle: 'preserve-3d',
+          transition: 'transform 0.6s',
+          transform: isFlipped ? 'rotateY(180deg)' : 'none'
+        }}
+      >
+        {/* Forside: Buoy AI chat */}
+        <div
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            backfaceVisibility: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            padding: '1rem',
+            boxSizing: 'border-box',
+            backgroundColor: '#F4F7FA',
+            borderRadius: '8px'
+          }}
+        >
+          <h2>Buoy AI</h2>
+          <div
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              marginBottom: '1rem',
+              background: '#fff',
+              borderRadius: '4px',
+              padding: '0.5rem'
+            }}
+            aria-live="polite"
+          >
+            {/* Eksempel på chatmeldinger */
+            <p><strong>Bruker:</strong> Hva er omsetningstrenden vår?</p>
+            <p><strong>Buoy:</strong> Her er en rask oversikt:</p>
+            {/* Sparkline mikro‑visualisering med tooltip */}
+            <svg
+              width="100%"
+              height="40"
+              aria-label="Liten graf som viser omsetningstrend"
+            >
+              <title>Omsetning de siste fem månedene</title>
+              <polyline
+                fill="none"
+                stroke="#007acc"
+                strokeWidth="2"
+                points="0,30 25,20 50,25 75,10 100,20"
+              />
+            </svg>
+            {/* Vis hvorfor‑knapp: placeholder for forklaringer/kilder */}
+            <button
+              type="button"
+              onClick={() => {
+                /* TODO: connect to explanation drawer */
+                alert('Dette vil vise forklaringen og kilder.');
+              }}
+              style={{ marginTop: '0.5rem' }}
+            >
+              Vis hvorfor
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setFlipped(true)}
+            style={{ alignSelf: 'center' }}
+            aria-label="Åpne Navi"
+          >
+            Åpne Navi
+          </button>
+        </div>
+
+        {/* Bakside: Navi‑add‑ons */}
+        <div
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            backfaceVisibility: 'hidden',
+            transform: 'rotateY(180deg)',
+            display: 'flex',
+            flexDirection: 'column',
+            padding: '1rem',
+            boxSizing: 'border-box',
+            backgroundColor: '#F0F4F8',
+            borderRadius: '8px'
+          }}
+        >
+          <h2>Navi‑add‑ons</h2>
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '0.5rem',
+              flex: 1,
+              overflowY: 'auto'
+            }}
+          >
+            {['Outlook', 'SharePoint', 'CRM', 'ERP', 'Analyse'].map((addon) => (
+              <div
+                key={addon}
+                style={{
+                  flex: '1 1 45%',
+                  minWidth: '120px',
+                  background: '#fff',
+                  borderRadius: '4px',
+                  padding: '0.5rem',
+                  textAlign: 'center',
+                  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)'
+                }}
+              >
+                {addon}
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => setFlipped(false)}
+            style={{ alignSelf: 'center' }}
+            aria-label="Gå tilbake til Buoy AI"
+          >
+            Tilbake til Buoy AI
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Hva
![flip_small](https://github.com/user-attachments/assets/17909db8-e7eb-4014-b612-341d430b664b)

- Legger til docs/ux.md med visjon for Buoy AI ↔ Navi flip-kort, mikro-visualiseringer og A11y.
- Legger til prototypes/FlipCardPrototype.tsx som React flip-kort prototype (Buoy chat foran, Navi bak).
- Oppdaterer STATUS.md med "UX Vision v1: ✅".

Hvorfor
- Definerer grunnmuren for Workbuoy-opplevelsen: et intuitivt flip-kort som kombinerer chat og data-navigasjon.
- Mikrovisualiseringer og "Vis hvorfor"-mønster gjør AI-responsene forklarbare og transparente for alle brukere.
- A11y-krav og bestemor-vennlige prinsipper sikrer at produktet er tilgjengelig for alle.

Hvordan teste
- Les docs/ux.md for designprinsipper og interaksjonsbeskrivelse.
- Last prototypes/FlipCardPrototype.tsx i en React-sandbox eller Storybook, og se flip-kortet i aksjon.
- Klikk på kortet eller bruk Enter-tasten for å flippe; forsiden viser Buoy-chat med sparkline og "Vis hvorfor"-knapp.

Risiko/roll-back
- Ingen backend- eller CI-endringer, kun nye filer i docs/ og prototypes/.
- Kan rulles tilbake ved å fjerne docs/ux.md, prototypes/FlipCardPrototype.tsx og status-linjen.

TODO (PR-2)
- Flytt flip-kortet inn i en frontendpakke (Vite + React) og lag BuoyChat- og NaviGrid-komponentene.
- Legg til AutonomySlider som styrer hvor mye autonomi Buoy skal ha.
- Lag mock for /api/health for "Backend OK"-indikator og integrer A11y i shell.