### PR TITLE
Resolve introspection fetch fallback

### DIFF
--- a/frontend/src/api/introspection.ts
+++ b/frontend/src/api/introspection.ts
@@ -1,5 +1,28 @@
 import { apiFetch } from '@/api';
 
-export async function fetchIntrospectionReport(){
-  return apiFetch('/api/introspection');
+export type IntrospectionSignal = {
+  id: string;
+  status: string;
+  detail: string;
+};
+
+export type IntrospectionReport = {
+  generatedAt: string;
+  summary: string;
+  signals: IntrospectionSignal[];
+  recommendations: string[];
+};
+
+export type IntrospectionResponse = {
+  ok: boolean;
+  awarenessScore: number;
+  introspectionReport: IntrospectionReport;
+};
+
+export async function fetchIntrospectionReport(): Promise<IntrospectionResponse> {
+  try {
+    return await apiFetch<IntrospectionResponse>('/api/introspection');
+  } catch (error) {
+    return apiFetch<IntrospectionResponse>('/genesis/introspection-report');
+  }
 }


### PR DESCRIPTION
## Summary
- restore the introspection API fetch logic with fallback to the genesis endpoint
- add exported typings for the introspection response consumed by the badge component

## Testing
- npm run typecheck --prefix frontend *(fails: missing @testing-library/react and jest globals in repo baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68cdca18ad54832abaffc8921a093515