### PR TITLE
cleanup: consolidate event bus

### DIFF
--- a/src/core/eventBusV2.ts
+++ b/src/core/eventBusV2.ts
@@ -1,23 +1,2 @@
-// src/core/eventBusV2.ts
-export interface PriorityBus {
-  emit<T>(type: string, payload: T, opts?: {priority?: 'high'|'med'|'low', idempotencyKey?: string}): Promise<void>;
-  on(type: string, handler: (payload:any)=>Promise<void>): void;
-  stats(): Promise<{queues:any[], dlq:any[]}>;
-}
-
-let priorityBus: any; let dlq: any;
-try { priorityBus = require('./priorityBus'); } catch {}
-try { dlq = require('./dlq'); } catch {}
-
-async function stats() {
-  const queues = (priorityBus?.snapshot && await priorityBus.snapshot()) || [];
-  const dead = (dlq?.snapshot && await dlq.snapshot()) || [];
-  return { queues, dlq: dead };
-}
-
-export const bus: PriorityBus = {
-  emit: (type: string, payload: any, opts?: any) => priorityBus?.emit ? priorityBus.emit(type, payload, opts) : Promise.resolve(),
-  on: (type: string, handler: (payload:any)=>Promise<void>) => { if (priorityBus?.on) priorityBus.on(type, handler); },
-  stats
-};
-export default bus;
+export * from './events/bus';
+export { bus as default } from './events/bus';

--- a/src/core/events/bus.ts
+++ b/src/core/events/bus.ts
@@ -1,55 +1,275 @@
-export type Priority = 'high'|'medium'|'low';
+import crypto from 'crypto';
 
-export interface WorkbuoyEvent<T=any> {
-  id: string; type: string; priority: Priority;
-  timestamp: string; correlationId?: string; payload: T; retries?: number;
+export type Priority = 'high' | 'medium' | 'low';
+
+export interface WorkbuoyEvent<T = any> {
+  id: string;
+  type: string;
+  priority: Priority;
+  timestamp: string;
+  payload: T;
+  correlationId?: string;
+  source?: string;
+  retries: number;
+  lastError?: string;
+  headers?: Record<string, string>;
+  meta?: Record<string, any>;
 }
 
-type Handler = (e: WorkbuoyEvent)=>Promise<void>;
+export interface LegacyEvent<T = any> {
+  id?: string;
+  type: string;
+  priority?: string;
+  payload?: T;
+  timestamp?: string;
+  ts?: string;
+  correlationId?: string;
+  source?: string;
+  retries?: number;
+  attempts?: number;
+  headers?: Record<string, string>;
+  meta?: Record<string, any>;
+  lastError?: string;
+}
 
-const handlers = new Map<string, Handler[]>();
-const processed = new Set<string>();
-const dlq: WorkbuoyEvent[] = [];
+export interface EmitOptions {
+  priority?: string;
+  idempotencyKey?: string;
+  correlationId?: string;
+  source?: string;
+  headers?: Record<string, string>;
+  meta?: Record<string, any>;
+}
 
-const queues: Record<Priority, WorkbuoyEvent[]> = { high:[], medium:[], low:[] };
-const MAX_RETRIES = 3;
+type Handler<T = any> = (event: WorkbuoyEvent<T>) => Promise<void> | void;
+type ConsumerMap = Map<string, Handler>;
 
-export const EventBus = {
-  subscribe(type: string, handler: Handler) {
-    const list = handlers.get(type) ?? [];
-    list.push(handler);
-    handlers.set(type, list);
-  },
+const PRIORITIES: Priority[] = ['high', 'medium', 'low'];
+const DEFAULT_MAX_ATTEMPTS = Math.max(1, Number(process.env.BUS_MAX_ATTEMPTS || process.env.EVENTBUS_MAX_ATTEMPTS || 3));
 
-  async publish<T>(event: WorkbuoyEvent<T>) {
-    if (processed.has(event.id)) return; // idempotent
-    queues[event.priority].push({ ...event, retries: event.retries ?? 0 });
-    await drain();
-  },
+function normalizePriority(priority?: string): Priority {
+  const value = (priority ?? 'medium').toLowerCase();
+  if (value === 'high' || value === 'urgent' || value === 'critical') return 'high';
+  if (value === 'low' || value === 'minor') return 'low';
+  return 'medium';
+}
 
-  // testing/introspection
-  __dlq() { return dlq.slice(); },
-  __reset() {
-    handlers.clear(); processed.clear(); dlq.splice(0, dlq.length);
-    queues.high.length = queues.medium.length = queues.low.length = 0;
+function nextId(seed?: string): string {
+  if (seed) return seed;
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  return `evt-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function cloneEvent<T>(event: WorkbuoyEvent<T>): WorkbuoyEvent<T> {
+  return { ...event, payload: event.payload };
+}
+
+class PriorityEventBus {
+  private readonly queues: Record<Priority, WorkbuoyEvent[]> = {
+    high: [],
+    medium: [],
+    low: []
+  };
+  private readonly handlers = new Map<string, ConsumerMap>();
+  private readonly pending = new Set<string>();
+  private readonly processed = new Set<string>();
+  private readonly dlq: WorkbuoyEvent[] = [];
+  private listenerSeq = 0;
+  private drainSequence: Promise<void> = Promise.resolve();
+  private readonly maxAttempts = DEFAULT_MAX_ATTEMPTS;
+
+  async emit<T>(eventOrType: string | LegacyEvent<T>, payload?: T, opts?: EmitOptions): Promise<void> {
+    const event = this.normalize(eventOrType, payload, opts);
+    if (!this.enqueue(event)) return;
+    await this.ensureDrain();
   }
-};
 
-async function drain() {
-  for (const p of (['high','medium','low'] as Priority[])) {
-    while (queues[p].length) {
-      const ev = queues[p].shift()!;
-      const list = handlers.get(ev.type) ?? [];
-      if (!list.length) { processed.add(ev.id); continue; }
+  async publish<T>(event: LegacyEvent<T>, opts?: EmitOptions): Promise<void> {
+    const normalized = this.normalize(event, undefined, opts);
+    if (!this.enqueue(normalized)) return;
+    await this.ensureDrain();
+  }
 
-      try {
-        for (const h of list) await h(ev);
-        processed.add(ev.id);
-      } catch (_e) {
-        ev.retries = (ev.retries ?? 0) + 1;
-        if (ev.retries >= MAX_RETRIES) dlq.push(ev);
-        else queues[p].push(ev);
+  subscribe<T>(type: string, consumerOrHandler: string | Handler<T>, maybeHandler?: Handler<T>): void {
+    const handler = typeof consumerOrHandler === 'function' ? consumerOrHandler : maybeHandler;
+    if (!handler) return;
+    const consumerId = typeof consumerOrHandler === 'string' ? consumerOrHandler : `listener-${++this.listenerSeq}`;
+    const topicHandlers = this.handlers.get(type) ?? new Map<string, Handler>();
+    topicHandlers.set(consumerId, handler as Handler);
+    this.handlers.set(type, topicHandlers);
+  }
+
+  on<T>(type: string, handler: (payload: T, event: WorkbuoyEvent<T>) => Promise<void> | void): void {
+    this.subscribe(type, async (event) => {
+      await handler(event.payload as T, event as WorkbuoyEvent<T>);
+    });
+  }
+
+  async stats(): Promise<{ queues: Array<{ name: Priority; size: number }>; dlq: Array<WorkbuoyEvent> }> {
+    return {
+      queues: PRIORITIES.map((name) => ({ name, size: this.queues[name].length })),
+      dlq: this.dlq.map((event) => cloneEvent(event))
+    };
+  }
+
+  _peek(): { sizes: Record<Priority | 'dlq', number>; queues: Record<Priority, WorkbuoyEvent[]>; dlq: WorkbuoyEvent[] } {
+    return {
+      sizes: {
+        high: this.queues.high.length,
+        medium: this.queues.medium.length,
+        low: this.queues.low.length,
+        dlq: this.dlq.length
+      },
+      queues: {
+        high: this.queues.high.map((event) => cloneEvent(event)),
+        medium: this.queues.medium.map((event) => cloneEvent(event)),
+        low: this.queues.low.map((event) => cloneEvent(event))
+      },
+      dlq: this.dlq.map((event) => cloneEvent(event))
+    };
+  }
+
+  dlqList(): WorkbuoyEvent[] {
+    return this.dlq.map((event) => cloneEvent(event));
+  }
+
+  reset(): void {
+    this.handlers.clear();
+    this.pending.clear();
+    this.processed.clear();
+    this.queues.high.length = 0;
+    this.queues.medium.length = 0;
+    this.queues.low.length = 0;
+    this.dlq.length = 0;
+  }
+
+  private normalize<T>(eventOrType: string | LegacyEvent<T>, payload?: T, opts?: EmitOptions): WorkbuoyEvent<T> {
+    if (!eventOrType) throw new Error('event type required');
+    const base: LegacyEvent<T> = typeof eventOrType === 'string'
+      ? { type: eventOrType, payload }
+      : { ...eventOrType };
+
+    if (payload !== undefined && base.payload === undefined) base.payload = payload;
+    if (opts?.priority) base.priority = opts.priority;
+    if (opts?.correlationId) base.correlationId = opts.correlationId;
+    if (opts?.source) base.source = opts.source;
+    if (opts?.headers) base.headers = { ...(base.headers ?? {}), ...opts.headers };
+    if (opts?.meta) base.meta = { ...(base.meta ?? {}), ...opts.meta };
+    if (opts?.idempotencyKey) base.id = opts.idempotencyKey;
+
+    const id = nextId(base.id);
+    const priority = normalizePriority(base.priority);
+    const timestamp = base.timestamp ?? base.ts ?? new Date().toISOString();
+    const retries = typeof base.retries === 'number'
+      ? base.retries
+      : typeof base.attempts === 'number' && base.attempts > 0
+        ? base.attempts
+        : 0;
+
+    return {
+      id,
+      type: base.type,
+      priority,
+      timestamp,
+      correlationId: base.correlationId,
+      source: base.source,
+      payload: base.payload as T,
+      retries,
+      lastError: base.lastError,
+      headers: base.headers,
+      meta: base.meta
+    };
+  }
+
+  private enqueue(event: WorkbuoyEvent, allowDuplicate = false): boolean {
+    if (!allowDuplicate) {
+      if (this.processed.has(event.id)) return false;
+      if (this.pending.has(event.id)) return false;
+    }
+    this.queues[event.priority].push(event);
+    this.pending.add(event.id);
+    return true;
+  }
+
+  private dequeue(): WorkbuoyEvent | undefined {
+    for (const priority of PRIORITIES) {
+      const queue = this.queues[priority];
+      if (queue.length) {
+        const event = queue.shift()!;
+        this.pending.delete(event.id);
+        return event;
+      }
+    }
+    return undefined;
+  }
+
+  private ensureDrain(): Promise<void> {
+    this.drainSequence = this.drainSequence.then(() => this.drain());
+    return this.drainSequence;
+  }
+
+  private async drain(): Promise<void> {
+    while (true) {
+      const event = this.dequeue();
+      if (!event) break;
+      const handlers = this.handlers.get(event.type);
+      if (!handlers || handlers.size === 0) {
+        this.processed.add(event.id);
+        continue;
+      }
+
+      let failed = false;
+      for (const handler of handlers.values()) {
+        try {
+          await handler(event);
+        } catch (err) {
+          failed = true;
+          event.retries += 1;
+          event.lastError = err instanceof Error ? err.message : String(err);
+        }
+      }
+
+      if (!failed) {
+        this.processed.add(event.id);
+        continue;
+      }
+
+      if (event.retries >= this.maxAttempts) {
+        this.dlq.push({ ...event });
+        this.processed.add(event.id);
+      } else {
+        this.enqueue({ ...event }, true);
       }
     }
   }
 }
+
+const bus = new PriorityEventBus();
+
+export const EventBus = {
+  subscribe(type: string, handler: Handler): void {
+    bus.subscribe(type, handler);
+  },
+  async publish<T>(event: LegacyEvent<T>): Promise<void> {
+    await bus.publish(event);
+  },
+  __dlq(): WorkbuoyEvent[] {
+    return bus.dlqList();
+  },
+  __reset(): void {
+    bus.reset();
+  }
+};
+
+export { bus };
+export const priorityBus = bus;
+export const PriorityBus = bus;
+export const emit = bus.emit.bind(bus);
+export const on = bus.on.bind(bus);
+export const stats = bus.stats.bind(bus);
+export const publish = bus.publish.bind(bus);
+export const subscribe = bus.subscribe.bind(bus);
+export const dlqList = bus.dlqList.bind(bus);
+export const reset = bus.reset.bind(bus);
+export const peek = bus._peek.bind(bus);
+export default bus;

--- a/src/core/events/priorityBus.ts
+++ b/src/core/events/priorityBus.ts
@@ -1,3 +1,2 @@
-// src/core/events/priorityBus.ts
-export * from '../eventBusV2';
-export { bus as default } from '../eventBusV2';
+export * from './bus';
+export { bus as default } from './bus';


### PR DESCRIPTION
## What
- centralize the priority queue implementation in `src/core/events/bus.ts`, exposing emit/on/publish/subscribe plus stats/_peek/dlq/reset for route and test consumers
- collapse `eventBusV2` and `events/priorityBus` into thin re-exports of the shared bus so every import path resolves to the same instance surface
- retain DLQ/introspection helpers via the shared implementation to keep `_debug/bus` and DLQ routes functioning

## Why
- removes the duplicate bus logic that previously lived in `eventBusV2.ts` so future changes only touch one implementation
- aligns with the consolidation goal: all consumers (`eventBus`, `eventBusV2`, `events/priorityBus`) receive the same working priority bus with retries/DLQ/stats
- keeps the acceptance contract for `_debug/bus` and DLQ inspection while ensuring publish/subscribe aliases remain intact for legacy flows

## Files touched
- src/core/events/bus.ts
- src/core/eventBusV2.ts
- src/core/events/priorityBus.ts

## Risk
- Medium – shared event bus behaviour, but API surface unchanged and tests cover retries/DLQ expectations

## Testing steps
- `npm test`
- `rg "class PriorityBus" src | grep -v _legacy`
- `NODE_PATH=backend/node_modules node -r ts-node/register -e "const a=require('./src/core/eventBusV2');const b=require('./src/core/eventBus');const c=require('./src/core/events/priorityBus');console.log([a.bus,b.default,c.default].every(x=>typeof x.emit==='function'&&typeof x.on==='function'&&typeof x.stats==='function'))"`

## Smoke
npm run dev
curl -s http://localhost:3000/status | jq .
curl -s http://localhost:3000/api/knowledge/search?q=hello | jq .
curl -s http://localhost:3000/_debug/bus | jq .

diff
```diff
diff --git a/src/core/events/bus.ts b/src/core/events/bus.ts
@@
-import type Priority = 'high'|'medium'|'low';
-
-export interface WorkbuoyEvent<T=any> {
-  id: string; type: string; priority: Priority;
-  timestamp: string; correlationId?: string; payload: T; retries?: number;
-}
-
-type Handler = (e: WorkbuoyEvent)=>Promise<void>;
-
-const handlers = new Map<string, Handler[]>();
-const processed = new Set<string>();
-const dlq: WorkbuoyEvent[] = [];
-
-const queues: Record<Priority, WorkbuoyEvent[]> = { high:[], medium:[], low:[] };
-const MAX_RETRIES = 3;
-
-export const EventBus = {
-  subscribe(type: string, handler: Handler) {
-    const list = handlers.get(type) ?? [];
-    list.push(handler);
-    handlers.set(type, list);
-  },
-
-  async publish<T>(event: WorkbuoyEvent<T>) {
-    if (processed.has(event.id)) return; // idempotent
-    queues[event.priority].push({ ...event, retries: event.retries ?? 0 });
-    await drain();
-  },
-
-  // testing/introspection
-  __dlq() { return dlq.slice(); },
-  __reset() {
-    handlers.clear(); processed.clear(); dlq.splice(0, dlq.length);
-    queues.high.length = queues.medium.length = queues.low.length = 0;
-  }
-};
-
-async function drain() {
-  for (const p of (['high','medium','low'] as Priority[])) {
-    while (queues[p].length) {
-      const ev = queues[p].shift()!;
-      const list = handlers.get(ev.type) ?? [];
-      if (!list.length) { processed.add(ev.id); continue; }
-
-      try {
-        for (const h of list) await h(ev);
-        processed.add(ev.id);
-      } catch (_e) {
-        ev.retries = (ev.retries ?? 0) + 1;
-        if (ev.retries >= MAX_RETRIES) dlq.push(ev);
-        else queues[p].push(ev);
-      }
-    }
-  }
-}
+import crypto from 'crypto';
+
+export type Priority = 'high' | 'medium' | 'low';
+
+export interface WorkbuoyEvent<T = any> {
+  id: string;
+  type: string;
+  priority: Priority;
+  timestamp: string;
+  payload: T;
+  correlationId?: string;
+  source?: string;
+  retries: number;
+  lastError?: string;
+  headers?: Record<string, string>;
+  meta?: Record<string, any>;
+}
+
+export interface LegacyEvent<T = any> {
+  id?: string;
+  type: string;
+  priority?: string;
+  payload?: T;
+  timestamp?: string;
+  ts?: string;
+  correlationId?: string;
+  source?: string;
+  retries?: number;
+  attempts?: number;
+  headers?: Record<string, string>;
+  meta?: Record<string, any>;
+  lastError?: string;
+}
+
+export interface EmitOptions {
+  priority?: string;
+  idempotencyKey?: string;
+  correlationId?: string;
+  source?: string;
+  headers?: Record<string, string>;
+  meta?: Record<string, any>;
+}
+
+type Handler<T = any> = (event: WorkbuoyEvent<T>) => Promise<void> | void;
+type ConsumerMap = Map<string, Handler>;
+
+const PRIORITIES: Priority[] = ['high', 'medium', 'low'];
+const DEFAULT_MAX_ATTEMPTS = Math.max(1, Number(process.env.BUS_MAX_ATTEMPTS || process.env.EVENTBUS_MAX_ATTEMPTS || 3));
+
+function normalizePriority(priority?: string): Priority {
+  const value = (priority ?? 'medium').toLowerCase();
+  if (value === 'high' || value === 'urgent' || value === 'critical') return 'high';
+  if (value === 'low' || value === 'minor') return 'low';
+  return 'medium';
+}
+
+function nextId(seed?: string): string {
+  if (seed) return seed;
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  return `evt-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function cloneEvent<T>(event: WorkbuoyEvent<T>): WorkbuoyEvent<T> {
+  return { ...event, payload: event.payload };
+}
+
+class PriorityEventBus {
+  private readonly queues: Record<Priority, WorkbuoyEvent[]> = {
+    high: [],
+    medium: [],
+    low: []
+  };
+  private readonly handlers = new Map<string, ConsumerMap>();
+  private readonly pending = new Set<string>();
+  private readonly processed = new Set<string>();
+  private readonly dlq: WorkbuoyEvent[] = [];
+  private listenerSeq = 0;
+  private drainSequence: Promise<void> = Promise.resolve();
+  private readonly maxAttempts = DEFAULT_MAX_ATTEMPTS;
+
+  async emit<T>(eventOrType: string | LegacyEvent<T>, payload?: T, opts?: EmitOptions): Promise<void> {
+    const event = this.normalize(eventOrType, payload, opts);
+    if (!this.enqueue(event)) return;
+    await this.ensureDrain();
+  }
+
+  async publish<T>(event: LegacyEvent<T>, opts?: EmitOptions): Promise<void> {
+    const normalized = this.normalize(event, undefined, opts);
+    if (!this.enqueue(normalized)) return;
+    await this.ensureDrain();
+  }
+
+  subscribe<T>(type: string, consumerOrHandler: string | Handler<T>, maybeHandler?: Handler<T>): void {
+    const handler = typeof consumerOrHandler === 'function' ? consumerOrHandler : maybeHandler;
+    if (!handler) return;
+    const consumerId = typeof consumerOrHandler === 'string' ? consumerOrHandler : `listener-${++this.listenerSeq}`;
+    const topicHandlers = this.handlers.get(type) ?? new Map<string, Handler>();
+    topicHandlers.set(consumerId, handler as Handler);
+    this.handlers.set(type, topicHandlers);
+  }
+
+  on<T>(type: string, handler: (payload: T, event: WorkbuoyEvent<T>) => Promise<void> | void): void {
+    this.subscribe(type, async (event) => {
+      await handler(event.payload as T, event as WorkbuoyEvent<T>);
+    });
+  }
+
+  async stats(): Promise<{ queues: Array<{ name: Priority; size: number }>; dlq: Array<WorkbuoyEvent> }> {
+    return {
+      queues: PRIORITIES.map((name) => ({ name, size: this.queues[name].length })),
+      dlq: this.dlq.map((event) => cloneEvent(event))
+    };
+  }
+
+  _peek(): { sizes: Record<Priority | 'dlq', number>; queues: Record<Priority, WorkbuoyEvent[]>; dlq: WorkbuoyEvent[] } {
+    return {
+      sizes: {
+        high: this.queues.high.length,
+        medium: this.queues.medium.length,
+        low: this.queues.low.length,
+        dlq: this.dlq.length
+      },
+      queues: {
+        high: this.queues.high.map((event) => cloneEvent(event)),
+        medium: this.queues.medium.map((event) => cloneEvent(event)),
+        low: this.queues.low.map((event) => cloneEvent(event))
+      },
+      dlq: this.dlq.map((event) => cloneEvent(event))
+    };
+  }
+
+  dlqList(): WorkbuoyEvent[] {
+    return this.dlq.map((event) => cloneEvent(event));
+  }
+
+  reset(): void {
+    this.handlers.clear();
+    this.pending.clear();
+    this.processed.clear();
+    this.queues.high.length = 0;
+    this.queues.medium.length = 0;
+    this.queues.low.length = 0;
+    this.dlq.length = 0;
+  }
+
+  private normalize<T>(eventOrType: string | LegacyEvent<T>, payload?: T, opts?: EmitOptions): WorkbuoyEvent<T> {
+    if (!eventOrType) throw new Error('event type required');
+    const base: LegacyEvent<T> = typeof eventOrType === 'string'
+      ? { type: eventOrType, payload }
+      : { ...eventOrType };
+
+    if (payload !== undefined && base.payload === undefined) base.payload = payload;
+    if (opts?.priority) base.priority = opts.priority;
+    if (opts?.correlationId) base.correlationId = opts.correlationId;
+    if (opts?.source) base.source = opts.source;
+    if (opts?.headers) base.headers = { ...(base.headers ?? {}), ...opts.headers };
+    if (opts?.meta) base.meta = { ...(base.meta ?? {}), ...opts.meta };
+    if (opts?.idempotencyKey) base.id = opts.idempotencyKey;
+
+    const id = nextId(base.id);
+    const priority = normalizePriority(base.priority);
+    const timestamp = base.timestamp ?? base.ts ?? new Date().toISOString();
+    const retries = typeof base.retries === 'number'
+      ? base.retries
+      : typeof base.attempts === 'number' && base.attempts > 0
+        ? base.attempts
+        : 0;
+
+    return {
+      id,
+      type: base.type,
+      priority,
+      timestamp,
+      correlationId: base.correlationId,
+      source: base.source,
+      payload: base.payload as T,
+      retries,
+      lastError: base.lastError,
+      headers: base.headers,
+      meta: base.meta
+    };
+  }
+
+  private enqueue(event: WorkbuoyEvent, allowDuplicate = false): boolean {
+    if (!allowDuplicate) {
+      if (this.processed.has(event.id)) return false;
+      if (this.pending.has(event.id)) return false;
+    }
+    this.queues[event.priority].push(event);
+    this.pending.add(event.id);
+    return true;
+  }
+
+  private dequeue(): WorkbuoyEvent | undefined {
+    for (const priority of PRIORITIES) {
+      const queue = this.queues[priority];
+      if (queue.length) {
+        const event = queue.shift()!;
+        this.pending.delete(event.id);
+        return event;
+      }
+    }
+    return undefined;
+  }
+
+  private ensureDrain(): Promise<void> {
+    this.drainSequence = this.drainSequence.then(() => this.drain());
+    return this.drainSequence;
+  }
+
+  private async drain(): Promise<void> {
+    while (true) {
+      const event = this.dequeue();
+      if (!event) break;
+      const handlers = this.handlers.get(event.type);
+      if (!handlers || handlers.size === 0) {
+        this.processed.add(event.id);
+        continue;
+      }
+
+      let failed = false;
+      for (const handler of handlers.values()) {
+        try {
+          await handler(event);
+        } catch (err) {
+          failed = true;
+          event.retries += 1;
+          event.lastError = err instanceof Error ? err.message : String(err);
+        }
+      }
+
+      if (!failed) {
+        this.processed.add(event.id);
+        continue;
+      }
+
+      if (event.retries >= this.maxAttempts) {
+        this.dlq.push({ ...event });
+        this.processed.add(event.id);
+      } else {
+        this.enqueue({ ...event }, true);
+      }
+    }
+  }
+}
+
+const bus = new PriorityEventBus();
+
+export const EventBus = {
+  subscribe(type: string, handler: Handler): void {
+    bus.subscribe(type, handler);
+  },
+  async publish<T>(event: LegacyEvent<T>): Promise<void> {
+    await bus.publish(event);
+  },
+  __dlq(): WorkbuoyEvent[] {
+    return bus.dlqList();
+  },
+  __reset(): void {
+    bus.reset();
+  }
+};
+
+export { bus };
+export const priorityBus = bus;
+export const PriorityBus = bus;
+export const emit = bus.emit.bind(bus);
+export const on = bus.on.bind(bus);
+export const stats = bus.stats.bind(bus);
+export const publish = bus.publish.bind(bus);
+export const subscribe = bus.subscribe.bind(bus);
+export const dlqList = bus.dlqList.bind(bus);
+export const reset = bus.reset.bind(bus);
+export const peek = bus._peek.bind(bus);
+export default bus;
```

## DoR
- [Medium] src/core/events/bus.ts
- [Low] src/core/eventBusV2.ts
- [Low] src/core/events/priorityBus.ts

## DoD
- [x] Tests green
- [ ] CI green
- [x] No breaking changes
- [x] PII-masking & correlation preserved


------
https://chatgpt.com/codex/tasks/task_e_68cb07c73230832a8434bebfa15cdad3