### PR TITLE
feat: improve logger correlation propagation

### DIFF
--- a/src/buoy/agent.ts
+++ b/src/buoy/agent.ts
@@ -32,7 +32,8 @@ function tryRequire<T = any>(mod: string): T | null {
 const explainLib = tryRequire<any>("../core/explain");
 const eventBus = tryRequire<any>("../core/eventBus");
 const audit = tryRequire<any>("../core/audit");
-const logger = tryRequire<any>("../core/logger");
+const loggerModule = tryRequire<any>("../core/logging/logger");
+const logger = loggerModule?.logger ?? loggerModule?.default ?? loggerModule;
 
 function buildExplanation(input: Partial<Explanation>): Explanation {
   if (explainLib && typeof explainLib.buildExplanation === "function") {
@@ -53,7 +54,7 @@ export async function run(input: RunInput, req: Request): Promise<RunOutput> {
   const { intent, params } = input || {};
   const corrId = ctx.correlationId;
 
-  logger?.info?.({ corrId, intent, tag: "buoy.run.start" });
+  logger?.info?.('buoy.run.start', { intent, tag: "buoy.run.start", correlationId: corrId }, corrId);
 
   // Reasoning (MVP)
   const planRes = await plan(intent, ctx);
@@ -81,7 +82,7 @@ export async function run(input: RunInput, req: Request): Promise<RunOutput> {
     await audit.append({ ts: new Date().toISOString(), msg: "buoy.action.executed", meta: { intent, action: planRes.action, ok: !!execRes?.ok, corrId } });
   }
 
-  logger?.info?.({ corrId, intent, tag: "buoy.run.end" });
+  logger?.info?.('buoy.run.end', { intent, tag: "buoy.run.end", correlationId: corrId }, corrId);
 
   return {
     result: execRes,

--- a/src/core/http/middleware/requestContext.ts
+++ b/src/core/http/middleware/requestContext.ts
@@ -8,5 +8,6 @@ export function requestContext(req: Request, _res: Response, next: NextFunction)
   const al = Number(req.headers['x-autonomy-level'] || 2);
   wb.autonomyLevel = Number.isFinite(al) ? al : 2;
   (req as any).wb = wb;
+  (req as any).correlationId = wb.correlationId;
   next();
 }

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,5 +1,0 @@
-// Unified logger alias:
-// This file re-exports the canonical logger from src/core/logging/logger.ts
-// so all legacy imports `from "../../core/logger"` now resolve to the same implementation.
-export * from "./logging/logger";
-export { default } from "./logging/logger";

--- a/src/core/logging/logger.ts
+++ b/src/core/logging/logger.ts
@@ -3,7 +3,9 @@ import fs from 'fs';
 import path from 'path';
 import { maskPII } from './maskPII';
 
-type Level = 'debug'|'info'|'warn'|'error';
+export type Level = 'debug'|'info'|'warn'|'error';
+export type LogFields = Record<string, any> & { correlationId?: string };
+
 const LOG_FILE = process.env.WB_LOG_FILE || path.join(process.cwd(), 'workbuoy.log');
 
 function write(fields: Record<string, any>) {
@@ -14,22 +16,80 @@ function write(fields: Record<string, any>) {
   console.log(line);
 }
 
-export function log(level: Level, msg: string, fields: Record<string, any> = {}) {
+function sanitise(fields: LogFields = {}) {
   const safe: Record<string, any> = {};
-  for (const [k,v] of Object.entries(fields)) safe[k] = typeof v === 'string' ? maskPII(v) : v;
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === undefined) continue;
+    safe[k] = typeof v === 'string' ? maskPII(v) : v;
+  }
+  return safe;
+}
+
+export function log(level: Level, msg: string, fields: LogFields = {}, correlationId?: string) {
+  const { correlationId: fieldCorrelationId, ...rest } = fields || {};
+  const safe = sanitise(rest);
+  const corr = correlationId || (typeof fieldCorrelationId === 'string' ? fieldCorrelationId : undefined);
+  if (corr) safe.correlationId = corr;
   write({ level, msg, ...safe });
 }
+
+function pickCorrelation(...values: Array<unknown>): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length) return value;
+  }
+  return undefined;
+}
+
+type StructuredFields = LogFields & { msg?: string; message?: string };
+
+function normaliseArgs(level: Level, args: any[]): [string, LogFields, string | undefined] {
+  const [first, second, third] = args;
+  if (typeof first === 'string') {
+    const fields = (second && typeof second === 'object' && !Array.isArray(second)) ? { ...(second as LogFields) } : {};
+    const { correlationId: fromFields, ...rest } = fields as StructuredFields;
+    const correlationId = pickCorrelation(third, typeof second === 'string' ? second : undefined, fromFields);
+    return [first, rest, correlationId];
+  }
+
+  const record: StructuredFields = (first && typeof first === 'object' && !Array.isArray(first))
+    ? { ...(first as StructuredFields) }
+    : {};
+  const { msg, message, correlationId: fromRecord, ...rest } = record;
+  const extra = (second && typeof second === 'object' && !Array.isArray(second)) ? { ...(second as LogFields) } : {};
+  const { correlationId: fromExtra, ...extraRest } = extra as StructuredFields;
+  const messageText = typeof msg === 'string' ? msg : typeof message === 'string' ? message : level;
+  const correlationId = pickCorrelation(third, typeof second === 'string' ? second : undefined, fromRecord, fromExtra);
+  return [messageText, { ...rest, ...extraRest }, correlationId];
+}
+
+type LoggerMethod = (...args: any[]) => void;
+
+function createMethod(level: Level): LoggerMethod {
+  return (...args: any[]) => {
+    const [msg, fields, correlationId] = normaliseArgs(level, args);
+    log(level, msg, fields, correlationId);
+  };
+}
+
+export const logger = {
+  debug: createMethod('debug'),
+  info: createMethod('info'),
+  warn: createMethod('warn'),
+  error: createMethod('error'),
+};
+
+export default logger;
 
 export function requestLogger() {
   return (req: any, _res: any, next: any) => {
     const wb = req.wb || {};
+    const correlationId = wb.correlationId || req.correlationId;
     log('info', 'http_request', {
       method: req.method,
       url: req.originalUrl || req.url,
-      correlationId: wb.correlationId,
       roleId: wb.roleId,
       autonomyLevel: wb.autonomyLevel
-    });
+    }, correlationId);
     next();
   };
 }

--- a/src/core/middleware/errorHandler.ts
+++ b/src/core/middleware/errorHandler.ts
@@ -1,19 +1,19 @@
 import type { Request, Response, NextFunction } from "express";
 import { AppError } from "../errors";
-import { logger } from "../logger";
+import { logger } from "../logging/logger";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
   const correlationId = req.correlationId;
   if (err instanceof AppError) {
-    logger.error("app_error", { correlationId, code: (err as any).code, details: (err as any).details, stack: (err as any).stack });
+    logger.error("app_error", { code: (err as any).code, details: (err as any).details, stack: (err as any).stack }, correlationId);
     return res.status((err as any).statusCode || 500).json({
       error: { message: (err as any).message, code: (err as any).code, details: (err as any).details },
       correlationId,
     });
   }
   const anyErr = err as any;
-  logger.error("unhandled_error", { correlationId, err: { message: anyErr?.message, stack: anyErr?.stack } });
+  logger.error("unhandled_error", { err: { message: anyErr?.message, stack: anyErr?.stack } }, correlationId);
   return res.status(500).json({
     error: { message: "Internal Server Error" },
     correlationId,

--- a/src/core/middleware/requestContext.ts
+++ b/src/core/middleware/requestContext.ts
@@ -5,11 +5,15 @@ declare global {
   namespace Express {
     interface Request {
       correlationId?: string;
+      wb?: { correlationId?: string };
     }
   }
 }
 
 export function requestContext(req: Request, _res: Response, next: NextFunction) {
-  req.correlationId = req.headers["x-correlation-id"]?.toString() || randomUUID();
+  const correlationId = req.headers["x-correlation-id"]?.toString() || randomUUID();
+  req.correlationId = correlationId;
+  const existing = (req as any).wb || {};
+  (req as any).wb = { ...existing, correlationId };
   next();
 }

--- a/tests/logging.correlation.full.test.ts
+++ b/tests/logging.correlation.full.test.ts
@@ -1,5 +1,19 @@
-// tests/logging.correlation.full.test.ts
-const maybe = process.env.TEST_CORRELATION ? it : it.skip;
-maybe('propagates x-correlation-id header end-to-end', async () => {
-  expect(true).toBe(true);
+import express from 'express';
+import request from 'supertest';
+import { requestContext } from '../src/core/middleware/requestContext';
+
+describe('requestContext correlation exposure', () => {
+  it('makes correlationId available on req and wb', async () => {
+    const app = express();
+    app.use(requestContext as any);
+    app.get('/ctx', (req: any, res) => {
+      res.json({ correlationId: req.correlationId, wbCorrelationId: req.wb?.correlationId });
+    });
+
+    const correlationId = 'corr-full-123';
+    const res = await request(app).get('/ctx').set('x-correlation-id', correlationId);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ correlationId, wbCorrelationId: correlationId });
+  });
 });

--- a/tests/logging.correlation.test.ts
+++ b/tests/logging.correlation.test.ts
@@ -1,5 +1,29 @@
-// tests/logging.correlation.test.ts
-const maybe = process.env.TEST_CORRELATION ? it : it.skip;
-maybe('propagates correlation id (smoke)', async () => {
-  expect(true).toBe(true);
+import express from 'express';
+import request from 'supertest';
+import { requestContext } from '../src/core/middleware/requestContext';
+import { errorHandler } from '../src/core/middleware/errorHandler';
+import { AppError } from '../src/core/errors';
+import * as logging from '../src/core/logging/logger';
+
+describe('logging correlation propagation', () => {
+  it('logs correlation id from requestContext via errorHandler', async () => {
+    const app = express();
+    const logSpy = jest.spyOn(logging, 'log').mockImplementation(() => undefined);
+    app.use(requestContext as any);
+    app.get('/boom', (_req, _res, next) => {
+      next(new AppError('test error', 418, 'E_TEST'));
+    });
+    app.use(errorHandler as any);
+
+    const correlationId = 'corr-test-001';
+    const res = await request(app).get('/boom').set('x-correlation-id', correlationId);
+
+    expect(res.status).toBe(418);
+    expect(res.body.correlationId).toBe(correlationId);
+
+    const errorCall = logSpy.mock.calls.find(([level]) => level === 'error');
+    expect(errorCall?.[3]).toBe(correlationId);
+
+    logSpy.mockRestore();
+  });
 });

--- a/tests/logging.masking.test.ts
+++ b/tests/logging.masking.test.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import * as logging from '../src/core/logging/logger';
+
+describe('logger PII masking', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('masks sensitive strings and preserves correlationId', () => {
+    const appendSpy = jest.spyOn(fs, 'appendFileSync').mockImplementation(() => undefined);
+    logging.log('info', 'user_signup', {
+      email: 'user@example.com',
+      phone: '+15551234567',
+      account: 'NO9386011117947'
+    }, 'corr-mask-001');
+
+    expect(appendSpy).toHaveBeenCalled();
+    const payload = appendSpy.mock.calls[0]?.[1];
+    expect(typeof payload).toBe('string');
+    const record = JSON.parse(String(payload).trim());
+    expect(record.email).toBe('u***@example.com');
+    expect(record.phone).toContain('***');
+    expect(record.account).toContain('****');
+    expect(record.correlationId).toBe('corr-mask-001');
+  });
+});


### PR DESCRIPTION
## Summary
- remove the legacy `src/core/logger.ts` shim and extend the core logger to handle correlation ids directly
- ensure request context and middleware attach correlation ids to logging calls and update the buoy agent to consume the canonical logger
- add tests covering correlation propagation from middleware and PII masking behaviour

## Testing
- `npm test`
- `npm run typecheck` *(fails: existing parse errors in frontend/src/api/introspection.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcef0da24832ab879be7d32d8fd7b