### PR TITLE
refactor(frontend): share introspection api types

### DIFF
--- a/frontend/src/api/introspection.ts
+++ b/frontend/src/api/introspection.ts
@@ -1,17 +1,7 @@
 import { apiFetch } from '@/api/client';
+import type { IntrospectionResponse } from '@/types/introspection';
 
-export type IntrospectionReport = {
-  generatedAt: string;
-  summary: string;
-  signals: Array<{ id: string; status: string; detail: string }>;
-  recommendations: string[];
-};
-
-export type IntrospectionResponse = {
-  ok: boolean;
-  awarenessScore: number;
-  introspectionReport: IntrospectionReport;
-};
+export type { IntrospectionReport, IntrospectionResponse } from '@/types/introspection';
 
 export async function fetchIntrospectionReport(): Promise<IntrospectionResponse> {
   return apiFetch<IntrospectionResponse>('/genesis/introspection-report');

--- a/frontend/src/types/introspection.ts
+++ b/frontend/src/types/introspection.ts
@@ -1,0 +1,12 @@
+export type IntrospectionReport = {
+  generatedAt: string;
+  summary: string;
+  signals: Array<{ id: string; status: string; detail: string }>;
+  recommendations: string[];
+};
+
+export type IntrospectionResponse = {
+  ok: boolean;
+  awarenessScore: number;
+  introspectionReport: IntrospectionReport;
+};


### PR DESCRIPTION
## Summary
- add shared `IntrospectionReport`/`IntrospectionResponse` definitions under `frontend/src/types`
- re-export the introspection types from the API helper so consumers keep receiving typed data

## Testing
- npm run typecheck --prefix frontend *(fails: existing missing module/type definition errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc35a5288832ab67bd134e32a5c32