### PR TITLE
chore(repo): scaffold core/flex/secure + frontend stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # WorkBuoy Suite
 
+WorkBuoy Suite is an AI‑first office platform built around two core primitives: **Buoy AI** and **Navi**. It replaces traditional apps and menus with context‑aware suggestions and autonomous execution.
+
+## Architecture
+
+* **CORE** – the heart of WorkBuoy. All integrations (CRM, Visma ERP, email), Buoy, Navi, policy hooks, audit logging and explainability live here.
+* **FLEX** – on‑demand mode of the CORE used for ad‑hoc requests. Uses the same endpoints but is triggered manually or via batch jobs.
+* **SECURE** – compliance‑focused mode of the CORE. Enforces stricter policies (e.g. autonomy levels, data redaction, EU‑only processing).
+
+Buoy and Navi live in CORE and behave the same across all modes. **Navi** sets the autonomy level (0 = suggest only, 1 = auto + receipt, 2 = full auto + summary). **Buoy** executes and displays drafts, actions and receipts, always with explanations.  
+For more details, see [docs/core.md](docs/core.md) and [docs/secure.md](docs/secure.md). The current project status is tracked in [STATUS.md](STATUS.md).
 
 ## Release Orchestrate (GitHub Actions)
-Se `.github/workflows/release-orchestrate.yml`. Kjør via Actions → workbuoy-release-orchestrate med inputs `modules` og `environment`.
-
+Se `.github/workflows/release-orchestrate.yml`. Kjør via Actions → workbuoy‑release‑orchestrate med inputs `modules` og `environment`.
 
 ## CI Templates
-- GitLab CI: `.gitlab-ci.yml`
-- Azure DevOps: `azure-pipelines.yml`
+
+- GitLab CI: `.gitlab‑ci.yml`
+- Azure DevOps: `azure‑pipelines.yml`

--- a/docs/core.md
+++ b/docs/core.md
@@ -1,0 +1,3 @@
+# Core Module
+
+This document outlines the core architecture of Workbuoy. The Core module provides the foundation for all modes, including integration with CRM, ERP, and email, as well as Buoy AI and Navi. It defines the complete endpoint, policy hooks, and explanation helpers.

--- a/docs/secure.md
+++ b/docs/secure.md
@@ -1,0 +1,3 @@
+# Secure Mode
+
+This document outlines the Secure mode of Workbuoy. In Secure mode, the same Core APIs are used but additional compliance policies are enforced, such as stricter canExecute requirements, data redaction, and EU data residency guarantees.

--- a/frontend/src/components/AutonomySlider.tsx
+++ b/frontend/src/components/AutonomySlider.tsx
@@ -1,0 +1,6 @@
+// AutonomySlider component stub
+import React from 'react';
+
+export const AutonomySlider: React.FC = () => {
+  return <div>Autonomy Slider placeholder</div>;
+};

--- a/frontend/src/components/WhyDrawer.tsx
+++ b/frontend/src/components/WhyDrawer.tsx
@@ -1,0 +1,6 @@
+// WhyDrawer component stub
+import React from 'react';
+
+export const WhyDrawer: React.FC = () => {
+  return <div>Why Drawer placeholder</div>;
+};

--- a/prototypes/FlipCardPrototype.tsx
+++ b/prototypes/FlipCardPrototype.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const FlipCardPrototype: React.FC = () => {
+  return <div>Flip Card Prototype Placeholder</div>;
+};
+
+export default FlipCardPrototype;

--- a/src/core/complete.ts
+++ b/src/core/complete.ts
@@ -1,0 +1,5 @@
+// Core complete handler stub
+export function complete() {
+  // TODO: implement complete logic
+  return {};
+}

--- a/src/core/explain.ts
+++ b/src/core/explain.ts
@@ -1,0 +1,10 @@
+// Core explanation helpers stub
+export interface Explanation {
+  source: string;
+  ref: string;
+  why: string;
+}
+
+export function buildExplanation(source: string, ref: string, why: string): Explanation {
+  return { source, ref, why };
+}

--- a/src/core/policy.ts
+++ b/src/core/policy.ts
@@ -1,0 +1,5 @@
+// Core policy hook stub
+export function canExecute(user: any, action: any, context: any) {
+  // TODO: implement policy logic
+  return { allow: true };
+}

--- a/src/features/client360/README.md
+++ b/src/features/client360/README.md
@@ -1,0 +1,3 @@
+# Client 360
+
+This is a stub README for the client360 feature.

--- a/src/features/deal-to-invoice/README.md
+++ b/src/features/deal-to-invoice/README.md
@@ -1,0 +1,3 @@
+# Deal to Invoice
+
+This is a stub README for the deal-to-invoice feature.

--- a/src/features/payments/README.md
+++ b/src/features/payments/README.md
@@ -1,0 +1,3 @@
+# Payments
+
+This is a stub README for the payments feature.

--- a/src/integrations/crm/__mocks__/index.ts
+++ b/src/integrations/crm/__mocks__/index.ts
@@ -1,0 +1,6 @@
+// CRM mock integration stub
+export const crmMock = {
+  getContacts: () => {
+    return [];
+  },
+};

--- a/src/integrations/crm/index.ts
+++ b/src/integrations/crm/index.ts
@@ -1,0 +1,6 @@
+// CRM integration stub
+export const crmIntegration = {
+  getContacts: () => {
+    return [];
+  },
+};

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,0 +1,2 @@
+// Integrations index stub
+export * from './crm';


### PR DESCRIPTION
l## Endringsplan

Legger til minimal repo-struktur med stubfiler for kjerne, integrasjoner, features, frontend, docs og prototypes.

**Repo tree (uten node_modules):**
```
src/core/complete.ts
src/core/policy.ts
src/core/explain.ts
src/integrations/index.ts
src/integrations/crm/index.ts
src/integrations/crm/__mocks__/index.ts
src/features/deal-to-invoice/README.md
src/features/payments/README.md
src/features/client360/README.md
frontend/src/components/AutonomySlider.tsx
frontend/src/components/WhyDrawer.tsx
docs/core.md
docs/secure.md
prototypes/FlipCardPrototype.tsx
README.md (oppdatert)
```

## Hva & hvorfor

Dette skaffolder Workbuoy Suite for videre utvikling. Vi legger inn stubber for core/flex/secure-modus og frontendkomponenter slik at fremtidige features kan implementeres i små PR-er. Oppdatert README dokumenterer arkitektur (CORE/FLEX/SECURE), Buoy/Navi og lenker til docs.

## Hvordan teste

Naviger til denne grenen og bekreft at de nye filene finnes, og at README beskriver arkitektur og lenker til docs. CI skal fortsatt være grønn.
