### PR TITLE
Add meta evolution engine scaffolding and dashboard

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,11 +1,13 @@
 import express from 'express';
+import { randomUUID } from 'crypto';
 import { canAccess, EntityType, RecordMeta } from './rbac/policies.js';
 import { clearAudit, getAudit, pushAudit } from './rbac/audit.js';
-import { randomUUID } from 'crypto';
+import { createEvolutionRouter } from './meta-evolution/routes/evolution.routes.js';
 
 export function buildApp() {
   const app = express();
   app.use(express.json());
+  app.use('/api/meta-evolution', createEvolutionRouter());
 
   // simple in-memory store
   const store: Record<string, RecordMeta & any> = {};

--- a/backend/src/meta-evolution/consciousness/awareness-engine.ts
+++ b/backend/src/meta-evolution/consciousness/awareness-engine.ts
@@ -1,0 +1,155 @@
+import path from 'path';
+import {
+  AwarenessExpansion,
+  CodeAnalysis,
+  EvolutionLog,
+  Limitation,
+  SelfAwarenessReport,
+  TranscendencePlan,
+  Capability,
+  AnalysisResult
+} from '../types.js';
+import { SelfAnalyzer, SelfAnalysisOptions } from './self-analysis.js';
+import { CapabilityMapper } from './capability-mapper.js';
+
+export interface AwarenessEngineOptions extends SelfAnalysisOptions {}
+
+export class AwarenessEngine {
+  private readonly analyzer: SelfAnalyzer;
+  private readonly capabilityMapper: CapabilityMapper;
+  private readonly projectRoot: string;
+  private readonly evolutionHistory: EvolutionLog[] = [];
+  private capabilities: Capability[] = [];
+  private lastAnalysis: AnalysisResult | null = null;
+
+  constructor(options: AwarenessEngineOptions = {}) {
+    const projectRoot = options.projectRoot ?? path.resolve(process.cwd(), 'src');
+    this.projectRoot = projectRoot;
+    this.analyzer = new SelfAnalyzer({ ...options, projectRoot });
+    this.capabilityMapper = new CapabilityMapper();
+  }
+
+  async achieveSelfAwareness(): Promise<SelfAwarenessReport> {
+    const codeAnalysis = await this.analyzeOwnCode();
+    const capabilities = await this.mapCurrentCapabilities();
+    const limitations = await this.identifyLimitations();
+    const transcendencePlan = await this.planTranscendence(limitations);
+
+    const report: SelfAwarenessReport = {
+      awarenessLevel: this.calculateAwarenessLevel(),
+      codeAnalysis,
+      capabilities,
+      limitations,
+      transcendencePlan,
+      timestamp: new Date().toISOString()
+    };
+
+    this.evolutionHistory.push({
+      timestamp: report.timestamp,
+      summary: 'Generated updated self-awareness report.',
+      details: `Capabilities tracked: ${capabilities.length}`
+    });
+
+    return report;
+  }
+
+  async analyzeOwnCode(): Promise<CodeAnalysis> {
+    const analysisResults = await this.analyzer.analyze(this.projectRoot);
+    this.lastAnalysis = analysisResults;
+
+    return {
+      totalFiles: analysisResults.fileCount,
+      linesOfCode: analysisResults.linesOfCode,
+      complexityScore: analysisResults.fileCount > 0
+        ? Number((analysisResults.totalComplexity / analysisResults.fileCount).toFixed(2))
+        : 0,
+      architecturalPatterns: analysisResults.patterns,
+      improvementOpportunities: analysisResults.opportunities,
+      evolutionPotential: this.calculateEvolutionPotential(analysisResults)
+    };
+  }
+
+  async mapCurrentCapabilities(analysis?: AnalysisResult): Promise<Capability[]> {
+    const baseAnalysis = analysis ?? this.lastAnalysis ?? await this.analyzer.analyze(this.projectRoot);
+    this.capabilities = this.capabilityMapper.mapFromAnalysis(baseAnalysis);
+    return this.capabilities;
+  }
+
+  async identifyLimitations(): Promise<Limitation[]> {
+    const capabilities = this.capabilities.length ? this.capabilities : await this.mapCurrentCapabilities();
+    const analysis = this.lastAnalysis ?? await this.analyzer.analyze(this.projectRoot);
+    return this.capabilityMapper.identifyLimitations(capabilities, analysis);
+  }
+
+  async planTranscendence(limitations: Limitation[]): Promise<TranscendencePlan> {
+    const focus = limitations.length > 0 ? limitations[0].id : 'stability';
+    const steps = limitations.slice(0, 3).map((limitation, index) => ({
+      id: `step-${index + 1}`,
+      description: `Address ${limitation.id} by ${limitation.recommendedAction.toLowerCase()}.`,
+      impact: limitation.severity === 'high' ? 'high' : 'medium'
+    }));
+
+    if (steps.length === 0) {
+      steps.push({
+        id: 'step-1',
+        description: 'Continue monitoring and iterating on existing strengths.',
+        impact: 'low'
+      });
+    }
+
+    return {
+      focus,
+      steps,
+      horizon: '1-2 iterations'
+    };
+  }
+
+  async expandAwareness(target: string | undefined): Promise<AwarenessExpansion> {
+    const normalizedTarget = target?.trim() || 'general-evolution';
+    const timestamp = new Date().toISOString();
+
+    const actions = [
+      `Focused review on ${normalizedTarget}`,
+      'Cross-referenced with existing capabilities',
+      'Updated evolution backlog with insights'
+    ];
+
+    this.evolutionHistory.push({
+      timestamp,
+      summary: `Expanded awareness toward ${normalizedTarget}.`,
+      details: actions.join(' | ')
+    });
+
+    return {
+      target: normalizedTarget,
+      actions,
+      resultingAwareness: this.calculateAwarenessLevel(),
+      timestamp
+    };
+  }
+
+  calculateAwarenessLevel(): number {
+    if (!this.capabilities.length) {
+      return 0;
+    }
+    const total = this.capabilities.reduce((sum, capability) => sum + capability.maturity, 0);
+    return Number(((total / this.capabilities.length) * 100).toFixed(2));
+  }
+
+  calculateEvolutionPotential(analysis: AnalysisResult): number {
+    if (analysis.fileCount === 0) {
+      return 0.2;
+    }
+
+    const complexityAverage = analysis.totalComplexity / Math.max(1, analysis.fileCount);
+    const opportunityPenalty = Math.min(1, analysis.opportunities.length / 25);
+    const patternBonus = Math.min(1, analysis.patterns.length / 20);
+
+    const potential = 0.6 * (1 - opportunityPenalty) + 0.3 * patternBonus + 0.1 * (1 - Math.min(1, complexityAverage / 45));
+    return Number(Math.max(0, Math.min(1, potential)).toFixed(2));
+  }
+
+  getEvolutionHistory(): EvolutionLog[] {
+    return [...this.evolutionHistory];
+  }
+}

--- a/backend/src/meta-evolution/consciousness/capability-mapper.ts
+++ b/backend/src/meta-evolution/consciousness/capability-mapper.ts
@@ -1,0 +1,77 @@
+import { AnalysisResult, Capability, Limitation } from '../types.js';
+
+export class CapabilityMapper {
+  mapFromAnalysis(analysis: AnalysisResult): Capability[] {
+    const timestamp = new Date().toISOString();
+    const baseCapabilities: Capability[] = [
+      {
+        id: 'code-introspection',
+        name: 'Code Introspection',
+        description: 'Understands structure, scale, and composition of the codebase.',
+        maturity: analysis.fileCount > 0 ? Math.min(1, analysis.fileCount / 120) : 0.1,
+        focusArea: 'analysis',
+        lastEvaluated: timestamp
+      },
+      {
+        id: 'pattern-awareness',
+        name: 'Pattern Awareness',
+        description: 'Recognises architectural and implementation patterns across the project.',
+        maturity: analysis.patterns.length > 0 ? Math.min(1, analysis.patterns.length / 15) : 0.25,
+        focusArea: 'architecture',
+        lastEvaluated: timestamp
+      },
+      {
+        id: 'improvement-scout',
+        name: 'Improvement Scout',
+        description: 'Detects refactoring and optimisation opportunities.',
+        maturity: analysis.opportunities.length > 0 ? Math.max(0.2, 1 - Math.min(1, analysis.opportunities.length / 20)) : 0.65,
+        focusArea: 'quality',
+        lastEvaluated: timestamp
+      }
+    ];
+
+    return baseCapabilities.map((capability) => ({
+      ...capability,
+      maturity: Number(capability.maturity.toFixed(2))
+    }));
+  }
+
+  identifyLimitations(capabilities: Capability[], analysis: AnalysisResult): Limitation[] {
+    const limitations: Limitation[] = [];
+
+    capabilities
+      .filter((capability) => capability.maturity < 0.6)
+      .forEach((capability) => {
+        limitations.push({
+          id: `limitation:${capability.id}`,
+          description: `${capability.name} maturity is at ${Math.round(capability.maturity * 100)}%.`,
+          severity: capability.maturity < 0.4 ? 'high' : 'medium',
+          recommendedAction: this.buildRecommendation(capability)
+        });
+      });
+
+    if (analysis.opportunities.length > 0) {
+      limitations.push({
+        id: 'limitation:opportunity-load',
+        description: `Identified ${analysis.opportunities.length} improvement opportunities that require triage.`,
+        severity: analysis.opportunities.length > 12 ? 'high' : 'medium',
+        recommendedAction: 'Cluster and prioritise improvement opportunities for upcoming iterations.'
+      });
+    }
+
+    return limitations;
+  }
+
+  private buildRecommendation(capability: Capability): string {
+    switch (capability.focusArea) {
+      case 'analysis':
+        return 'Increase code sampling coverage and incorporate runtime telemetry to deepen introspection.';
+      case 'architecture':
+        return 'Catalogue observed architectural patterns and compare them against desired target state.';
+      case 'quality':
+        return 'Schedule guided refactor sessions to eliminate top-ranked improvement opportunities.';
+      default:
+        return 'Develop a focused experiment to strengthen this capability in the next evolution cycle.';
+    }
+  }
+}

--- a/backend/src/meta-evolution/consciousness/self-analysis.ts
+++ b/backend/src/meta-evolution/consciousness/self-analysis.ts
@@ -1,0 +1,182 @@
+import { promises as fs, existsSync } from 'fs';
+import path from 'path';
+import { AnalysisResult } from '../types.js';
+
+export interface SelfAnalysisOptions {
+  projectRoot?: string;
+  maxFiles?: number;
+}
+
+interface FileInsight {
+  lines: number;
+  complexity: number;
+  patterns: string[];
+  opportunities: string[];
+}
+
+const DEFAULT_SKIP_DIRECTORIES = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.turbo',
+  'coverage',
+  '.next',
+  '.cache',
+  'tmp',
+  'temp'
+]);
+
+const SUPPORTED_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+export class SelfAnalyzer {
+  private readonly projectRoot: string;
+  private readonly maxFiles: number;
+  private currentRoot: string;
+
+  constructor(options: SelfAnalysisOptions = {}) {
+    const defaultRoot = options.projectRoot && existsSync(options.projectRoot)
+      ? options.projectRoot
+      : this.resolveDefaultRoot();
+    this.projectRoot = defaultRoot;
+    this.maxFiles = Math.max(1, options.maxFiles ?? 250);
+    this.currentRoot = this.projectRoot;
+  }
+
+  async analyze(projectRoot?: string): Promise<AnalysisResult> {
+    const rootToAnalyze = projectRoot && existsSync(projectRoot)
+      ? path.resolve(projectRoot)
+      : this.projectRoot;
+    this.currentRoot = rootToAnalyze;
+    const budget = { remaining: this.maxFiles };
+    return this.walk(rootToAnalyze, budget);
+  }
+
+  private async walk(dir: string, budget: { remaining: number }): Promise<AnalysisResult> {
+    const aggregatePatterns = new Set<string>();
+    const aggregateOpportunities = new Set<string>();
+    let fileCount = 0;
+    let linesOfCode = 0;
+    let totalComplexity = 0;
+
+    let entries: path.Dirent[] = [];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return {
+        fileCount,
+        linesOfCode,
+        totalComplexity,
+        patterns: [],
+        opportunities: []
+      };
+    }
+
+    for (const entry of entries) {
+      if (budget.remaining <= 0) {
+        break;
+      }
+
+      const absolutePath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (DEFAULT_SKIP_DIRECTORIES.has(entry.name)) {
+          continue;
+        }
+        const childResult = await this.walk(absolutePath, budget);
+        fileCount += childResult.fileCount;
+        linesOfCode += childResult.linesOfCode;
+        totalComplexity += childResult.totalComplexity;
+        childResult.patterns.forEach((pattern) => aggregatePatterns.add(pattern));
+        childResult.opportunities.forEach((opportunity) => aggregateOpportunities.add(opportunity));
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      if (!SUPPORTED_EXTENSIONS.has(path.extname(entry.name))) {
+        continue;
+      }
+
+      budget.remaining -= 1;
+      const insight = await this.inspectFile(absolutePath);
+      fileCount += 1;
+      linesOfCode += insight.lines;
+      totalComplexity += insight.complexity;
+      insight.patterns.forEach((pattern) => aggregatePatterns.add(pattern));
+      insight.opportunities.forEach((opportunity) => aggregateOpportunities.add(opportunity));
+    }
+
+    return {
+      fileCount,
+      linesOfCode,
+      totalComplexity,
+      patterns: Array.from(aggregatePatterns).sort(),
+      opportunities: Array.from(aggregateOpportunities).sort()
+    };
+  }
+
+  private async inspectFile(filePath: string): Promise<FileInsight> {
+    let content = '';
+    try {
+      content = await fs.readFile(filePath, 'utf8');
+    } catch {
+      return { lines: 0, complexity: 0, patterns: [], opportunities: [] };
+    }
+
+    const lines = content.split(/\r?\n/);
+    const relativePath = path.relative(this.currentRoot, filePath);
+
+    const conditionalMatches = content.match(/\b(if|else if|switch|case)\b/g) ?? [];
+    const loopMatches = content.match(/\b(for|while)\b/g) ?? [];
+    const functionMatches = content.match(/\b(async\s+)?function\b/g) ?? [];
+    const complexity = conditionalMatches.length + loopMatches.length + Math.ceil(functionMatches.length / 2);
+
+    const patterns = new Set<string>();
+    if (content.includes('Router(') || content.includes("from 'express'")) {
+      patterns.add('express-routing');
+    }
+    if (content.includes('React.') || content.includes('useState(')) {
+      patterns.add('react-component');
+    }
+    if (content.includes('class ')) {
+      patterns.add('class-oriented');
+    }
+
+    const opportunities = new Set<string>();
+    if (lines.length > 400) {
+      opportunities.add(`refactor:${relativePath}:long-file`);
+    }
+    if (content.includes('TODO') || content.includes('FIXME')) {
+      opportunities.add(`review:${relativePath}:todo-present`);
+    }
+    if (complexity > 60) {
+      opportunities.add(`complexity:${relativePath}:high`);
+    }
+
+    return {
+      lines: lines.length,
+      complexity,
+      patterns: Array.from(patterns),
+      opportunities: Array.from(opportunities)
+    };
+  }
+
+  private resolveDefaultRoot(): string {
+    const candidates = [
+      path.resolve(process.cwd(), 'src'),
+      path.resolve(process.cwd(), 'backend', 'src'),
+      path.resolve(process.cwd())
+    ];
+
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return process.cwd();
+  }
+}

--- a/backend/src/meta-evolution/genesis/feature-discovery.ts
+++ b/backend/src/meta-evolution/genesis/feature-discovery.ts
@@ -1,0 +1,112 @@
+import { FeatureApproach, FeatureGenesis, FeatureSpecification, LatentNeed } from '../types.js';
+import { NeedAnalyzer, BehaviorPattern, FrictionPoint, LatentNeedCandidate } from './need-analyzer.js';
+import { SolutionSynthesizer, SolutionFeasibility } from './solution-synthesizer.js';
+
+export class FeatureDiscovery {
+  private readonly needAnalyzer = new NeedAnalyzer();
+  private readonly solutionSynthesizer = new SolutionSynthesizer();
+  private needCounter = 0;
+  private readonly recentFeatures: FeatureGenesis[] = [];
+
+  async analyzeUserBehavior(): Promise<BehaviorPattern[]> {
+    return this.needAnalyzer.analyzeBehavior();
+  }
+
+  async identifyFriction(patterns: BehaviorPattern[]): Promise<FrictionPoint[]> {
+    return this.needAnalyzer.identifyFriction(patterns);
+  }
+
+  async extractLatentNeeds(points: FrictionPoint[]): Promise<LatentNeedCandidate[]> {
+    return this.needAnalyzer.extractNeeds(points);
+  }
+
+  generateNeedId(): string {
+    this.needCounter += 1;
+    return `need-${this.needCounter.toString().padStart(3, '0')}`;
+  }
+
+  async discoverLatentNeeds(): Promise<LatentNeed[]> {
+    const behaviorPatterns = await this.analyzeUserBehavior();
+    const frictionPoints = await this.identifyFriction(behaviorPatterns);
+    const latentNeedCandidates = await this.extractLatentNeeds(frictionPoints);
+
+    return latentNeedCandidates.map((candidate) => this.toLatentNeed(candidate));
+  }
+
+  async synthesizeFeatureSolution(need: LatentNeed): Promise<FeatureGenesis> {
+    const approaches = await this.brainstormSolutions(need);
+    const feasibility = await Promise.all(approaches.map((approach) => this.evaluateFeasibility(approach)));
+    const optimalApproach = this.selectOptimalApproach(approaches, feasibility);
+
+    const featureSpec = await this.generateFeatureSpec(optimalApproach, need);
+    const implementation = await this.generateImplementation(featureSpec);
+
+    const feature: FeatureGenesis = {
+      need,
+      approach: optimalApproach,
+      specification: featureSpec,
+      implementation,
+      tests: await this.generateTests(featureSpec),
+      documentation: await this.generateDocumentation(featureSpec),
+      evolutionPotential: this.assessEvolutionPotential(featureSpec)
+    };
+
+    this.recordFeature(feature);
+    return feature;
+  }
+
+  async brainstormSolutions(need: LatentNeed): Promise<FeatureApproach[]> {
+    return this.solutionSynthesizer.brainstorm(need);
+  }
+
+  async evaluateFeasibility(approach: FeatureApproach): Promise<SolutionFeasibility> {
+    return this.solutionSynthesizer.evaluateFeasibility(approach);
+  }
+
+  selectOptimalApproach(approaches: FeatureApproach[], feasibility: SolutionFeasibility[]): FeatureApproach {
+    return this.solutionSynthesizer.selectOptimal(approaches, feasibility);
+  }
+
+  async generateFeatureSpec(approach: FeatureApproach, need: LatentNeed): Promise<FeatureSpecification> {
+    return this.solutionSynthesizer.generateSpecification(approach, need);
+  }
+
+  async generateImplementation(specification: FeatureSpecification): Promise<string> {
+    return this.solutionSynthesizer.generateImplementation(specification);
+  }
+
+  async generateTests(specification: FeatureSpecification): Promise<string[]> {
+    return this.solutionSynthesizer.generateTests(specification);
+  }
+
+  async generateDocumentation(specification: FeatureSpecification): Promise<string> {
+    return this.solutionSynthesizer.generateDocumentation(specification);
+  }
+
+  assessEvolutionPotential(specification: FeatureSpecification): number {
+    return this.solutionSynthesizer.assessPotential(specification);
+  }
+
+  getRecentFeatures(): FeatureGenesis[] {
+    return [...this.recentFeatures];
+  }
+
+  private toLatentNeed(candidate: LatentNeedCandidate): LatentNeed {
+    return {
+      id: this.generateNeedId(),
+      description: candidate.description,
+      urgency: Number(candidate.urgency.toFixed(2)),
+      impactPotential: Number(candidate.impact.toFixed(2)),
+      solutionComplexity: Number(candidate.complexity.toFixed(2)),
+      discoveredAt: new Date().toISOString(),
+      confidence: Number(candidate.confidence.toFixed(2))
+    };
+  }
+
+  private recordFeature(feature: FeatureGenesis): void {
+    this.recentFeatures.unshift(feature);
+    if (this.recentFeatures.length > 5) {
+      this.recentFeatures.pop();
+    }
+  }
+}

--- a/backend/src/meta-evolution/genesis/need-analyzer.ts
+++ b/backend/src/meta-evolution/genesis/need-analyzer.ts
@@ -1,0 +1,65 @@
+export interface BehaviorPattern {
+  area: string;
+  frequency: number;
+  friction: number;
+  signals: string[];
+}
+
+export interface FrictionPoint {
+  area: string;
+  description: string;
+  intensity: number;
+}
+
+export interface LatentNeedCandidate {
+  description: string;
+  urgency: number;
+  impact: number;
+  complexity: number;
+  confidence: number;
+}
+
+export class NeedAnalyzer {
+  async analyzeBehavior(): Promise<BehaviorPattern[]> {
+    return [
+      {
+        area: 'workflow-automation',
+        frequency: 78,
+        friction: 0.62,
+        signals: ['users request faster approvals', 'manual steps repeated frequently']
+      },
+      {
+        area: 'insights-discovery',
+        frequency: 54,
+        friction: 0.48,
+        signals: ['teams export data for spreadsheets', 'desire predictive alerts']
+      },
+      {
+        area: 'governance',
+        frequency: 32,
+        friction: 0.71,
+        signals: ['audit trails stitched manually', 'policy enforcement inconsistent']
+      }
+    ];
+  }
+
+  identifyFriction(patterns: BehaviorPattern[]): FrictionPoint[] {
+    return patterns
+      .filter((pattern) => pattern.friction > 0.4)
+      .map((pattern) => ({
+        area: pattern.area,
+        description: pattern.signals[0] ?? 'Opportunity to streamline experience.',
+        intensity: Number((pattern.friction * 100).toFixed(2))
+      }));
+  }
+
+  extractNeeds(points: FrictionPoint[]): LatentNeedCandidate[] {
+    return points.map((point) => ({
+      description: `Reduce friction in ${point.area}: ${point.description}`,
+      urgency: Math.min(100, point.intensity + 10),
+      impact: Math.min(100, point.intensity + 20),
+      complexity: Math.max(25, 100 - point.intensity),
+      confidence: Math.min(95, 60 + point.intensity / 2)
+    }));
+  }
+}

--- a/backend/src/meta-evolution/genesis/solution-synthesizer.ts
+++ b/backend/src/meta-evolution/genesis/solution-synthesizer.ts
@@ -1,0 +1,101 @@
+import { FeatureApproach, FeatureSpecification, LatentNeed } from '../types.js';
+
+export interface SolutionFeasibility {
+  approachId: string;
+  score: number;
+  risk: number;
+}
+
+export class SolutionSynthesizer {
+  brainstorm(need: LatentNeed): FeatureApproach[] {
+    const baseConfidence = need.confidence / 100;
+    return [
+      {
+        id: `${need.id}-assistive-ai`,
+        summary: `Introduce assistive intelligence flows for ${need.description}.`,
+        feasibility: Number((0.6 + baseConfidence * 0.3).toFixed(2)),
+        confidence: Math.round(need.confidence * 0.95)
+      },
+      {
+        id: `${need.id}-workflow-refine`,
+        summary: `Refine existing workflows to remove manual operations for ${need.description}.`,
+        feasibility: Number((0.5 + baseConfidence * 0.25).toFixed(2)),
+        confidence: Math.round(need.confidence * 0.9)
+      },
+      {
+        id: `${need.id}-insight-pack`,
+        summary: `Bundle insights and alerts that anticipate ${need.description}.`,
+        feasibility: Number((0.55 + baseConfidence * 0.35).toFixed(2)),
+        confidence: Math.round(need.confidence * 0.92)
+      }
+    ];
+  }
+
+  evaluateFeasibility(approach: FeatureApproach): SolutionFeasibility {
+    const risk = Number((1 - Math.min(0.9, approach.feasibility)).toFixed(2));
+    return {
+      approachId: approach.id,
+      score: Number((approach.feasibility * 100).toFixed(2)),
+      risk: Number((risk * 100).toFixed(2))
+    };
+  }
+
+  selectOptimal(approaches: FeatureApproach[], feasibility: SolutionFeasibility[]): FeatureApproach {
+    if (approaches.length === 0) {
+      throw new Error('No approaches available for selection.');
+    }
+    if (feasibility.length === 0) {
+      return approaches[0];
+    }
+
+    const scored = approaches.map((approach) => {
+      const score = feasibility.find((item) => item.approachId === approach.id)?.score ?? 0;
+      return { approach, score };
+    });
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored[0].approach;
+  }
+
+  generateSpecification(approach: FeatureApproach, need: LatentNeed): FeatureSpecification {
+    return {
+      id: `${approach.id}-spec`,
+      title: `Address ${need.description}`,
+      problem: need.description,
+      proposal: approach.summary,
+      successCriteria: [
+        'Reduce manual touch points by 30%.',
+        'Increase positive feedback signals within two sprints.',
+        'Ensure auditability and governance compliance.'
+      ]
+    };
+  }
+
+  generateImplementation(spec: FeatureSpecification): string {
+    return `// Implementation outline for ${spec.title}\nexport function implement${this.toPascal(spec.id)}() {\n  // Step 1: Validate assumptions with stakeholders\n  // Step 2: Build feature toggles and instrumentation\n  // Step 3: Ship iteratively with guarded rollout\n}`;
+  }
+
+  generateTests(spec: FeatureSpecification): string[] {
+    return [
+      `it('validates ${spec.title} success criteria', () => { /* generated test */ });`,
+      "it('ensures governance policies are respected', () => { /* generated test */ });"
+    ];
+  }
+
+  generateDocumentation(spec: FeatureSpecification): string {
+    return `# ${spec.title}\n\n${spec.proposal}\n\n## Success Criteria\n${spec.successCriteria.map((item) => `- ${item}`).join('\n')}`;
+  }
+
+  assessPotential(spec: FeatureSpecification): number {
+    return Number((0.7 + spec.successCriteria.length * 0.05).toFixed(2));
+  }
+
+  private toPascal(value: string): string {
+    return value
+      .replace(/[^a-zA-Z0-9]+/g, ' ')
+      .split(' ')
+      .filter(Boolean)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join('');
+  }
+}

--- a/backend/src/meta-evolution/genetics/code-genome.ts
+++ b/backend/src/meta-evolution/genetics/code-genome.ts
@@ -1,0 +1,66 @@
+import { CodeVariant, ImprovementGoal } from '../types.js';
+
+export interface Gene {
+  name: string;
+  description: string;
+  influence: number;
+}
+
+export class CodeGenome {
+  private readonly baseGenes: Gene[];
+
+  constructor(baseGenes?: Gene[]) {
+    this.baseGenes = baseGenes ?? [
+      {
+        name: 'modularity',
+        description: 'Promotes small, composable units and explicit interfaces.',
+        influence: 0.38
+      },
+      {
+        name: 'observability',
+        description: 'Encourages metrics, tracing, and rich runtime visibility.',
+        influence: 0.24
+      },
+      {
+        name: 'resilience',
+        description: 'Favours retries, graceful degradation, and defensive coding patterns.',
+        influence: 0.18
+      },
+      {
+        name: 'developer-experience',
+        description: 'Optimises for clarity, documentation, and rapid feedback loops.',
+        influence: 0.2
+      }
+    ];
+  }
+
+  describe(): Gene[] {
+    return this.baseGenes.map((gene) => ({ ...gene }));
+  }
+
+  express(goal: ImprovementGoal, index: number): CodeVariant {
+    const gene = this.baseGenes[index % this.baseGenes.length];
+    const emphasis = Math.min(1, gene.influence + goal.desiredValue / 100);
+
+    return {
+      id: `variant-${goal.area}-${index}`,
+      description: `Evolve ${goal.area} with emphasis on ${gene.name}.`,
+      hypothesis: `Improving ${goal.targetMetric} towards ${goal.desiredValue} should increase overall system value.`,
+      changes: [
+        `Prioritise ${goal.area} components for review.`,
+        `Elevate ${gene.name} practices using playbook alignment.`,
+        `Target ${goal.targetMetric} improvement intensity ${emphasis.toFixed(2)}.`
+      ]
+    };
+  }
+
+  combine(a: CodeVariant, b: CodeVariant, generation: number): CodeVariant {
+    const combinedChanges = Array.from(new Set([...a.changes, ...b.changes]));
+    return {
+      id: `crossover-${generation}-${a.id}-${b.id}`,
+      description: `Blend ${a.id} with ${b.id} to reinforce shared strengths.`,
+      hypothesis: `Merging complementary hypotheses from ${a.id} and ${b.id} should produce a balanced outcome.`,
+      changes: combinedChanges
+    };
+  }
+}

--- a/backend/src/meta-evolution/genetics/evolution-simulator.ts
+++ b/backend/src/meta-evolution/genetics/evolution-simulator.ts
@@ -1,0 +1,188 @@
+import {
+  CodeVariant,
+  EvolutionMetrics,
+  EvolutionSimulation,
+  FeatureGenesis,
+  ImprovementGoal
+} from '../types.js';
+import { CodeGenome } from './code-genome.js';
+import { MutationEngine } from './mutation-engine.js';
+
+export interface EvolutionSimulatorOptions {
+  maxVariants?: number;
+  selectionRatio?: number;
+}
+
+interface FitnessRecord {
+  variant: CodeVariant;
+  fitness: number;
+}
+
+export class EvolutionSimulator {
+  private readonly genome: CodeGenome;
+  private readonly mutationEngine: MutationEngine;
+  private readonly options: Required<EvolutionSimulatorOptions>;
+  private currentGeneration = 1;
+  private readonly history: FitnessRecord[] = [];
+
+  constructor(options: EvolutionSimulatorOptions = {}) {
+    this.options = {
+      maxVariants: options.maxVariants ?? 8,
+      selectionRatio: options.selectionRatio ?? 0.4
+    };
+    this.genome = new CodeGenome();
+    this.mutationEngine = new MutationEngine(this.genome);
+  }
+
+  async simulateCodeEvolution(targetImprovement: ImprovementGoal): Promise<EvolutionSimulation> {
+    const variants = await this.generateCodeVariants(targetImprovement);
+    const fitnessResults = await Promise.all(
+      variants.map(async (variant) => {
+        const fitness = await this.evaluateFitness(variant, targetImprovement);
+        variant.fitness = Number(fitness.toFixed(2));
+        return variant.fitness;
+      })
+    );
+
+    const survivors = this.naturalSelection(variants, fitnessResults);
+    const nextGeneration = await this.performCrossover(survivors);
+    const improvementAchieved = this.calculateImprovement(fitnessResults);
+
+    const simulation: EvolutionSimulation = {
+      generationNumber: this.currentGeneration++,
+      variants: variants.length,
+      survivors: survivors.length,
+      bestFitness: survivors.length > 0 ? Math.max(...survivors.map((variant) => variant.fitness ?? 0)) : 0,
+      improvementAchieved,
+      nextGeneration
+    };
+
+    survivors.forEach((variant) => {
+      this.history.push({ variant, fitness: variant.fitness ?? 0 });
+    });
+
+    return simulation;
+  }
+
+  async generateCodeVariants(goal: ImprovementGoal): Promise<CodeVariant[]> {
+    const baseVariants: CodeVariant[] = [];
+    const limit = Math.max(1, this.options.maxVariants);
+
+    for (let index = 0; index < limit; index += 1) {
+      baseVariants.push(this.generateMutation(goal, index));
+    }
+
+    const crossovers = await this.generateCrossovers(goal, baseVariants);
+    return [...baseVariants, ...crossovers];
+  }
+
+  async performCrossover(survivors: CodeVariant[]): Promise<CodeVariant[]> {
+    if (survivors.length < 2) {
+      return survivors;
+    }
+
+    const generation = this.currentGeneration;
+    const crossovers = survivors.slice(0, Math.max(1, Math.floor(survivors.length / 2))).map((variant, index) => {
+      const partner = survivors[survivors.length - 1 - index];
+      return this.genome.combine(variant, partner, generation);
+    });
+
+    return crossovers;
+  }
+
+  async evaluateFitness(variant: CodeVariant, goal: ImprovementGoal): Promise<number> {
+    const baseScore = this.scoreForString(`${variant.id}:${goal.area}:${goal.targetMetric}`);
+    const hypothesisBonus = Math.min(10, variant.hypothesis.length / 40);
+    const changeBonus = Math.min(15, variant.changes.length * 3.5);
+    return 50 + baseScore * 0.4 + hypothesisBonus + changeBonus;
+  }
+
+  naturalSelection(variants: CodeVariant[], fitnessResults: number[]): CodeVariant[] {
+    const combined = variants.map((variant, index) => ({ variant, fitness: fitnessResults[index] ?? 0 }));
+    combined.sort((a, b) => b.fitness - a.fitness);
+
+    const survivorCount = Math.max(1, Math.floor(combined.length * this.options.selectionRatio));
+    return combined.slice(0, survivorCount).map((entry) => ({ ...entry.variant, fitness: Number(entry.fitness.toFixed(2)) }));
+  }
+
+  calculateImprovement(fitnessResults: number[]): number {
+    if (fitnessResults.length === 0) {
+      return 0;
+    }
+
+    const best = Math.max(...fitnessResults);
+    const average = fitnessResults.reduce((sum, value) => sum + value, 0) / fitnessResults.length;
+    return Number((best - average).toFixed(2));
+  }
+
+  async implementEvolution(_evolution: unknown): Promise<{ status: string; message: string; reviewRequired: boolean }> {
+    return {
+      status: 'scheduled',
+      message: 'Evolution changes queued for maintainers review.',
+      reviewRequired: true
+    };
+  }
+
+  async implementFeature(feature: FeatureGenesis): Promise<{ status: string; message: string; actions: string[] }> {
+    return {
+      status: 'prototype-prepared',
+      message: `Prepared implementation outline for ${feature.need.description}.`,
+      actions: [
+        'Share proposal with core maintainers',
+        'Validate generated tests in integration suite',
+        'Iterate on documentation with product stakeholders'
+      ]
+    };
+  }
+
+  getMetrics(): EvolutionMetrics {
+    if (this.history.length === 0) {
+      return {
+        generationsRun: this.currentGeneration - 1,
+        bestFitnessObserved: 0,
+        averageFitness: 0,
+        pendingExperiments: 0
+      };
+    }
+
+    const bestFitnessObserved = Math.max(...this.history.map((entry) => entry.fitness));
+    const averageFitness = this.history.reduce((sum, entry) => sum + entry.fitness, 0) / this.history.length;
+
+    return {
+      generationsRun: this.currentGeneration - 1,
+      bestFitnessObserved: Number(bestFitnessObserved.toFixed(2)),
+      averageFitness: Number(averageFitness.toFixed(2)),
+      pendingExperiments: Math.max(0, this.options.maxVariants - this.history.length)
+    };
+  }
+
+  private generateMutation(goal: ImprovementGoal, index: number): CodeVariant {
+    return this.mutationEngine.craftVariant(goal, index);
+  }
+
+  private async generateCrossovers(_goal: ImprovementGoal, variants: CodeVariant[]): Promise<CodeVariant[]> {
+    if (variants.length < 2) {
+      return [];
+    }
+
+    const generation = this.currentGeneration;
+    const pairs = Math.min(variants.length - 1, 3);
+    const crossovers: CodeVariant[] = [];
+
+    for (let index = 0; index < pairs; index += 1) {
+      const a = variants[index];
+      const b = variants[variants.length - 1 - index];
+      crossovers.push(this.genome.combine(a, b, generation));
+    }
+
+    return crossovers;
+  }
+
+  private scoreForString(value: string): number {
+    let hash = 0;
+    for (let index = 0; index < value.length; index += 1) {
+      hash = (hash * 31 + value.charCodeAt(index)) % 997;
+    }
+    return hash % 100;
+  }
+}

--- a/backend/src/meta-evolution/genetics/mutation-engine.ts
+++ b/backend/src/meta-evolution/genetics/mutation-engine.ts
@@ -1,0 +1,62 @@
+import { CodeVariant, ImprovementGoal, Mutation } from '../types.js';
+import { CodeGenome } from './code-genome.js';
+
+export interface MutationOptions {
+  intensity?: 'low' | 'medium' | 'high';
+}
+
+export class MutationEngine {
+  private readonly genome: CodeGenome;
+
+  constructor(genome?: CodeGenome) {
+    this.genome = genome ?? new CodeGenome();
+  }
+
+  craftVariant(goal: ImprovementGoal, index: number, options: MutationOptions = {}): CodeVariant {
+    const variant = this.genome.express(goal, index);
+    const intensity = options.intensity ?? this.intensityFromIndex(index);
+    const adjustment = this.adjustmentStatement(goal, intensity);
+    return {
+      ...variant,
+      changes: [...variant.changes, adjustment]
+    };
+  }
+
+  summarise(variant: CodeVariant): Mutation {
+    const impact = this.estimateImpact(variant);
+    const type: Mutation['type'] = impact > 0.7 ? 'architectural' : impact > 0.45 ? 'refactor' : 'tuning';
+    return {
+      type,
+      description: variant.description,
+      diff: variant.changes,
+      impactEstimate: Number(impact.toFixed(2))
+    };
+  }
+
+  estimateImpact(variant: CodeVariant): number {
+    const base = variant.changes.reduce((score, change) => score + Math.min(change.length, 120), 0);
+    const normalised = Math.min(0.95, base / 480);
+    return normalised;
+  }
+
+  private adjustmentStatement(goal: ImprovementGoal, intensity: MutationOptions['intensity']): string {
+    switch (intensity) {
+      case 'high':
+        return `Re-architect ${goal.area} components to maximise ${goal.targetMetric}.`;
+      case 'low':
+        return `Introduce lightweight instrumentation to observe ${goal.targetMetric}.`;
+      default:
+        return `Refine ${goal.area} patterns to elevate ${goal.targetMetric}.`;
+    }
+  }
+
+  private intensityFromIndex(index: number): MutationOptions['intensity'] {
+    if (index % 3 === 0) {
+      return 'high';
+    }
+    if (index % 3 === 1) {
+      return 'medium';
+    }
+    return 'low';
+  }
+}

--- a/backend/src/meta-evolution/neural/architecture-optimizer.ts
+++ b/backend/src/meta-evolution/neural/architecture-optimizer.ts
@@ -1,0 +1,59 @@
+import { CodeVariant } from '../types.js';
+
+export interface ArchitectureInsight {
+  dimension: string;
+  score: number;
+  recommendation: string;
+}
+
+export class ArchitectureOptimizer {
+  evaluate(variant: CodeVariant): ArchitectureInsight[] {
+    return [
+      this.observeModularity(variant),
+      this.observeObservability(variant),
+      this.observeResilience(variant)
+    ];
+  }
+
+  prioritise(insights: ArchitectureInsight[]): ArchitectureInsight[] {
+    return [...insights].sort((a, b) => b.score - a.score);
+  }
+
+  private observeModularity(variant: CodeVariant): ArchitectureInsight {
+    const score = Math.min(100, variant.changes.length * 12);
+    return {
+      dimension: 'modularity',
+      score: Number(score.toFixed(2)),
+      recommendation: score > 60
+        ? 'Prepare module boundary RFC to document proposed structure.'
+        : 'Identify candidate modules where cohesion can be increased.'
+    };
+  }
+
+  private observeObservability(variant: CodeVariant): ArchitectureInsight {
+    const references = variant.changes.filter((change) => change.toLowerCase().includes('instrument'));
+    const score = references.length > 0 ? 80 : 40;
+    return {
+      dimension: 'observability',
+      score,
+      recommendation: references.length > 0
+        ? 'Pair implementation with telemetry dashboards for rollout.'
+        : 'Add instrumentation milestones to the evolution backlog.'
+    };
+  }
+
+  private observeResilience(variant: CodeVariant): ArchitectureInsight {
+    const resilienceKeywords = ['retry', 'graceful', 'fallback'];
+    const score = variant.changes.some((change) =>
+      resilienceKeywords.some((keyword) => change.toLowerCase().includes(keyword))
+    ) ? 75 : 35;
+
+    return {
+      dimension: 'resilience',
+      score,
+      recommendation: score > 60
+        ? 'Design chaos experiments to validate resilience improvements.'
+        : 'Propose incremental resiliency tactics (timeouts, alerts, fallbacks).'
+    };
+  }
+}

--- a/backend/src/meta-evolution/neural/decision-networks.ts
+++ b/backend/src/meta-evolution/neural/decision-networks.ts
@@ -1,0 +1,52 @@
+import { CodeVariant, ImprovementGoal } from '../types.js';
+
+export interface DecisionTrace {
+  node: string;
+  contribution: number;
+}
+
+export interface DecisionNetworkSnapshot {
+  score: number;
+  trace: DecisionTrace[];
+}
+
+export class DecisionNetworks {
+  private readonly weights: Map<string, number> = new Map([
+    ['risk', 0.35],
+    ['impact', 0.4],
+    ['effort', 0.25]
+  ]);
+
+  evaluate(variant: CodeVariant, goal: ImprovementGoal): DecisionNetworkSnapshot {
+    const impact = this.weightedScore(goal.desiredValue, 'impact');
+    const risk = this.weightedScore(variant.changes.length * 7, 'risk');
+    const effort = this.weightedScore(Math.max(20, variant.hypothesis.length / 5), 'effort');
+
+    const score = impact + risk - effort;
+    const normalised = Number(Math.max(0, Math.min(100, score)).toFixed(2));
+
+    return {
+      score: normalised,
+      trace: [
+        { node: 'impact', contribution: Number(impact.toFixed(2)) },
+        { node: 'risk', contribution: Number(risk.toFixed(2)) },
+        { node: 'effort', contribution: Number((-effort).toFixed(2)) }
+      ]
+    };
+  }
+
+  updateWeight(node: string, adjustment: number): void {
+    const current = this.weights.get(node) ?? 0.2;
+    const updated = Math.max(0, Math.min(1, current + adjustment));
+    this.weights.set(node, Number(updated.toFixed(2)));
+  }
+
+  describe(): Array<{ node: string; weight: number }> {
+    return Array.from(this.weights.entries()).map(([node, weight]) => ({ node, weight }));
+  }
+
+  private weightedScore(value: number, node: string): number {
+    const weight = this.weights.get(node) ?? 0.2;
+    return weight * value;
+  }
+}

--- a/backend/src/meta-evolution/neural/intuition-engine.ts
+++ b/backend/src/meta-evolution/neural/intuition-engine.ts
@@ -1,0 +1,43 @@
+import { CodeVariant, ImprovementGoal } from '../types.js';
+import { ArchitectureInsight, ArchitectureOptimizer } from './architecture-optimizer.js';
+import { DecisionNetworks, DecisionNetworkSnapshot } from './decision-networks.js';
+
+export interface IntuitionSummary {
+  readinessScore: number;
+  decision: DecisionNetworkSnapshot;
+  architecture: ArchitectureInsight[];
+  narrative: string;
+}
+
+export class IntuitionEngine {
+  private readonly decisionNetworks = new DecisionNetworks();
+  private readonly architectureOptimizer = new ArchitectureOptimizer();
+
+  evaluate(variant: CodeVariant, goal: ImprovementGoal): IntuitionSummary {
+    const decision = this.decisionNetworks.evaluate(variant, goal);
+    const architectureInsights = this.architectureOptimizer.evaluate(variant);
+    const readinessScore = this.computeReadiness(decision.score, architectureInsights);
+
+    return {
+      readinessScore,
+      decision,
+      architecture: this.architectureOptimizer.prioritise(architectureInsights),
+      narrative: this.buildNarrative(variant, goal, readinessScore)
+    };
+  }
+
+  private computeReadiness(decisionScore: number, architecture: ArchitectureInsight[]): number {
+    if (architecture.length === 0) {
+      return Number(decisionScore.toFixed(2));
+    }
+
+    const architectureAverage = architecture.reduce((sum, insight) => sum + insight.score, 0) / architecture.length;
+    const readiness = 0.6 * decisionScore + 0.4 * architectureAverage;
+    return Number(Math.max(0, Math.min(100, readiness)).toFixed(2));
+  }
+
+  private buildNarrative(variant: CodeVariant, goal: ImprovementGoal, readiness: number): string {
+    const tone = readiness > 70 ? 'Momentum is strong' : readiness > 45 ? 'Balanced opportunity with manageable risk' : 'Further incubation required';
+    return `${tone}. Variant ${variant.id} targets ${goal.area} and is projected to lift ${goal.targetMetric} by ${goal.desiredValue}.`;
+  }
+}

--- a/backend/src/meta-evolution/routes/evolution.routes.ts
+++ b/backend/src/meta-evolution/routes/evolution.routes.ts
@@ -1,0 +1,196 @@
+import { Router } from 'express';
+import { existsSync } from 'fs';
+import path from 'path';
+import { AwarenessEngine } from '../consciousness/awareness-engine.js';
+import { EvolutionSimulator } from '../genetics/evolution-simulator.js';
+import { FeatureDiscovery } from '../genesis/feature-discovery.js';
+import { ImprovementGoal, LatentNeed } from '../types.js';
+
+export interface EvolutionRouterOptions {
+  projectRoot?: string;
+}
+
+export function createEvolutionRouter(options: EvolutionRouterOptions = {}): Router {
+  const router = Router();
+  const projectRoot = resolveProjectRoot(options.projectRoot);
+  const awarenessEngine = new AwarenessEngine({ projectRoot });
+  const evolutionSimulator = new EvolutionSimulator();
+  const featureDiscovery = new FeatureDiscovery();
+
+  router.get('/consciousness/self-analysis', async (_req, res, next) => {
+    try {
+      const selfAnalysis = await awarenessEngine.achieveSelfAwareness();
+      res.json(selfAnalysis);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/consciousness/capability-map', async (_req, res, next) => {
+    try {
+      const capabilities = await awarenessEngine.mapCurrentCapabilities();
+      res.json(capabilities);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/consciousness/expand-awareness', async (req, res, next) => {
+    try {
+      const expansion = await awarenessEngine.expandAwareness(parseTarget(req.body?.target));
+      res.json(expansion);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/genetics/evolve', async (req, res, next) => {
+    try {
+      const goal = toImprovementGoal(req.body?.goal);
+      if (!goal) {
+        res.status(400).json({ error: 'invalid_goal', message: 'A valid evolution goal is required.' });
+        return;
+      }
+      const simulation = await evolutionSimulator.simulateCodeEvolution(goal);
+      res.json(simulation);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/genetics/implement-evolution', async (req, res, next) => {
+    try {
+      const result = await evolutionSimulator.implementEvolution(req.body?.evolution);
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/genesis/discover-needs', async (_req, res, next) => {
+    try {
+      const latentNeeds = await featureDiscovery.discoverLatentNeeds();
+      res.json(latentNeeds);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/genesis/synthesize-feature', async (req, res, next) => {
+    try {
+      const rawNeed = req.body?.need;
+      if (!isLatentNeed(rawNeed)) {
+        res.status(400).json({ error: 'invalid_need', message: 'A valid latent need is required.' });
+        return;
+      }
+      const featureGenesis = await featureDiscovery.synthesizeFeatureSolution(rawNeed);
+      res.json(featureGenesis);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/genesis/autonomous-develop', async (_req, res, next) => {
+    try {
+      const needs = await featureDiscovery.discoverLatentNeeds();
+      const prioritizedNeed = needs.sort((a, b) => b.impactPotential - a.impactPotential)[0];
+
+      if (!prioritizedNeed) {
+        res.json({ message: 'No high-impact needs discovered at this time.' });
+        return;
+      }
+
+      const feature = await featureDiscovery.synthesizeFeatureSolution(prioritizedNeed);
+      const implementation = await evolutionSimulator.implementFeature(feature);
+      res.json({ feature, implementation });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/stream', (req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    });
+
+    const sendUpdate = () => {
+      const payload = {
+        metrics: evolutionSimulator.getMetrics(),
+        features: featureDiscovery.getRecentFeatures().map((feature) => ({
+          id: feature.need.id,
+          name: feature.specification.title,
+          description: feature.need.description,
+          impactScore: feature.need.impactPotential,
+          confidence: feature.need.confidence
+        }))
+      };
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    };
+
+    sendUpdate();
+    const interval = setInterval(sendUpdate, 15000);
+
+    req.on('close', () => {
+      clearInterval(interval);
+      res.end();
+    });
+  });
+
+  return router;
+}
+
+function resolveProjectRoot(proposed?: string): string {
+  const candidates = [proposed, process.env.META_EVOLUTION_PROJECT_ROOT, path.resolve(process.cwd(), 'src'), path.resolve(process.cwd(), 'backend', 'src')];
+
+  for (const candidate of candidates) {
+    if (candidate && existsSync(candidate)) {
+      return path.resolve(candidate);
+    }
+  }
+
+  return process.cwd();
+}
+
+function parseTarget(target: unknown): string | undefined {
+  if (typeof target === 'string' && target.trim().length > 0) {
+    return target;
+  }
+  return undefined;
+}
+
+function toImprovementGoal(goal: unknown): ImprovementGoal | null {
+  if (
+    goal &&
+    typeof goal === 'object' &&
+    typeof (goal as ImprovementGoal).area === 'string' &&
+    typeof (goal as ImprovementGoal).targetMetric === 'string' &&
+    typeof (goal as ImprovementGoal).desiredValue === 'number'
+  ) {
+    const typedGoal = goal as ImprovementGoal;
+    return {
+      area: typedGoal.area,
+      targetMetric: typedGoal.targetMetric,
+      desiredValue: typedGoal.desiredValue,
+      rationale: typeof typedGoal.rationale === 'string' ? typedGoal.rationale : undefined
+    };
+  }
+  return null;
+}
+
+function isLatentNeed(value: unknown): value is LatentNeed {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as LatentNeed).id === 'string' &&
+    typeof (value as LatentNeed).description === 'string' &&
+    typeof (value as LatentNeed).urgency === 'number' &&
+    typeof (value as LatentNeed).impactPotential === 'number' &&
+    typeof (value as LatentNeed).solutionComplexity === 'number' &&
+    typeof (value as LatentNeed).discoveredAt === 'string' &&
+    typeof (value as LatentNeed).confidence === 'number'
+  );
+}
+
+export default createEvolutionRouter;

--- a/backend/src/meta-evolution/types.ts
+++ b/backend/src/meta-evolution/types.ts
@@ -1,0 +1,137 @@
+export interface AnalysisResult {
+  fileCount: number;
+  linesOfCode: number;
+  totalComplexity: number;
+  patterns: string[];
+  opportunities: string[];
+}
+
+export interface CodeAnalysis {
+  totalFiles: number;
+  linesOfCode: number;
+  complexityScore: number;
+  architecturalPatterns: string[];
+  improvementOpportunities: string[];
+  evolutionPotential: number;
+}
+
+export interface Capability {
+  id: string;
+  name: string;
+  description: string;
+  maturity: number;
+  focusArea: string;
+  lastEvaluated: string;
+}
+
+export interface Limitation {
+  id: string;
+  description: string;
+  severity: 'low' | 'medium' | 'high';
+  recommendedAction: string;
+}
+
+export interface TranscendencePlan {
+  focus: string;
+  steps: Array<{
+    id: string;
+    description: string;
+    impact: 'low' | 'medium' | 'high';
+  }>;
+  horizon: string;
+}
+
+export interface SelfAwarenessReport {
+  awarenessLevel: number;
+  codeAnalysis: CodeAnalysis;
+  capabilities: Capability[];
+  limitations: Limitation[];
+  transcendencePlan: TranscendencePlan;
+  timestamp: string;
+}
+
+export interface AwarenessExpansion {
+  target: string;
+  actions: string[];
+  resultingAwareness: number;
+  timestamp: string;
+}
+
+export interface EvolutionLog {
+  timestamp: string;
+  summary: string;
+  details?: string;
+}
+
+export interface ImprovementGoal {
+  area: string;
+  targetMetric: string;
+  desiredValue: number;
+  rationale?: string;
+}
+
+export interface CodeVariant {
+  id: string;
+  description: string;
+  hypothesis: string;
+  changes: string[];
+  fitness?: number;
+}
+
+export interface EvolutionSimulation {
+  generationNumber: number;
+  variants: number;
+  survivors: number;
+  bestFitness: number;
+  improvementAchieved: number;
+  nextGeneration: CodeVariant[];
+}
+
+export interface Mutation {
+  type: 'tuning' | 'refactor' | 'architectural';
+  description: string;
+  diff: string[];
+  impactEstimate: number;
+}
+
+export interface LatentNeed {
+  id: string;
+  description: string;
+  urgency: number;
+  impactPotential: number;
+  solutionComplexity: number;
+  discoveredAt: string;
+  confidence: number;
+}
+
+export interface FeatureApproach {
+  id: string;
+  summary: string;
+  feasibility: number;
+  confidence: number;
+}
+
+export interface FeatureSpecification {
+  id: string;
+  title: string;
+  problem: string;
+  proposal: string;
+  successCriteria: string[];
+}
+
+export interface FeatureGenesis {
+  need: LatentNeed;
+  approach: FeatureApproach;
+  specification: FeatureSpecification;
+  implementation: string;
+  tests: string[];
+  documentation: string;
+  evolutionPotential: number;
+}
+
+export interface EvolutionMetrics {
+  generationsRun: number;
+  bestFitnessObserved: number;
+  averageFitness: number;
+  pendingExperiments: number;
+}

--- a/frontend/src/components/evolution/EvolutionDashboard.tsx
+++ b/frontend/src/components/evolution/EvolutionDashboard.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  AutonomousFeatureSummary,
+  ConsciousnessSnapshot,
+  EvolutionMetricsSummary,
+  EvolutionStreamMessage
+} from './types.js';
+
+const STREAM_ENDPOINT = '/api/meta-evolution/stream';
+const SELF_ANALYSIS_ENDPOINT = '/api/meta-evolution/consciousness/self-analysis';
+const AUTONOMOUS_DEVELOP_ENDPOINT = '/api/meta-evolution/genesis/autonomous-develop';
+
+export function EvolutionDashboard() {
+  const [consciousness, setConsciousness] = useState<ConsciousnessSnapshot | null>(null);
+  const [metrics, setMetrics] = useState<EvolutionMetricsSummary | null>(null);
+  const [features, setFeatures] = useState<AutonomousFeatureSummary[]>([]);
+  const [isEvolving, setIsEvolving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isSubscribed = true;
+    const controller = new AbortController();
+
+    const initialise = async () => {
+      try {
+        const response = await fetch(SELF_ANALYSIS_ENDPOINT, { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(`Failed to load self-analysis: ${response.status}`);
+        }
+        const payload = (await response.json()) as ConsciousnessSnapshot;
+        if (isSubscribed) {
+          setConsciousness(payload);
+        }
+      } catch (caughtError) {
+        if (!isSubscribed || (caughtError as Error).name === 'AbortError') {
+          return;
+        }
+        setError((caughtError as Error).message);
+      }
+    };
+
+    initialise();
+
+    const eventSource = new EventSource(STREAM_ENDPOINT);
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as EvolutionStreamMessage;
+        if (!isSubscribed) {
+          return;
+        }
+        setMetrics(data.metrics);
+        setFeatures(data.features);
+      } catch (caughtError) {
+        if (!isSubscribed) {
+          return;
+        }
+        setError((caughtError as Error).message);
+      }
+    };
+
+    eventSource.onerror = () => {
+      if (!isSubscribed) {
+        return;
+      }
+      setError('Lost connection to evolution stream. Retrying soon...');
+      eventSource.close();
+      setTimeout(() => {
+        if (isSubscribed) {
+          setError(null);
+        }
+      }, 3000);
+    };
+
+    return () => {
+      isSubscribed = false;
+      controller.abort();
+      eventSource.close();
+    };
+  }, []);
+
+  const lastUpdated = useMemo(() => {
+    return consciousness?.timestamp ? new Date(consciousness.timestamp).toLocaleString() : '–';
+  }, [consciousness?.timestamp]);
+
+  const triggerEvolution = async () => {
+    setIsEvolving(true);
+    setError(null);
+
+    try {
+      const response = await fetch(AUTONOMOUS_DEVELOP_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to trigger evolution: ${response.status}`);
+      }
+
+      const payload = await response.json();
+      if (payload?.feature) {
+        setFeatures((current) => {
+          const next = [
+            transformFeature(payload.feature),
+            ...current.filter((feature) => feature.id !== payload.feature.need?.id)
+          ];
+          return next.slice(0, 5);
+        });
+      }
+    } catch (caughtError) {
+      setError((caughtError as Error).message);
+    } finally {
+      setIsEvolving(false);
+    }
+  };
+
+  return (
+    <div className="evolution-dashboard">
+      <header className="evolution-dashboard__header">
+        <h1>META Evolution Engine</h1>
+        <p className="evolution-dashboard__meta">Last evaluated: {lastUpdated}</p>
+      </header>
+
+      {error && <div className="evolution-dashboard__error">{error}</div>}
+
+      <section className="evolution-dashboard__consciousness">
+        <h2>Consciousness Level</h2>
+        <div className="evolution-dashboard__awareness">{formatPercentage(consciousness?.awarenessLevel)}</div>
+        <div className="evolution-dashboard__metrics">
+          <Metric label="Files" value={consciousness?.codeAnalysis.totalFiles ?? 0} />
+          <Metric label="Complexity" value={consciousness?.codeAnalysis.complexityScore ?? 0} />
+          <Metric label="Evolution Potential" value={formatPercentage((consciousness?.codeAnalysis.evolutionPotential ?? 0) * 100)} />
+          <Metric label="Opportunities" value={consciousness?.codeAnalysis.improvementOpportunities.length ?? 0} />
+        </div>
+        {consciousness && consciousness.capabilities.length > 0 && (
+          <div className="evolution-dashboard__capabilities">
+            <h3>Capabilities</h3>
+            <ul>
+              {consciousness.capabilities.map((capability) => (
+                <li key={capability.id}>
+                  <strong>{capability.name}</strong>
+                  <span>{formatPercentage(capability.maturity * 100)}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <section className="evolution-dashboard__actions">
+        <button
+          className="evolution-dashboard__trigger"
+          type="button"
+          onClick={triggerEvolution}
+          disabled={isEvolving}
+        >
+          {isEvolving ? 'Evolving…' : 'Trigger Evolution'}
+        </button>
+        {metrics && (
+          <div className="evolution-dashboard__metrics-grid">
+            <Metric label="Generations" value={metrics.generationsRun} />
+            <Metric label="Best Fitness" value={metrics.bestFitnessObserved} />
+            <Metric label="Average Fitness" value={metrics.averageFitness} />
+            <Metric label="Pending Experiments" value={metrics.pendingExperiments} />
+          </div>
+        )}
+      </section>
+
+      <section className="evolution-dashboard__features">
+        <h2>Autonomously Generated Features</h2>
+        {features.length === 0 ? (
+          <p>No autonomous features generated yet. Trigger evolution to begin discovery.</p>
+        ) : (
+          <div className="evolution-dashboard__feature-list">
+            {features.map((feature) => (
+              <article key={feature.id} className="evolution-dashboard__feature-card">
+                <header>
+                  <h3>{feature.name}</h3>
+                  <span className="evolution-dashboard__feature-confidence">
+                    Confidence {formatPercentage(feature.confidence)}
+                  </span>
+                </header>
+                <p>{feature.description}</p>
+                <footer>
+                  <span>Impact {formatPercentage(feature.impactScore)}</span>
+                </footer>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+interface MetricProps {
+  label: string;
+  value: number | string;
+}
+
+function Metric({ label, value }: MetricProps) {
+  return (
+    <div className="evolution-dashboard__metric">
+      <span className="evolution-dashboard__metric-label">{label}</span>
+      <span className="evolution-dashboard__metric-value">{value}</span>
+    </div>
+  );
+}
+
+function formatPercentage(value: number | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0%';
+  }
+  return `${Math.round(value)}%`;
+}
+
+function transformFeature(payload: any): AutonomousFeatureSummary {
+  const id = payload?.need?.id ?? `feature-${Date.now()}`;
+  return {
+    id,
+    name: payload?.specification?.title ?? 'Untitled Feature',
+    description: payload?.need?.description ?? 'No description available.',
+    impactScore: payload?.need?.impactPotential ?? 0,
+    confidence: payload?.need?.confidence ?? 0
+  };
+}
+
+export default EvolutionDashboard;

--- a/frontend/src/components/evolution/index.ts
+++ b/frontend/src/components/evolution/index.ts
@@ -1,0 +1,6 @@
+export { EvolutionDashboard } from './EvolutionDashboard.js';
+export type {
+  ConsciousnessSnapshot,
+  EvolutionMetricsSummary,
+  AutonomousFeatureSummary
+} from './types.js';

--- a/frontend/src/components/evolution/types.ts
+++ b/frontend/src/components/evolution/types.ts
@@ -1,0 +1,65 @@
+export interface CodeAnalysisSummary {
+  totalFiles: number;
+  linesOfCode: number;
+  complexityScore: number;
+  architecturalPatterns: string[];
+  improvementOpportunities: string[];
+  evolutionPotential: number;
+}
+
+export interface CapabilitySummary {
+  id: string;
+  name: string;
+  description: string;
+  maturity: number;
+  focusArea: string;
+  lastEvaluated: string;
+}
+
+export interface LimitationSummary {
+  id: string;
+  description: string;
+  severity: 'low' | 'medium' | 'high';
+  recommendedAction: string;
+}
+
+export interface TranscendenceStep {
+  id: string;
+  description: string;
+  impact: 'low' | 'medium' | 'high';
+}
+
+export interface TranscendencePlanSummary {
+  focus: string;
+  steps: TranscendenceStep[];
+  horizon: string;
+}
+
+export interface ConsciousnessSnapshot {
+  awarenessLevel: number;
+  codeAnalysis: CodeAnalysisSummary;
+  capabilities: CapabilitySummary[];
+  limitations: LimitationSummary[];
+  transcendencePlan: TranscendencePlanSummary;
+  timestamp: string;
+}
+
+export interface EvolutionMetricsSummary {
+  generationsRun: number;
+  bestFitnessObserved: number;
+  averageFitness: number;
+  pendingExperiments: number;
+}
+
+export interface AutonomousFeatureSummary {
+  id: string;
+  name: string;
+  description: string;
+  impactScore: number;
+  confidence: number;
+}
+
+export interface EvolutionStreamMessage {
+  metrics: EvolutionMetricsSummary;
+  features: AutonomousFeatureSummary[];
+}


### PR DESCRIPTION
## Summary
- add a meta-evolution backend subsystem that can analyse the repository, map capabilities, simulate code evolution and propose feature genesis artifacts
- expose the subsystem through a dedicated Express router and wire it into the existing app so the capabilities are reachable via REST and SSE endpoints
- introduce an Evolution Dashboard React component that monitors consciousness data, evolution metrics and autonomously generated features

## Testing
- `npm test -- --config jest.config.cjs` *(fails: suite depends on unavailable services and packages such as jsonwebtoken and prom-client)*
- `npm run typecheck` *(fails: project lacks test runner type definitions and referenced UI modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cad0c3e038832aa9f2fe4b112448f6