### PR TITLE
Mount metrics handler, guard writes, and wire deals API

### DIFF
--- a/src/features/deals/deals.router.ts
+++ b/src/features/deals/deals.router.ts
@@ -1,15 +1,15 @@
 // src/features/deals/deals.router.ts
 import { Router } from 'express';
-import { policyV2Guard } from '../../core/policyV2';
+import { policyGuardWrite } from '../../core/policy/guard';
 import { listDeals, upsertDeal, removeDeal } from './deals.service';
 
 const r = Router();
 r.get('/deals', async (_req,res)=> res.json(await listDeals()));
-r.post('/deals', policyV2Guard, async (req,res)=>{
+r.post('/deals', policyGuardWrite('deals'), async (req,res)=>{
   const d = await upsertDeal(req.body);
   res.json(d);
 });
-r.delete('/deals/:id', policyV2Guard, async (req,res)=>{
+r.delete('/deals/:id', policyGuardWrite('deals'), async (req,res)=>{
   const ok = await removeDeal(req.params.id);
   res.json({ ok });
 });

--- a/src/routes/finance.reminder.ts
+++ b/src/routes/finance.reminder.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { FinanceOrchestrator } from '../finance/orchestrator';
+import { policyGuardWrite } from '../core/policy/guard';
 // The orchestrator instance should be created and passed in from your composition root.
 // Here we create a tiny factory expecting a connector via req.app.get('financeConnector') for testability.
 
@@ -7,13 +8,18 @@ export function financeReminderRouter() {
   const r = Router();
 
   // POST /api/finance/reminder/suggest { invoiceId, customerEmail? }
-  r.post('/reminder/suggest', async (req: any, res, next) => {
+  r.post('/reminder/suggest', policyGuardWrite('finance'), async (req: any, res, next) => {
     try {
       const { invoiceId, customerEmail } = req.body || {};
       const connector = req.app.get('financeConnector');
       if (!connector) return res.status(503).json({ error: 'finance connector unavailable' });
       const orch = new FinanceOrchestrator(connector);
-      const autonomy = Number(req.headers['x-autonomy-level'] ?? 3);
+      const autonomySource =
+        (req as any).wb?.autonomyLevel ??
+        (req as any).wb?.autonomy ??
+        req.headers['x-autonomy-level'] ??
+        req.headers['x-autonomy'];
+      const autonomy = typeof autonomySource === 'number' ? autonomySource : Number(autonomySource ?? 0);
       const tenantId = String(req.headers['x-tenant-id'] ?? 'T1');
       const out = await orch.suggestReminder({ invoiceId, customerEmail }, { autonomy_level: autonomy as any, tenantId, role: 'finance' });
       res.json(out);

--- a/src/routes/manual.complete.ts
+++ b/src/routes/manual.complete.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { logIntent } from '../core/intentLog';
+import { policyGuardWrite } from '../core/policy/guard';
 
 export function manualCompleteRouter() {
   const r = Router();
-  r.post('/manual-complete', async (req: any, res, next) => {
+  r.post('/manual-complete', policyGuardWrite('manual'), async (req: any, res, next) => {
     try {
       const { capability, payload, note } = req.body || {};
       const tenantId = String(req.headers['x-tenant-id'] ?? 'T1');

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import { correlationHeader } from './middleware/correlationHeader';
 import { wbContext } from './middleware/wbContext';
 import { requestLogger } from './core/logging/logger';
-import { timingMiddleware } from './core/observability/metrics';
+import { timingMiddleware, metricsHandler } from './core/observability/metrics';
 import { errorHandler } from './core/http/middleware/errorHandler';
 import { debugBusHandler } from './routes/_debug.bus';
 import knowledgeRouter from './routes/knowledge.router';
@@ -51,6 +51,7 @@ function safeMount(path: string, modPath: string, factory?: string) {
 safeMount('/api/crm/contacts', './src/features/crm/routes', 'crmRouter');
 safeMount('/api/tasks', './src/features/tasks/routes', 'tasksRouter');
 safeMount('/api/logs', './src/features/log/routes', 'logRouter');
+safeMount('/api', './src/features/deals/deals.router');
 safeMount('/buoy', './src/routes/buoy.complete', 'buoyRouter');
 safeMount('/api/insights', './src/routes/insights', 'insightsRouter');
 safeMount('/api/finance', './src/routes/finance.reminder', 'financeReminderRouter');
@@ -59,7 +60,6 @@ safeMount('/', './src/routes/genesis.autonomy', 'metaGenesisRouter');
 safeMount('/api', '../backend/routes/proactivity');
 safeMount('/api', '../backend/routes/admin.subscription');
 safeMount('/api', '../backend/routes/explainability');
-safeMount('/', '../backend/routes/metrics');
 
 app.use('/api', knowledgeRouter);
 app.use('/api/audit', auditRouter());
@@ -72,6 +72,8 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Operability surfaces
+app.get('/metrics', metricsHandler);
+
 app.get('/status', async (_req, res) => {
   try {
     const stats = await bus.stats();

--- a/tests/deals.e2e.test.ts
+++ b/tests/deals.e2e.test.ts
@@ -1,9 +1,34 @@
 // tests/deals.e2e.test.ts
 import request from 'supertest';
 import app from '../src/server';
-describe('deals', ()=>{
-  it('lists without error', async ()=>{
+
+describe('deals', () => {
+  const headers = { 'x-autonomy-level': '2', 'x-role': 'ops' };
+
+  it('lists existing deals', async () => {
     const r = await request(app).get('/api/deals');
-    expect([200,404].includes(r.status)).toBe(true);
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.body)).toBe(true);
+  });
+
+  it('rejects writes without policy headers', async () => {
+    const r = await request(app)
+      .post('/api/deals')
+      .send({ contactId: 'deal-test-contact', value: 10, status: 'open' });
+    expect(r.status).toBe(400);
+    expect(r.body?.code).toBe('E_POLICY_HEADERS_MISSING');
+  });
+
+  it('allows writes with required policy headers', async () => {
+    const id = `deal-${Date.now()}`;
+    const create = await request(app)
+      .post('/api/deals')
+      .set(headers)
+      .send({ id, contactId: 'deal-test-contact', value: 42, status: 'open' });
+    expect(create.status).toBe(200);
+    expect(create.body?.id).toBe(id);
+
+    const cleanup = await request(app).delete(`/api/deals/${id}`).set(headers);
+    expect(cleanup.status).toBe(200);
   });
 });

--- a/tests/e2e/dealflow.test.ts
+++ b/tests/e2e/dealflow.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import app from '../../src/server';
 
 describe('deal → audit flow', () => {
-  const headers = { 'x-role':'owner', 'x-autonomy':'2' };
+  const headers = { 'x-role':'owner', 'x-autonomy-level':'2' };
   it('creates a deal and lists audit entries', async () => {
     // create contact (best-effort; tolerate 2xx/4xx if route differs)
     await request(app).post('/api/crm/contacts').send({ id:'c-e2e', name:'E2E' }).set(headers);

--- a/tests/e2e/finance.reminder.test.ts
+++ b/tests/e2e/finance.reminder.test.ts
@@ -6,6 +6,8 @@ describe('Finance Reminder suggest', () => {
   it('POST /api/finance/reminder/suggest returns draftEmail', async () => {
     const res = await request(app)
       .post('/api/finance/reminder/suggest')
+      .set('x-autonomy-level','2')
+      .set('x-role','ops')
       .set('content-type','application/json')
       .send({ invoiceId: 'INV-77' })
       .expect(200);
@@ -15,6 +17,8 @@ describe('Finance Reminder suggest', () => {
   it('POST /api/finance/reminder/suggest 400 when missing invoiceId', async () => {
     await request(app)
       .post('/api/finance/reminder/suggest')
+      .set('x-autonomy-level','2')
+      .set('x-role','ops')
       .set('content-type','application/json')
       .send({})
       .expect(400);

--- a/tests/e2e/manual.complete.test.ts
+++ b/tests/e2e/manual.complete.test.ts
@@ -5,6 +5,8 @@ describe('POST /api/manual-complete', () => {
   it('logs manual completion and returns ok', async () => {
     const res = await request(app)
       .post('/api/manual-complete')
+      .set('x-autonomy-level','2')
+      .set('x-role','ops')
       .set('content-type','application/json')
       .send({ capability: 'finance.invoice.send', payload: { invoiceId:'INV-9' }, outcome:{ marked:true } })
       .expect(200);

--- a/tests/finance/reminder.e2e.test.ts
+++ b/tests/finance/reminder.e2e.test.ts
@@ -19,6 +19,8 @@ describe('POST /api/finance/reminder/suggest', () => {
   it('returns a draftEmail', async () => {
     const res = await request(app)
       .post('/api/finance/reminder/suggest')
+      .set('x-autonomy-level','2')
+      .set('x-role','ops')
       .send({ invoiceId: 'INV-1', customerEmail: 'a@b.com' })
       .expect(200);
     expect(res.body?.outcome?.draftEmail).toMatch(/faktura INV-1/);

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -4,6 +4,11 @@ import app from '../src/server';
 describe('metrics', ()=>{
   it('returns prometheus text', async ()=>{
     const r = await request(app).get('/metrics');
-    expect([200,404].includes(r.status)).toBe(true);
+    expect(r.status).toBe(200);
+    expect(r.headers['content-type']).toMatch(/text\/plain/);
+    expect(r.text).toContain('eventbus_queue_high');
+    expect(r.text).toContain('eventbus_queue_med');
+    expect(r.text).toContain('eventbus_queue_low');
+    expect(r.text).toContain('eventbus_dlq_size');
   });
 });

--- a/tests/routes/manual.complete.test.ts
+++ b/tests/routes/manual.complete.test.ts
@@ -12,7 +12,12 @@ describe('POST /api/manual-complete', () => {
   app.use('/api', manualCompleteRouter());
 
   it('records manual completion and returns an id', async () => {
-    const r = await request(app).post('/api/manual-complete').send({ capability: 'finance.invoice.send', note: 'sent via phone' }).expect(200);
+    const r = await request(app)
+      .post('/api/manual-complete')
+      .set('x-autonomy-level', '2')
+      .set('x-role', 'ops')
+      .send({ capability: 'finance.invoice.send', note: 'sent via phone' })
+      .expect(200);
     expect(r.body?.ok).toBe(true);
     expect(r.body?.intentId).toBe('intent-1');
   });


### PR DESCRIPTION
## What
- Mount the real Prometheus metrics handler on `/metrics` so queue and DLQ gauges surface.
- Enforce the policy v2 write guard on finance reminder, manual complete, and deals routes.
- Wire the deals router into the server and adjust tests to exercise the guarded endpoints.

## Why
- Operators need the documented metrics to monitor bus health.
- Remaining write routes must respect autonomy headers to satisfy policy baselines.
- The UI expects `/api/deals`; mounting it ensures persistence-backed deals flow works end-to-end.

## Files touched
- `src/server.ts`, `src/routes/finance.reminder.ts`, `src/routes/manual.complete.ts`
- `src/features/deals/deals.router.ts`
- Jest suites under `tests/**` covering metrics, policy guards, finance reminder, manual complete, and deals flows

## Risk
- Medium: touches authentication/guard paths and operability surface; mitigated by targeted Jest coverage.

## Testing
- `npm test -- --coverage`
- `npm run typecheck --if-present || true`

## Smoke
```bash
curl -i -X POST http://localhost:3000/api/finance/reminder/suggest \
  -H 'content-type: application/json' \
  -d '{}' | head

curl -i -X POST http://localhost:3000/api/finance/reminder/suggest \
  -H 'x-autonomy-level: 2' -H 'x-role: ops' \
  -H 'content-type: application/json' \
  -d '{}' | head

curl -i -X POST http://localhost:3000/api/manual-complete \
  -H 'x-autonomy-level: 2' -H 'x-role: ops' \
  -H 'content-type: application/json' \
  -d '{}' | head

curl -s http://localhost:3000/metrics | (head -n 50 || cat) | sed -n '1,120p'

curl -s http://localhost:3000/api/deals | jq . || true
```

## Acceptance (DoD)
- [x] `/metrics` emits Prometheus text including `eventbus_queue_high`, `eventbus_queue_med`, `eventbus_queue_low`, and `eventbus_dlq_size`.
- [x] `/api/finance/reminder/suggest` and `/api/manual-complete` return 400 with `E_POLICY_HEADERS_MISSING` when autonomy headers are absent and 2xx with level 2 headers.
- [x] `/api/deals` is mounted; GET returns 2xx and write endpoints require policy headers.
- [x] Jest suite exercises the new guards and metrics; typecheck passes.

## Rollback
- Revert commit `Mount metrics handler, guard writes, and wire deals API` and redeploy; restore previous metrics stub if necessary.


------
https://chatgpt.com/codex/tasks/task_e_68cdd55a685c832aa74963c9db4a8f06