### PR TITLE
feat/meta: implement META capabilities endpoint

### DIFF
--- a/backend/jest.meta.config.cjs
+++ b/backend/jest.meta.config.cjs
@@ -5,5 +5,6 @@ module.exports = {
   testMatch: [
     '<rootDir>/tests/genesis.autonomy.test.ts',
     '<rootDir>/tests/eventBus.stats.shape.test.ts',
+    '<rootDir>/../tests/meta/**/*.test.ts',
   ],
 };

--- a/backend/meta/capabilities.ts
+++ b/backend/meta/capabilities.ts
@@ -1,0 +1,167 @@
+import type { MetaCapabilitiesResponse, MetaConnectorCapability } from './types';
+import type { ProviderName } from '../src/connectors/types';
+
+const BOOLEAN_TRUE_VALUES = new Set(['1', 'true', 'yes', 'on', 'enabled']);
+const BOOLEAN_FALSE_VALUES = new Set(['0', 'false', 'no', 'off', 'disabled']);
+
+const MODE_DEFAULTS: Readonly<MetaCapabilitiesResponse['modes']> = {
+  core: true,
+  flex: false,
+  secure: false,
+};
+
+type ConnectorRegistryEntry = {
+  name: ProviderName;
+  defaultEnabled: boolean;
+};
+
+const CONNECTOR_REGISTRY: ReadonlyArray<ConnectorRegistryEntry> = [
+  { name: 'hubspot', defaultEnabled: true },
+  { name: 'salesforce', defaultEnabled: true },
+  { name: 'dynamics', defaultEnabled: true },
+];
+
+const FEATURE_FLAG_PREFIX = 'META_FEATURE_';
+
+const CONNECTOR_ENV_PREFIXES = ['META_CONNECTOR_', 'WB_CONNECTOR_', 'CONNECTOR_'] as const;
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const normalised = value.trim().toLowerCase();
+  if (BOOLEAN_TRUE_VALUES.has(normalised)) {
+    return true;
+  }
+  if (BOOLEAN_FALSE_VALUES.has(normalised)) {
+    return false;
+  }
+  return defaultValue;
+}
+
+function coalesceEnv(keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const raw = process.env[key];
+    if (raw !== undefined) {
+      return raw;
+    }
+  }
+  return undefined;
+}
+
+function resolveModes(): MetaCapabilitiesResponse['modes'] {
+  const deriveMode = (mode: keyof MetaCapabilitiesResponse['modes']): boolean => {
+    const envCandidates = [
+      `META_MODE_${mode.toUpperCase()}`,
+      `META_MODE_${mode.toUpperCase()}_ENABLED`,
+      `WB_MODE_${mode.toUpperCase()}`,
+      `WB_MODE_${mode.toUpperCase()}_ENABLED`,
+    ] as const;
+    return parseBoolean(coalesceEnv(envCandidates), MODE_DEFAULTS[mode]);
+  };
+
+  return {
+    core: deriveMode('core'),
+    flex: deriveMode('flex'),
+    secure: deriveMode('secure'),
+  };
+}
+
+function resolveConnectorToggle(name: ProviderName, fallback: boolean): boolean {
+  const envKeys = CONNECTOR_ENV_PREFIXES.map(prefix => `${prefix}${name.toUpperCase()}_ENABLED`);
+  return parseBoolean(coalesceEnv(envKeys), fallback);
+}
+
+function resolveConnectors(): MetaConnectorCapability[] {
+  const globalDefault = parseBoolean(
+    coalesceEnv(['META_CONNECTORS_ENABLED', 'WB_CONNECTORS_ENABLED', 'CONNECTORS_ENABLED']),
+    true,
+  );
+
+  return CONNECTOR_REGISTRY.map(({ name, defaultEnabled }) => ({
+    name,
+    enabled: resolveConnectorToggle(name, globalDefault && defaultEnabled),
+  }));
+}
+
+function sanitiseFeatureName(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.toLowerCase().replace(/[^a-z0-9_\-]/g, '_');
+}
+
+function parseAggregatedFeatureFlags(raw: string | undefined): Record<string, boolean> {
+  if (!raw) {
+    return {};
+  }
+
+  const flags: Record<string, boolean> = {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      for (const [key, value] of Object.entries(parsed)) {
+        const name = sanitiseFeatureName(key);
+        if (!name) {
+          continue;
+        }
+        if (typeof value === 'boolean') {
+          flags[name] = value;
+          continue;
+        }
+        if (typeof value === 'number') {
+          flags[name] = value !== 0;
+          continue;
+        }
+        if (typeof value === 'string') {
+          flags[name] = parseBoolean(value, true);
+        }
+      }
+      return flags;
+    }
+  } catch {
+    // Fallback to comma-separated parsing below.
+  }
+
+  const segments = raw.split(',').map(segment => segment.trim()).filter(Boolean);
+  for (const segment of segments) {
+    const [namePart, valuePart] = segment.split('=');
+    const name = sanitiseFeatureName(namePart ?? '');
+    if (!name) {
+      continue;
+    }
+    flags[name] = parseBoolean(valuePart, true);
+  }
+  return flags;
+}
+
+function resolveFeatureFlags(): Record<string, boolean> {
+  const aggregated = parseAggregatedFeatureFlags(process.env.META_FEATURE_FLAGS);
+  const flags: Record<string, boolean> = { ...aggregated };
+
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!key.startsWith(FEATURE_FLAG_PREFIX) || key === 'META_FEATURE_FLAGS') {
+      continue;
+    }
+    const name = sanitiseFeatureName(key.slice(FEATURE_FLAG_PREFIX.length));
+    if (!name) {
+      continue;
+    }
+    flags[name] = parseBoolean(value, true);
+  }
+
+  const entries = Object.entries(flags);
+  entries.sort(([a], [b]) => a.localeCompare(b));
+  return Object.fromEntries(entries);
+}
+
+export function getCapabilities(): MetaCapabilitiesResponse {
+  return {
+    modes: resolveModes(),
+    connectors: resolveConnectors(),
+    feature_flags: resolveFeatureFlags(),
+  };
+}
+
+export default getCapabilities;

--- a/backend/meta/router.ts
+++ b/backend/meta/router.ts
@@ -3,6 +3,7 @@ import { getHealth } from './health';
 import { getVersion } from './version';
 import { runReadiness } from './readiness';
 import type { Probe } from './probes';
+import { getCapabilities } from './capabilities';
 
 export interface ReadinessOptions {
   probes?: Probe[];
@@ -53,7 +54,8 @@ export function createMetaRouter(options: MetaRouterOptions = {}): Router {
   });
 
   router.get('/capabilities', (_req: Request, res: Response) => {
-    res.status(501).json({ error: 'Not implemented' });
+    const payload = getCapabilities();
+    res.status(200).json(payload);
   });
 
   router.get('/policy', (_req: Request, res: Response) => {

--- a/backend/meta/types.ts
+++ b/backend/meta/types.ts
@@ -10,6 +10,21 @@ export interface HealthResponse {
   started_at: string;
 }
 
+export interface MetaConnectorCapability {
+  name: string;
+  enabled: boolean;
+}
+
+export interface MetaCapabilitiesResponse {
+  modes: {
+    core: boolean;
+    flex: boolean;
+    secure: boolean;
+  };
+  connectors: MetaConnectorCapability[];
+  feature_flags: Record<string, boolean>;
+}
+
 export interface VersionResponse {
   semver: string;
   git_sha: string;

--- a/openapi/meta.yaml
+++ b/openapi/meta.yaml
@@ -52,6 +52,17 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/VersionResponse' }
       security: []
+  /meta/capabilities:
+    get:
+      operationId: getMetaCapabilities
+      tags: [meta]
+      summary: Capability toggles and availability snapshot
+      responses:
+        '200':
+          description: Capabilities response
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CapabilitiesResponse' }
 components:
   securitySchemes:
     bearerAuth:
@@ -93,5 +104,28 @@ components:
         git_sha: { type: string }
         built_at: { type: string, format: date-time }
         commit_time: { type: string, format: date-time }
+    ConnectorCapability:
+      type: object
+      required: [name, enabled]
+      properties:
+        name: { type: string }
+        enabled: { type: boolean }
+    CapabilitiesResponse:
+      type: object
+      required: [modes, connectors, feature_flags]
+      properties:
+        modes:
+          type: object
+          required: [core, flex, secure]
+          properties:
+            core: { type: boolean }
+            flex: { type: boolean }
+            secure: { type: boolean }
+        connectors:
+          type: array
+          items: { $ref: '#/components/schemas/ConnectorCapability' }
+        feature_flags:
+          type: object
+          additionalProperties: { type: boolean }
 security:
   - bearerAuth: []

--- a/tests/meta/capabilities.test.ts
+++ b/tests/meta/capabilities.test.ts
@@ -1,0 +1,116 @@
+import express from 'express';
+import request from 'supertest';
+import router from '../../backend/meta/router';
+
+describe('META: /meta/capabilities', () => {
+  const ORIGINAL_ENV = process.env;
+
+  const createApp = () => {
+    const app = express();
+    app.use('/api/meta', router);
+    return app;
+  };
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.META_MODE_CORE;
+    delete process.env.META_MODE_CORE_ENABLED;
+    delete process.env.META_MODE_FLEX;
+    delete process.env.META_MODE_FLEX_ENABLED;
+    delete process.env.META_MODE_SECURE;
+    delete process.env.META_MODE_SECURE_ENABLED;
+    delete process.env.WB_MODE_CORE;
+    delete process.env.WB_MODE_CORE_ENABLED;
+    delete process.env.WB_MODE_FLEX;
+    delete process.env.WB_MODE_FLEX_ENABLED;
+    delete process.env.WB_MODE_SECURE;
+    delete process.env.WB_MODE_SECURE_ENABLED;
+    delete process.env.META_CONNECTORS_ENABLED;
+    delete process.env.WB_CONNECTORS_ENABLED;
+    delete process.env.CONNECTORS_ENABLED;
+    delete process.env.META_CONNECTOR_HUBSPOT_ENABLED;
+    delete process.env.META_CONNECTOR_SALESFORCE_ENABLED;
+    delete process.env.META_CONNECTOR_DYNAMICS_ENABLED;
+    delete process.env.WB_CONNECTOR_HUBSPOT_ENABLED;
+    delete process.env.WB_CONNECTOR_SALESFORCE_ENABLED;
+    delete process.env.WB_CONNECTOR_DYNAMICS_ENABLED;
+    delete process.env.CONNECTOR_HUBSPOT_ENABLED;
+    delete process.env.CONNECTOR_SALESFORCE_ENABLED;
+    delete process.env.CONNECTOR_DYNAMICS_ENABLED;
+    delete process.env.META_FEATURE_FLAGS;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns default capability snapshot when env is unset', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/meta/capabilities');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      modes: { core: true, flex: false, secure: false },
+      connectors: [
+        { name: 'hubspot', enabled: true },
+        { name: 'salesforce', enabled: true },
+        { name: 'dynamics', enabled: true },
+      ],
+      feature_flags: {},
+    });
+  });
+
+  it('respects mode and connector toggles from env', async () => {
+    process.env.META_MODE_CORE = 'false';
+    process.env.META_MODE_FLEX_ENABLED = '1';
+    process.env.WB_MODE_SECURE = 'true';
+
+    process.env.CONNECTORS_ENABLED = 'false';
+    process.env.META_CONNECTOR_SALESFORCE_ENABLED = 'true';
+    process.env.WB_CONNECTOR_DYNAMICS_ENABLED = 'true';
+
+    const app = createApp();
+    const res = await request(app).get('/api/meta/capabilities');
+
+    expect(res.status).toBe(200);
+    expect(res.body.modes).toEqual({ core: false, flex: true, secure: true });
+    expect(res.body.connectors).toEqual([
+      { name: 'hubspot', enabled: false },
+      { name: 'salesforce', enabled: true },
+      { name: 'dynamics', enabled: true },
+    ]);
+  });
+
+  it('aggregates feature flags and only exposes boolean toggles', async () => {
+    process.env.META_FEATURE_FLAGS = 'alpha, beta=false, gamma=yes';
+    process.env.META_FEATURE_EXPERIMENTAL = 'true';
+    process.env.SECRET_API_KEY = 'should_not_leak';
+
+    const app = createApp();
+    const res = await request(app).get('/api/meta/capabilities');
+
+    expect(res.status).toBe(200);
+    expect(res.body.feature_flags).toEqual({
+      alpha: true,
+      beta: false,
+      experimental: true,
+      gamma: true,
+    });
+    expect(Object.values(res.body.feature_flags).every((value: unknown) => typeof value === 'boolean')).toBe(true);
+    expect(res.body.feature_flags).not.toHaveProperty('secret_api_key');
+  });
+
+  it('parses feature flags from JSON configuration when provided', async () => {
+    process.env.META_FEATURE_FLAGS = '{"beta": true, "gamma": 0, "stringy": "no"}';
+
+    const app = createApp();
+    const res = await request(app).get('/api/meta/capabilities');
+
+    expect(res.status).toBe(200);
+    expect(res.body.feature_flags).toEqual({
+      beta: true,
+      gamma: false,
+      stringy: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement META capabilities handler that pulls mode toggles, connector registry enablement and feature flags from env/config
- wire the handler into the meta router, expand the OpenAPI contract and expose typed response models
- add supertest coverage for capability combinations and enable jest to execute meta test suite

## Testing
- `npm run typecheck`
- `npm test`
- `npx openapi-validate openapi/meta.yaml` *(fails: npm registry access returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb178b511c832ab51d1d1d0b0b16ea