### PR TITLE
feat/meta: audit stats, metrics, security, quickstart (PR6–PR9)

### DIFF
--- a/META_ROUTE_README.md
+++ b/META_ROUTE_README.md
@@ -109,7 +109,7 @@ The META surface provides operational telemetry for WorkBuoy services. All route
 ## Running locally
 1. Start dependencies via `docker-compose -f docker-compose.meta.yml up -d`.
 2. Seed env vars (see compose file for examples of `MODE_CORE`, feature flags, etc.).
-3. Hit the endpoints using the curls above. Use `scripts/smoke-meta.sh` for a quick public probe check.
+3. Hit the endpoints using the curls above. Use `scripts/smoke-meta.sh` for a quick probe check (set `META_TOKEN` to include `/readiness`).
 
 ## Auth & rate limiting
 - Attach a bearer token whose claims include `meta:read` for protected routes. For local testing you can stub `req.user` via middleware.

--- a/grafana/dashboards/meta.json
+++ b/grafana/dashboards/meta.json
@@ -63,8 +63,8 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "targets": [
         {
-          "expr": "increase(audit_failures_total[5m])",
-          "legendFormat": "failures"
+          "expr": "rate(audit_failures_total[5m])",
+          "legendFormat": "rate"
         }
       ]
     },

--- a/scripts/smoke-meta.sh
+++ b/scripts/smoke-meta.sh
@@ -4,4 +4,10 @@ set -euo pipefail
 curl -fsS http://localhost:8080/api/meta/health >/dev/null
 curl -fsS http://localhost:8080/api/meta/version >/dev/null
 
+if [ -n "${META_TOKEN:-}" ]; then
+  curl -fsS -H "Authorization: Bearer ${META_TOKEN}" http://localhost:8080/api/meta/readiness >/dev/null
+else
+  printf 'META_TOKEN not set; skipping /api/meta/readiness (requires meta:read).\n'
+fi
+
 printf 'META smoke check passed.\n'

--- a/tests/meta/audit-stats.test.ts
+++ b/tests/meta/audit-stats.test.ts
@@ -1,5 +1,4 @@
-import express from 'express';
-import type { NextFunction, Request, Response, Router as ExpressRouter } from 'express';
+import express, { type NextFunction, type Request, type Response, type Router as ExpressRouter } from 'express';
 import request from 'supertest';
 import { createMetaRouter } from '../../backend/meta/router';
 import type { AuditRepo, AuditRepoEvent } from '../../backend/meta/auditStats';

--- a/tests/meta/metrics.test.ts
+++ b/tests/meta/metrics.test.ts
@@ -16,12 +16,18 @@ describe('META: /meta/metrics', () => {
   };
 
   it('returns Prometheus exposition text', async () => {
+    metricsModule.recordMetaRequestLatency('health', 'GET', 200, 12);
+    metricsModule.recordPolicyDenyMetric('policy', 'deny');
+    metricsModule.recordAuditFailures(1);
     const app = createApp();
     const res = await request(app).get('/api/meta/metrics');
 
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/text\/plain/);
     expect(res.text.trim().length).toBeGreaterThan(0);
+    expect(res.text).toContain('meta_request_latency_ms');
+    expect(res.text).toContain('policy_denies_total');
+    expect(res.text).toContain('audit_failures_total');
   });
 
   it('falls back to JSON location when exporter errors', async () => {


### PR DESCRIPTION
## Summary
- ensure metrics exposition tests cover histogram, policy denies, and audit counters
- update prom-client mock to emit synthetic metric names for assertions
- note META_TOKEN auth for readiness smoke checks and align Grafana audit failure panel with rate query

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce5e4e4364832a9271a2fd88e9761f