### PR TITLE
feat: wave 9-11 frontend UX updates

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,8 +18,9 @@
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.5.4",
     "vite": "^5.4.0",
-    "@vitejs/plugin-react": "^4.3.1"
+    "vitest": "^2.0.5"
   }
 }

--- a/frontend/src/components/MorphingInput.test.tsx
+++ b/frontend/src/components/MorphingInput.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import MorphingInput from "./MorphingInput";
+
+describe("MorphingInput", () => {
+  function setup(initial = "") {
+    const Wrapper = () => {
+      const [value, setValue] = React.useState(initial);
+      return (
+        <MorphingInput
+          value={value}
+          onChange={setValue}
+          id="morph"
+          contacts={[
+            { id: "1", name: "Ola Nordmann" },
+            { id: "2", name: "Kari Nordmann" },
+          ]}
+          strings={{ label: "Morph" }}
+        />
+      );
+    };
+    return render(<Wrapper />);
+  }
+
+  it("shows contact picker when name is entered", () => {
+    setup();
+    const input = screen.getByLabelText("Morph");
+    fireEvent.change(input, { target: { value: "Ola Nordmann" } });
+    expect(screen.getByText("Ola Nordmann")).toBeInTheDocument();
+  });
+
+  it("shows calculator when arithmetic expression entered", () => {
+    setup();
+    const input = screen.getByLabelText("Morph");
+    fireEvent.change(input, { target: { value: "2+2" } });
+    expect(screen.getByText(/Resultat 4/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/MorphingInput.tsx
+++ b/frontend/src/components/MorphingInput.tsx
@@ -1,0 +1,282 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { morphingInputStrings } from "./morphingInput/strings";
+
+type Contact = { id: string; name: string; email?: string };
+
+type MorphingInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  contacts?: Contact[];
+  onSelectContact?: (contact: Contact) => void;
+  placeholder?: string;
+  id?: string;
+  strings?: Partial<typeof morphingInputStrings>;
+  ariaLabel?: string;
+  hideLabel?: boolean;
+};
+
+type Token = { type: "number" | "operator" | "paren"; value: string };
+
+type Operator = {
+  precedence: number;
+  assoc: "left" | "right";
+  fn: (a: number, b: number) => number;
+};
+
+const operators: Record<string, Operator> = {
+  "+": { precedence: 1, assoc: "left", fn: (a, b) => a + b },
+  "-": { precedence: 1, assoc: "left", fn: (a, b) => a - b },
+  "*": { precedence: 2, assoc: "left", fn: (a, b) => a * b },
+  "/": { precedence: 2, assoc: "left", fn: (a, b) => a / b },
+};
+
+const defaultContacts: Contact[] = [
+  { id: "c1", name: "Ola Nordmann", email: "ola@example.com" },
+  { id: "c2", name: "Kari Nordmann", email: "kari@example.com" },
+  { id: "c3", name: "Per Hansen", email: "per@example.com" },
+];
+
+function tokenize(input: string): Token[] | null {
+  const tokens: Token[] = [];
+  let idx = 0;
+  while (idx < input.length) {
+    const ch = input[idx];
+    if (ch === " ") {
+      idx += 1;
+      continue;
+    }
+    if (/[0-9.]/.test(ch)) {
+      let number = ch;
+      idx += 1;
+      while (idx < input.length && /[0-9.]/.test(input[idx])) {
+        number += input[idx];
+        idx += 1;
+      }
+      if (number.split(".").length > 2) return null;
+      tokens.push({ type: "number", value: number });
+      continue;
+    }
+    if (operators[ch]) {
+      tokens.push({ type: "operator", value: ch });
+      idx += 1;
+      continue;
+    }
+    if (ch === "(" || ch === ")") {
+      tokens.push({ type: "paren", value: ch });
+      idx += 1;
+      continue;
+    }
+    return null;
+  }
+  return tokens;
+}
+
+function evaluateExpression(expression: string): number | null {
+  const tokens = tokenize(expression);
+  if (!tokens) return null;
+  const output: Token[] = [];
+  const stack: Token[] = [];
+  for (const token of tokens) {
+    if (token.type === "number") {
+      output.push(token);
+    } else if (token.type === "operator") {
+      const op1 = operators[token.value];
+      if (!op1) return null;
+      while (stack.length) {
+        const peek = stack[stack.length - 1];
+        if (peek.type === "operator") {
+          const op2 = operators[peek.value];
+          if (
+            op2 &&
+            ((op1.assoc === "left" && op1.precedence <= op2.precedence) ||
+              (op1.assoc === "right" && op1.precedence < op2.precedence))
+          ) {
+            output.push(stack.pop()!);
+            continue;
+          }
+        }
+        break;
+      }
+      stack.push(token);
+    } else if (token.type === "paren") {
+      if (token.value === "(") {
+        stack.push(token);
+      } else {
+        let found = false;
+        while (stack.length) {
+          const popped = stack.pop()!;
+          if (popped.type === "paren" && popped.value === "(") {
+            found = true;
+            break;
+          }
+          output.push(popped);
+        }
+        if (!found) return null;
+      }
+    }
+  }
+  while (stack.length) {
+    const popped = stack.pop()!;
+    if (popped.type === "paren") return null;
+    output.push(popped);
+  }
+
+  const evalStack: number[] = [];
+  for (const token of output) {
+    if (token.type === "number") {
+      evalStack.push(parseFloat(token.value));
+    } else if (token.type === "operator") {
+      const b = evalStack.pop();
+      const a = evalStack.pop();
+      if (a === undefined || b === undefined) return null;
+      const op = operators[token.value];
+      if (!op) return null;
+      const result = op.fn(a, b);
+      if (!Number.isFinite(result)) return null;
+      evalStack.push(result);
+    }
+  }
+  if (evalStack.length !== 1) return null;
+  return Number.parseFloat(evalStack[0].toFixed(4));
+}
+
+function looksLikeExpression(value: string) {
+  if (!value.trim()) return false;
+  return /^[0-9+\-*/().\s]+$/.test(value);
+}
+
+const namePattern = /^[a-zA-ZæøåÆØÅ]+\s+[a-zA-ZæøåÆØÅ\-\s]+$/u;
+
+export function MorphingInput({
+  value,
+  onChange,
+  contacts = defaultContacts,
+  onSelectContact,
+  placeholder,
+  id = "morphing-input",
+  strings = {},
+  ariaLabel,
+  hideLabel = false,
+}: MorphingInputProps) {
+  const mergedStrings = { ...morphingInputStrings, ...strings };
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+
+  const contactMatches = useMemo(() => {
+    const query = value.trim().toLowerCase();
+    if (!query || (!namePattern.test(value.trim()) && query.length < 2)) return [];
+    return contacts.filter((contact) => contact.name.toLowerCase().includes(query));
+  }, [contacts, value]);
+
+  const expressionResult = useMemo(() => {
+    if (!looksLikeExpression(value)) return null;
+    return evaluateExpression(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (contactMatches.length) {
+      setActiveIndex(0);
+    } else {
+      setActiveIndex(-1);
+    }
+  }, [contactMatches.length]);
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!contactMatches.length) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % contactMatches.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index - 1 + contactMatches.length) % contactMatches.length);
+    } else if (event.key === "Enter" && activeIndex >= 0) {
+      event.preventDefault();
+      const contact = contactMatches[activeIndex];
+      if (contact) {
+        onSelectContact?.(contact);
+        onChange(contact.name);
+      }
+    }
+  }
+
+  return (
+    <div className="grid gap-2" aria-live="polite">
+      <label
+        htmlFor={id}
+        className={hideLabel ? 'text-xs font-medium text-slate-300' : 'text-xs font-medium text-slate-300'}
+        style={hideLabel ? { position: 'absolute', clip: 'rect(0 0 0 0)', width: 1, height: 1, margin: -1, border: 0, padding: 0 } : undefined}
+      >
+        {mergedStrings.label}
+      </label>
+      <div
+        role="combobox"
+        aria-expanded={contactMatches.length > 0}
+        aria-owns={contactMatches.length ? `${id}-contacts` : undefined}
+        aria-haspopup="listbox"
+        className="relative"
+      >
+        <input
+          id={id}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          aria-autocomplete="list"
+          aria-controls={contactMatches.length ? `${id}-contacts` : undefined}
+          aria-activedescendant={
+            contactMatches.length && activeIndex >= 0 ? `${id}-option-${activeIndex}` : undefined
+          }
+          onKeyDown={handleKeyDown}
+          className="h-11 w-full rounded-md border border-slate-800 bg-slate-900/60 px-3 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        />
+        {contactMatches.length > 0 && (
+          <ul
+            id={`${id}-contacts`}
+            role="listbox"
+            className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-md border border-slate-800 bg-slate-900/95 text-sm shadow-lg"
+          >
+            <li className="px-3 py-2 text-xs uppercase tracking-wide text-slate-400">
+              {mergedStrings.contactPickerHeading}
+            </li>
+            {contactMatches.map((contact, index) => (
+              <li
+                key={contact.id}
+                id={`${id}-option-${index}`}
+                role="option"
+                aria-selected={activeIndex === index}
+                className={`flex items-center justify-between px-3 py-2 hover:bg-slate-800 ${
+                  activeIndex === index ? "bg-slate-800/80" : ""
+                }`}
+              >
+                <span>
+                  <span className="block font-medium text-slate-100">{contact.name}</span>
+                  {contact.email && <span className="text-xs text-slate-400">{contact.email}</span>}
+                </span>
+                <button
+                  type="button"
+                  className="rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-200 hover:bg-slate-800"
+                  onClick={() => {
+                    onSelectContact?.(contact);
+                    onChange(contact.name);
+                  }}
+                >
+                  {mergedStrings.selectContact}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      {expressionResult !== null && (
+        <div
+          className="rounded-md border border-indigo-500/60 bg-indigo-900/20 px-3 py-2 text-xs text-indigo-100"
+          aria-live="polite"
+        >
+          <div className="font-semibold">{mergedStrings.calculatorHeading}</div>
+          <div>{mergedStrings.resultLabel(expressionResult)}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MorphingInput;

--- a/frontend/src/components/UndoToast.tsx
+++ b/frontend/src/components/UndoToast.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef, useState } from "react";
+import { undoToastStrings } from "./undoToast/strings";
+
+type UndoToastStatus = "idle" | "pending" | "success" | "error";
+
+type UndoToastProps = {
+  open: boolean;
+  title: string;
+  description?: string;
+  canUndo?: boolean;
+  onUndo?: () => Promise<boolean> | boolean;
+  onClose?: () => void;
+  strings?: Partial<typeof undoToastStrings>;
+};
+
+export function UndoToast({
+  open,
+  title,
+  description,
+  canUndo = false,
+  onUndo,
+  onClose,
+  strings = {},
+}: UndoToastProps) {
+  const mergedStrings = { ...undoToastStrings, ...strings };
+  const [status, setStatus] = useState<UndoToastStatus>("idle");
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const undoButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setStatus("idle");
+      const timer = window.setTimeout(() => {
+        undoButtonRef.current?.focus({ preventScroll: true });
+      }, 40);
+      const onKey = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          onClose?.();
+        }
+      };
+      document.addEventListener("keydown", onKey);
+      return () => {
+        window.clearTimeout(timer);
+        document.removeEventListener("keydown", onKey);
+      };
+    }
+    return;
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const observer = new MutationObserver(() => {
+      containerRef.current?.setAttribute("aria-live", "assertive");
+    });
+    if (containerRef.current) observer.observe(containerRef.current, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [open]);
+
+  if (!open) return null;
+
+  const actionLabel =
+    status === "pending"
+      ? mergedStrings.undoing
+      : status === "success"
+      ? mergedStrings.success
+      : canUndo
+      ? mergedStrings.undo
+      : mergedStrings.cannotUndo;
+
+  async function handleUndo() {
+    if (!canUndo || !onUndo) {
+      setStatus("error");
+      return;
+    }
+    try {
+      setStatus("pending");
+      const result = await onUndo();
+      setStatus(result ? "success" : "error");
+      if (result) {
+        window.setTimeout(() => {
+          onClose?.();
+        }, 1200);
+      }
+    } catch (error) {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="status"
+      aria-live="assertive"
+      className="fixed inset-x-0 bottom-6 z-[100] flex justify-center px-4"
+    >
+      <div className="w-full max-w-md rounded-lg border border-slate-800 bg-slate-900/95 p-4 shadow-xl">
+        <div className="flex items-start gap-3">
+          <div className="flex-1 text-sm text-slate-100">
+            <strong className="block text-sm font-semibold text-white">{title}</strong>
+            {description && <p className="mt-1 text-xs text-slate-300">{description}</p>}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              ref={undoButtonRef}
+              type="button"
+              className="inline-flex min-w-[80px] justify-center rounded-md border border-indigo-500 px-3 py-1 text-xs font-medium text-indigo-100 hover:bg-indigo-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={handleUndo}
+              disabled={status === "pending" || status === "success"}
+              aria-busy={status === "pending"}
+            >
+              {actionLabel}
+            </button>
+            <button
+              type="button"
+              className="rounded-md px-2 py-1 text-xs text-slate-300 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+              onClick={() => onClose?.()}
+            >
+              {mergedStrings.dismiss}
+            </button>
+          </div>
+        </div>
+        {!canUndo && status === "error" && (
+          <p className="mt-2 text-xs text-red-300" role="alert">
+            {mergedStrings.cannotUndo}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default UndoToast;

--- a/frontend/src/components/morphingInput/strings.ts
+++ b/frontend/src/components/morphingInput/strings.ts
@@ -1,0 +1,8 @@
+export const morphingInputStrings = {
+  label: "Skriv kommando eller navn",
+  contactPickerHeading: "Forslag fra kontakter",
+  calculatorHeading: "Kalkulator",
+  resultLabel: (result: number) => `Resultat ${result}`,
+  selectContact: "Velg",
+};
+export type MorphingInputStrings = typeof morphingInputStrings;

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+type ButtonVariant = "default" | "outline" | "ghost" | "secondary";
+type ButtonSize = "default" | "sm" | "lg";
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+const baseClass = "inline-flex items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none transition";
+const variants: Record<ButtonVariant, string> = {
+  default: "bg-indigo-600 text-white hover:bg-indigo-500",
+  outline: "border-slate-500 text-slate-100 hover:bg-slate-800",
+  ghost: "bg-transparent text-slate-100 hover:bg-slate-800/60",
+  secondary: "bg-slate-700 text-white hover:bg-slate-600",
+};
+const sizes: Record<ButtonSize, string> = {
+  default: "h-10",
+  sm: "h-8 text-xs px-2",
+  lg: "h-12 text-base px-5",
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = "", variant = "default", size = "default", type = "button", ...props }, ref) => {
+    const classes = [baseClass, variants[variant] ?? variants.default, sizes[size] ?? sizes.default, className]
+      .filter(Boolean)
+      .join(" ");
+    return <button ref={ref} type={type} className={classes} {...props} />;
+  }
+);
+Button.displayName = "Button";
+
+export default Button;

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+type CardProps = React.HTMLAttributes<HTMLDivElement>;
+
+type CardSectionProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className = "", ...props }, ref) => {
+  const classes = [
+    "rounded-xl border border-slate-800 bg-slate-900/60 text-slate-100 shadow-sm backdrop-blur",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return <div ref={ref} className={classes} {...props} />;
+});
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<HTMLDivElement, CardSectionProps>(({ className = "", ...props }, ref) => {
+  const classes = ["flex flex-col space-y-1.5 p-6", className].filter(Boolean).join(" ");
+  return <div ref={ref} className={classes} {...props} />;
+});
+CardHeader.displayName = "CardHeader";
+
+export const CardContent = React.forwardRef<HTMLDivElement, CardSectionProps>(({ className = "", ...props }, ref) => {
+  const classes = ["p-6 pt-0", className].filter(Boolean).join(" ");
+  return <div ref={ref} className={classes} {...props} />;
+});
+CardContent.displayName = "CardContent";
+
+export const CardFooter = React.forwardRef<HTMLDivElement, CardSectionProps>(({ className = "", ...props }, ref) => {
+  const classes = ["flex items-center p-6 pt-0", className].filter(Boolean).join(" ");
+  return <div ref={ref} className={classes} {...props} />;
+});
+CardFooter.displayName = "CardFooter";
+
+export default Card;

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useContext, useEffect, useMemo, useRef } from "react";
+
+type DialogContextValue = {
+  open: boolean;
+  setOpen: (value: boolean) => void;
+};
+
+const DialogContext = React.createContext<DialogContextValue | null>(null);
+
+type DialogProps = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (value: boolean) => void;
+  children: React.ReactNode;
+};
+
+export function Dialog({ open, defaultOpen = false, onOpenChange, children }: DialogProps) {
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+  const isControlled = typeof open === "boolean";
+  const currentOpen = isControlled ? open : internalOpen;
+
+  const setOpen = useCallback(
+    (value: boolean) => {
+      if (!isControlled) {
+        setInternalOpen(value);
+      }
+      onOpenChange?.(value);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const contextValue = useMemo(() => ({ open: !!currentOpen, setOpen }), [currentOpen, setOpen]);
+
+  return <DialogContext.Provider value={contextValue}>{children}</DialogContext.Provider>;
+}
+
+type DialogTriggerProps = {
+  children: React.ReactElement;
+};
+
+export const DialogTrigger = React.forwardRef<HTMLElement, DialogTriggerProps>(({ children }, ref) => {
+  const ctx = useContext(DialogContext);
+  if (!ctx) throw new Error("DialogTrigger must be used within a Dialog");
+  return React.cloneElement(children, {
+    ref,
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      children.props.onClick?.(event);
+      if (!event.defaultPrevented) ctx.setOpen(true);
+    },
+  });
+});
+DialogTrigger.displayName = "DialogTrigger";
+
+type DialogContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  children: React.ReactNode;
+};
+
+export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
+  ({ className = "", children, ...props }, ref) => {
+    const ctx = useContext(DialogContext);
+    const contentRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+      if (ctx?.open) {
+        const onKey = (event: KeyboardEvent) => {
+          if (event.key === "Escape") {
+            event.stopPropagation();
+            ctx.setOpen(false);
+          }
+        };
+        document.addEventListener("keydown", onKey);
+        const el = contentRef.current;
+        const previouslyFocused = document.activeElement as HTMLElement | null;
+        const focusTarget = el?.querySelector<HTMLElement>(
+          "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])"
+        );
+        focusTarget?.focus();
+        return () => {
+          document.removeEventListener("keydown", onKey);
+          previouslyFocused?.focus?.();
+        };
+      }
+      return;
+    }, [ctx?.open, ctx]);
+
+    if (!ctx?.open) return null;
+
+    const classes = [
+      "fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6",
+    ].join(" ");
+    const panelClass = [
+      "w-full max-w-lg rounded-xl border border-slate-800 bg-slate-900/95 p-6 text-slate-100 shadow-xl",
+      className,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <div className={classes} aria-modal="true" role="dialog" {...props}>
+        <div
+          ref={(node) => {
+            contentRef.current = node;
+            if (typeof ref === "function") ref(node);
+            else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+          }}
+          className={panelClass}
+        >
+          {children}
+        </div>
+      </div>
+    );
+  }
+);
+DialogContent.displayName = "DialogContent";
+
+export default Dialog;

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from "react";
+
+type DrawerProps = {
+  open: boolean;
+  onOpenChange?: (value: boolean) => void;
+  children: React.ReactNode;
+  title?: string;
+};
+
+export function Drawer({ open, onOpenChange, children }: DrawerProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onOpenChange?.(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-x-0 bottom-0 z-50 flex justify-center bg-black/60 p-4"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onOpenChange?.(false);
+      }}
+    >
+      <div className="w-full max-w-2xl rounded-t-2xl border border-slate-800 bg-slate-900/95 p-6 text-slate-100 shadow-xl">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default Drawer;

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className = "", type = "text", ...props }, ref) => {
+  const classes = [
+    "flex h-10 w-full rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return <input ref={ref} type={type} className={classes} {...props} />;
+});
+Input.displayName = "Input";
+
+export default Input;

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+type SelectContextValue = {
+  onValueChange?: (value: string) => void;
+};
+
+const SelectContext = React.createContext<SelectContextValue | null>(null);
+
+type SelectProps = {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  children: React.ReactNode;
+  name?: string;
+  disabled?: boolean;
+  "aria-label"?: string;
+};
+
+export function Select({ value, defaultValue, onValueChange, children, name, disabled, ...rest }: SelectProps) {
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(defaultValue ?? "");
+  const currentValue = isControlled ? value! : internal;
+
+  const handleChange = (next: string) => {
+    if (!isControlled) setInternal(next);
+    onValueChange?.(next);
+  };
+
+  return (
+    <SelectContext.Provider value={{ onValueChange: handleChange }}>
+      <select
+        {...rest}
+        name={name}
+        value={currentValue}
+        disabled={disabled}
+        onChange={(event) => handleChange(event.target.value)}
+        className="h-10 rounded-md border border-slate-800 bg-slate-900/60 px-3 text-sm text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      >
+        {children}
+      </select>
+    </SelectContext.Provider>
+  );
+}
+
+type SelectItemProps = {
+  value: string;
+  children: React.ReactNode;
+};
+
+export function SelectItem({ value, children }: SelectItemProps) {
+  return <option value={value}>{children}</option>;
+}
+
+export default Select;

--- a/frontend/src/components/undoToast/strings.ts
+++ b/frontend/src/components/undoToast/strings.ts
@@ -1,0 +1,8 @@
+export const undoToastStrings = {
+  undo: "Angre",
+  dismiss: "Lukk",
+  cannotUndo: "Kan ikke angre",
+  undoing: "Angrer…",
+  success: "Handling angret",
+};
+export type UndoToastStrings = typeof undoToastStrings;

--- a/frontend/src/features/addons/AddonsStore.ts
+++ b/frontend/src/features/addons/AddonsStore.ts
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useState } from "react";
+import { apiFetch } from "@/api";
+
+export type AddonManifestEntry = {
+  id: string;
+  name: string;
+  icon?: string;
+  category: string;
+  enabled: boolean;
+  description?: string;
+};
+
+export type UseAddonsStoreResult = {
+  addons: AddonManifestEntry[];
+  loading: boolean;
+  error: Error | null;
+  toggle: (id: string, value?: boolean) => void;
+};
+
+export function useAddonsStore(): UseAddonsStoreResult {
+  const [manifest, setManifest] = useState<AddonManifestEntry[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [localEnabled, setLocalEnabled] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    apiFetch<AddonManifestEntry[]>("/api/addons")
+      .then((entries) => {
+        if (!active) return;
+        setManifest(entries);
+        const map: Record<string, boolean> = {};
+        entries.forEach((entry) => {
+          map[entry.id] = entry.enabled !== false;
+        });
+        setLocalEnabled(map);
+        setError(null);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const addons = useMemo(
+    () =>
+      manifest.map((entry) => ({
+        ...entry,
+        enabled: localEnabled[entry.id] ?? entry.enabled,
+      })),
+    [manifest, localEnabled]
+  );
+
+  function toggle(id: string, value?: boolean) {
+    setLocalEnabled((prev) => {
+      const current = prev[id] ?? true;
+      const next = typeof value === "boolean" ? value : !current;
+      return {
+        ...prev,
+        [id]: next,
+      };
+    });
+  }
+
+  return { addons, loading, error, toggle };
+}
+
+export function getEnabledAddons(addons: AddonManifestEntry[]): AddonManifestEntry[] {
+  return addons.filter((addon) => addon.enabled);
+}

--- a/frontend/src/features/buoy/BuoyChat.tsx
+++ b/frontend/src/features/buoy/BuoyChat.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from "react";
 import { useBuoy } from "./useBuoy";
 import WhyDrawer from "./WhyDrawer";
 import type { UserMessage, AssistantMessage } from "./types";
+import MorphingInput from "@/components/MorphingInput";
+import { buoyStrings as strings } from "./strings";
 export default function BuoyChat() {
   const { messages, send } = useBuoy();
   const [input, setInput] = useState("");
@@ -11,27 +13,38 @@ export default function BuoyChat() {
     e.preventDefault(); if (!input.trim()) return; send(input.trim()); setInput("");
   }
   return (
-    <div role="region" aria-label="Buoy chat" aria-live="polite" style={{display:"grid", gridTemplateRows:"1fr auto", height:"100%"}}>
+    <div role="region" aria-label={strings.regionLabel} aria-live="polite" style={{display:"grid", gridTemplateRows:"1fr auto", height:"100%"}}>
       <div style={{overflow:"auto", padding:16}}>
         {messages.map(m => <ChatMessage key={m.id} msg={m} />)}
         <div ref={endRef}/>
       </div>
       <form onSubmit={handleSend} style={{display:"grid",gridTemplateColumns:"1fr auto",gap:8,padding:8}}>
-        <input value={input} onChange={e=>setInput(e.target.value)} placeholder="Skriv en handling…"
-               style={{padding:"10px 12px", borderRadius:8, border:"1px solid rgba(255,255,255,.14)", background:"transparent", color:"var(--ink)"}} />
-        <button className="chip">Send</button>
+        <MorphingInput
+          value={input}
+          onChange={setInput}
+          placeholder={strings.inputPlaceholder}
+          id="buoy-input"
+          ariaLabel="buoy-input"
+          hideLabel
+          strings={{
+            label: "buoy-input",
+            contactPickerHeading: strings.contactPickerHeading,
+            calculatorHeading: strings.calculatorHeading,
+          }}
+        />
+        <button className="chip">{strings.send}</button>
       </form>
     </div>
   );
 }
 function ChatMessage({ msg }:{ msg: UserMessage|AssistantMessage }){
   if (msg.role==="user") {
-    return <div style={{margin:"4px 0"}}><span className="chip" style={{marginRight:8}}>Du</span>{msg.text}</div>;
+    return <div style={{margin:"4px 0"}}><span className="chip" style={{marginRight:8}}>{strings.userLabel}</span>{msg.text}</div>;
   }
   const a = msg as AssistantMessage;
   return (
     <div style={{margin:"10px 0", padding:10, border:"1px solid rgba(255,255,255,.1)", borderRadius:10}}>
-      <div style={{marginBottom:6}}><span className="chip" style={{marginRight:8}}>Buoy</span>{a.text}</div>
+      <div style={{marginBottom:6}}><span className="chip" style={{marginRight:8}}>{strings.assistantLabel}</span>{a.text}</div>
       {a.actions?.length ? (
         <div style={{display:"flex", gap:8, flexWrap:"wrap"}}>
           {a.actions.map(act=><button key={act.id} className="chip">{act.label}</button>)}

--- a/frontend/src/features/buoy/strings.ts
+++ b/frontend/src/features/buoy/strings.ts
@@ -1,0 +1,10 @@
+export const buoyStrings = {
+  inputPlaceholder: "Skriv en handling…",
+  send: "Send",
+  regionLabel: "Buoy chat",
+  userLabel: "Du",
+  assistantLabel: "Buoy",
+  contactPickerHeading: "Forslag",
+  calculatorHeading: "Kalkulator",
+};
+export type BuoyStrings = typeof buoyStrings;

--- a/frontend/src/features/crm/ContactsPanel.test.tsx
+++ b/frontend/src/features/crm/ContactsPanel.test.tsx
@@ -1,18 +1,46 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { ContactsPanel } from './ContactsPanel';
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+import { ContactsPanel } from "./ContactsPanel";
 
-jest.mock('@/api', ()=>({
-  apiFetch: jest.fn(async ()=>[ {id:'1', name:'A', email:'a@test', phone:'123'} ])
+const apiFetch = vi.fn();
+
+vi.mock("@/api", () => ({
+  apiFetch: (...args: any[]) => apiFetch(...args),
 }));
 
-it('renders contacts list', async ()=>{
-  render(<ContactsPanel/>);
-  expect(await screen.findByText('A')).toBeInTheDocument();
+beforeEach(() => {
+  apiFetch.mockReset();
 });
 
-it('calls onClose when close button clicked', async ()=>{
-  const handleClose = jest.fn();
-  render(<ContactsPanel onClose={handleClose}/>);
-  fireEvent.click(await screen.findByRole('button', { name: /close/i }));
-  expect(handleClose).toHaveBeenCalled();
+test("shows undo toast after creating contact and performs undo", async () => {
+  apiFetch.mockImplementation((path: string, opts?: RequestInit) => {
+    if (path === "/api/crm/contacts" && !opts) {
+      return Promise.resolve([]);
+    }
+    if (path === "/api/crm/contacts" && opts?.method === "POST") {
+      return Promise.resolve({ id: "c1", name: "Test", email: "test@example.com", undoToken: "undo-1" });
+    }
+    if (path === "/core/undo") {
+      return Promise.resolve({});
+    }
+    if (path === "/api/crm/contacts" && opts?.method === "DELETE") {
+      return Promise.resolve({ undoToken: "undo-2" });
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<ContactsPanel />);
+
+  fireEvent.click(await screen.findByText("Legg til kontakt"));
+  fireEvent.change(screen.getByPlaceholderText("Navn"), { target: { value: "Test" } });
+  fireEvent.click(screen.getByText("Lagre"));
+
+  await waitFor(() => screen.getByText(/Kontakt Test ble opprettet/));
+
+  fireEvent.click(screen.getByText("Angre"));
+
+  await waitFor(() => {
+    expect(apiFetch).toHaveBeenCalledWith("/core/undo", expect.any(Object));
+  });
 });

--- a/frontend/src/features/crm/ContactsPanel.tsx
+++ b/frontend/src/features/crm/ContactsPanel.tsx
@@ -1,66 +1,247 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { apiFetch } from "@/api";
+import UndoToast from "@/components/UndoToast";
+import { contactsStrings as strings } from "./strings";
+import TemporalLayer from "@/features/time/TemporalLayer";
+import { audioCue } from "@/features/peripheral/AudioCue";
 
-type FormState = { id:string; name:string; email:string; phone:string };
+type FormState = { id: string; name: string; email: string; phone: string };
+type Contact = { id: string; name: string; email?: string; phone?: string; createdAt?: string };
+
+type UndoInfo = {
+  message: string;
+  token?: string;
+  applyLocalUndo?: () => void;
+};
+
+const initialForm: FormState = { id: "", name: "", email: "", phone: "" };
 
 export type ContactsPanelProps = {
   onClose?: () => void;
 };
 
 export function ContactsPanel({ onClose }: ContactsPanelProps = {}) {
-  const [contacts, setContacts] = useState<any[]>([]);
+  const [contacts, setContacts] = useState<Contact[]>([]);
   const [open, setOpen] = useState(false);
-  const [form, setForm] = useState<FormState>({ id:"", name:"", email:"", phone:"" });
+  const [form, setForm] = useState<FormState>(initialForm);
+  const [saving, setSaving] = useState(false);
+  const [undoInfo, setUndoInfo] = useState<UndoInfo | null>(null);
+  const [toastOpen, setToastOpen] = useState(false);
+  const [showTemporal, setShowTemporal] = useState(false);
 
   async function load() {
-    const res = await apiFetch<any[]>('/api/crm/contacts');
+    const res = await apiFetch<Contact[]>('/api/crm/contacts');
     setContacts(res);
   }
-  useEffect(()=>{ load(); }, []);
+
+  useEffect(() => {
+    load().catch(() => setContacts([]));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   async function save() {
-    await apiFetch('/api/crm/contacts', { method:'POST', body: JSON.stringify(form) });
-    setOpen(false);
-    setForm({ id:"", name:"", email:"", phone:"" });
-    load();
+    if (!form.name.trim()) return;
+    setSaving(true);
+    try {
+      const created = await apiFetch<Contact & { undoToken?: string }>(
+        '/api/crm/contacts',
+        { method: 'POST', body: JSON.stringify(form) }
+      );
+      setContacts(current => [created, ...current]);
+      audioCue.play('success');
+      setUndoInfo({
+        message: strings.toast.created(created.name),
+        token: created.undoToken,
+        applyLocalUndo: () => setContacts(current => current.filter(c => c.id !== created.id)),
+      });
+      setToastOpen(true);
+      setOpen(false);
+      setForm(initialForm);
+    } catch (error) {
+      audioCue.play('error');
+      setUndoInfo({ message: strings.toast.cannotUndo });
+      setToastOpen(true);
+    } finally {
+      setSaving(false);
+    }
   }
+
+  async function remove(contact: Contact) {
+    try {
+      const result = await apiFetch<{ undoToken?: string; restored?: Contact }>('/api/crm/contacts', {
+        method: 'DELETE',
+        body: JSON.stringify({ id: contact.id }),
+      });
+      setContacts(current => current.filter(c => c.id !== contact.id));
+      audioCue.play('success');
+      setUndoInfo({
+        message: strings.toast.deleted(contact.name || contact.id),
+        token: result?.undoToken,
+        applyLocalUndo: () => setContacts(current => [contact, ...current]),
+      });
+      setToastOpen(true);
+    } catch (error) {
+      audioCue.play('error');
+      setUndoInfo({ message: strings.toast.cannotUndo });
+      setToastOpen(true);
+    }
+  }
+
+  async function performUndo() {
+    if (!undoInfo?.token) {
+      return false;
+    }
+    try {
+      await apiFetch('/core/undo', {
+        method: 'POST',
+        body: JSON.stringify({ token: undoInfo.token }),
+      });
+      undoInfo.applyLocalUndo?.();
+      await load();
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  const temporalItems = useMemo(() =>
+    contacts.map((contact) => {
+      const created = contact.createdAt || new Date().toISOString();
+      const createdDate = new Date(created);
+      const diff = createdDate.getTime() - Date.now();
+      let state: 'past' | 'now' | 'future' = 'now';
+      if (diff < -86400000) state = 'past';
+      else if (diff > 86400000) state = 'future';
+      return {
+        id: contact.id,
+        title: contact.name || contact.id,
+        start: created,
+        state,
+      };
+    }),
+  [contacts]);
 
   return (
     <Card className="m-2">
       <CardContent>
-        <div className="flex justify-between items-center mb-2">
-          <h2 className="text-xl font-bold">Contacts</h2>
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h2 className="text-xl font-bold text-slate-100">{strings.title}</h2>
           <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowTemporal(true)}
+              aria-pressed={showTemporal}
+            >
+              {strings.overlayToggle}
+            </Button>
             {onClose && (
-              <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close contacts panel">
-                Close
+              <Button variant="ghost" size="sm" onClick={onClose} aria-label={strings.close}>
+                {strings.close}
               </Button>
             )}
-            <Dialog open={open} onOpenChange={(value)=>{ setOpen(value); }}>
-              <DialogTrigger asChild>
-                <Button>Add Contact</Button>
+            <Dialog open={open} onOpenChange={setOpen}>
+              <DialogTrigger>
+                <Button>{strings.addContact}</Button>
               </DialogTrigger>
               <DialogContent>
-                <Input placeholder="id" value={form.id} onChange={e=>setForm({...form,id:e.target.value})}/>
-                <Input placeholder="name" value={form.name} onChange={e=>setForm({...form,name:e.target.value})}/>
-                <Input placeholder="email" value={form.email} onChange={e=>setForm({...form,email:e.target.value})}/>
-                <Input placeholder="phone" value={form.phone} onChange={e=>setForm({...form,phone:e.target.value})}/>
-                <Button onClick={save}>Save</Button>
+                <div className="grid gap-3" role="form" aria-label={strings.addContact}>
+                  <Input
+                    placeholder={strings.idPlaceholder}
+                    value={form.id}
+                    onChange={(e) => setForm({ ...form, id: e.target.value })}
+                  />
+                  <Input
+                    placeholder={strings.namePlaceholder}
+                    value={form.name}
+                    onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  />
+                  <Input
+                    placeholder={strings.emailPlaceholder}
+                    type="email"
+                    value={form.email}
+                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                  />
+                  <Input
+                    placeholder={strings.phonePlaceholder}
+                    value={form.phone}
+                    onChange={(e) => setForm({ ...form, phone: e.target.value })}
+                  />
+                  <Button onClick={save} disabled={saving} aria-busy={saving}>
+                    {saving ? strings.saving : strings.save}
+                  </Button>
+                </div>
               </DialogContent>
             </Dialog>
           </div>
         </div>
-        <table className="w-full">
-          <thead><tr><th>ID</th><th>Name</th><th>Email</th><th>Phone</th></tr></thead>
-          <tbody>
-            {contacts.map(c=>(<tr key={c.id}><td>{c.id}</td><td>{c.name}</td><td>{c.email}</td><td>{c.phone}</td></tr>))}
-          </tbody>
-        </table>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800 text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="px-2 py-2">{strings.tableHeadings.id}</th>
+                <th className="px-2 py-2">{strings.tableHeadings.name}</th>
+                <th className="px-2 py-2">{strings.tableHeadings.email}</th>
+                <th className="px-2 py-2">{strings.tableHeadings.phone}</th>
+                <th className="px-2 py-2">{strings.tableHeadings.actions}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-900">
+              {contacts.map((contact) => (
+                <tr key={contact.id}>
+                  <td className="px-2 py-2 font-mono text-xs text-slate-400">{contact.id}</td>
+                  <td className="px-2 py-2">{contact.name}</td>
+                  <td className="px-2 py-2 text-slate-300">{contact.email}</td>
+                  <td className="px-2 py-2 text-slate-300">{contact.phone}</td>
+                  <td className="px-2 py-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => remove(contact)}
+                      aria-label={`${strings.delete} ${contact.name}`}
+                    >
+                      {strings.delete}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </CardContent>
+      {showTemporal && (
+        <TemporalLayer
+          items={temporalItems}
+          onClose={() => setShowTemporal(false)}
+          anchorLabel={strings.title}
+        />
+      )}
+      <UndoToast
+        open={toastOpen && !!undoInfo}
+        title={undoInfo?.message || ''}
+        description={!undoInfo?.token ? strings.toast.cannotUndo : undefined}
+        canUndo={!!undoInfo?.token}
+        onUndo={performUndo}
+        onClose={() => {
+          setToastOpen(false);
+          setUndoInfo(null);
+        }}
+      />
     </Card>
   );
 }

--- a/frontend/src/features/crm/strings.ts
+++ b/frontend/src/features/crm/strings.ts
@@ -1,0 +1,26 @@
+export const contactsStrings = {
+  title: "Kontakter",
+  addContact: "Legg til kontakt",
+  idPlaceholder: "ID",
+  namePlaceholder: "Navn",
+  emailPlaceholder: "E-post",
+  phonePlaceholder: "Telefon",
+  save: "Lagre",
+  saving: "Lagrer…",
+  close: "Lukk",
+  tableHeadings: {
+    id: "ID",
+    name: "Navn",
+    email: "E-post",
+    phone: "Telefon",
+    actions: "Handlinger",
+  },
+  delete: "Slett",
+  toast: {
+    created: (name: string) => `Kontakt ${name} ble opprettet`,
+    deleted: (name: string) => `Kontakt ${name} ble slettet`,
+    cannotUndo: "Kan ikke angre for denne handlingen",
+  },
+  overlayToggle: "Tidslag",
+};
+export type ContactsStrings = typeof contactsStrings;

--- a/frontend/src/features/deals/DealsPanel.test.tsx
+++ b/frontend/src/features/deals/DealsPanel.test.tsx
@@ -1,11 +1,42 @@
-import { render, screen } from '@testing-library/react';
-import { DealsPanel } from './DealsPanel';
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+import { DealsPanel } from "./DealsPanel";
 
-jest.mock('@/api', ()=>({
-  apiFetch: jest.fn(async ()=>[ {id:'d1', contactId:'c1', value:100, status:'open'} ])
+const apiFetch = vi.fn();
+
+vi.mock("@/api", () => ({
+  apiFetch: (...args: any[]) => apiFetch(...args),
 }));
 
-it('renders deals list', async ()=>{
-  render(<DealsPanel/>);
-  expect(await screen.findByText('d1')).toBeInTheDocument();
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
+test("updates deal status and allows undo", async () => {
+  apiFetch.mockImplementation((path: string, opts?: RequestInit) => {
+    if (path === "/api/deals" && !opts) {
+      return Promise.resolve([{ id: "d1", contactId: "c1", value: 100, status: "open" }]);
+    }
+    if (path === "/api/deals" && opts?.method === "POST") {
+      return Promise.resolve({ undoToken: "undo-deal" });
+    }
+    if (path === "/core/undo") {
+      return Promise.resolve({});
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<DealsPanel />);
+
+  const select = await screen.findByLabelText("Status");
+  fireEvent.change(select, { target: { value: "won" } });
+
+  await waitFor(() => screen.getByText(/Avtale d1 satt til won/));
+
+  fireEvent.click(screen.getByText("Angre"));
+
+  await waitFor(() => {
+    expect(apiFetch).toHaveBeenCalledWith("/core/undo", expect.any(Object));
+  });
 });

--- a/frontend/src/features/deals/DealsPanel.tsx
+++ b/frontend/src/features/deals/DealsPanel.tsx
@@ -1,44 +1,140 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectItem } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
 import { apiFetch } from "@/api";
+import UndoToast from "@/components/UndoToast";
+import TemporalLayer from "@/features/time/TemporalLayer";
+import { dealsStrings as strings } from "./strings";
+import { audioCue } from "@/features/peripheral/AudioCue";
+
+type Deal = {
+  id: string;
+  contactId?: string;
+  value?: number;
+  status: string;
+  updatedAt?: string;
+};
+
+type UndoInfo = {
+  message: string;
+  token?: string;
+  applyLocalUndo?: () => void;
+};
 
 export function DealsPanel() {
-  const [deals, setDeals] = useState<any[]>([]);
+  const [deals, setDeals] = useState<Deal[]>([]);
+  const [undoInfo, setUndoInfo] = useState<UndoInfo | null>(null);
+  const [toastOpen, setToastOpen] = useState(false);
+  const [showTemporal, setShowTemporal] = useState(false);
 
   async function load() {
-    const res = await apiFetch<any[]>('/api/deals');
+    const res = await apiFetch<Deal[]>('/api/deals');
     setDeals(res);
   }
-  useEffect(()=>{ load(); }, []);
+  useEffect(()=>{ load().catch(()=>setDeals([])); }, []);
 
   async function updateStatus(id:string, status:string) {
-    await apiFetch('/api/deals', { method:'POST', body: JSON.stringify({ id, status }) });
-    load();
+    const previous = deals.find(d => d.id === id)?.status;
+    try {
+      const result = await apiFetch<{ undoToken?: string }>('/api/deals', { method:'POST', body: JSON.stringify({ id, status }) });
+      setDeals(current => current.map(d => d.id === id ? { ...d, status, updatedAt: new Date().toISOString() } : d));
+      setUndoInfo({
+        message: strings.toast.statusChanged(id, status),
+        token: result?.undoToken,
+        applyLocalUndo: previous ? () => setDeals(current => current.map(d => d.id === id ? { ...d, status: previous } : d)) : undefined,
+      });
+      setToastOpen(true);
+      audioCue.play('success');
+    } catch (error) {
+      setUndoInfo({ message: strings.toast.statusChanged(id, status) });
+      setToastOpen(true);
+      audioCue.play('error');
+    }
   }
+
+  async function performUndo() {
+    if (!undoInfo?.token) return false;
+    try {
+      await apiFetch('/core/undo', { method: 'POST', body: JSON.stringify({ token: undoInfo.token }) });
+      undoInfo.applyLocalUndo?.();
+      await load();
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  const temporalItems = useMemo(() =>
+    deals.map((deal) => {
+      const updated = deal.updatedAt || new Date().toISOString();
+      let state: 'past' | 'now' | 'future' = 'now';
+      if (deal.status === 'won') state = 'past';
+      if (deal.status === 'open') state = 'future';
+      return {
+        id: deal.id,
+        title: `${deal.contactId || deal.id}`,
+        start: updated,
+        state,
+      };
+    }),
+  [deals]);
 
   return (
     <Card className="m-2">
       <CardContent>
-        <h2 className="text-xl font-bold mb-2">Deals</h2>
-        <table className="w-full">
-          <thead><tr><th>ID</th><th>Contact</th><th>Value</th><th>Status</th></tr></thead>
-          <tbody>
-            {deals.map(d=>(
-              <tr key={d.id}>
-                <td>{d.id}</td><td>{d.contactId}</td><td>{d.value}</td>
-                <td>
-                  <Select value={d.status} onValueChange={(s)=>updateStatus(d.id,s)}>
-                    <SelectItem value="open">Open</SelectItem>
-                    <SelectItem value="won">Won</SelectItem>
-                    <SelectItem value="lost">Lost</SelectItem>
-                  </Select>
-                </td>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-slate-100">{strings.title}</h2>
+          <Button variant="ghost" size="sm" onClick={() => setShowTemporal(true)} aria-pressed={showTemporal}>
+            {strings.overlayToggle}
+          </Button>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800 text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="px-2 py-2">{strings.id}</th>
+                <th className="px-2 py-2">{strings.contact}</th>
+                <th className="px-2 py-2">{strings.value}</th>
+                <th className="px-2 py-2">{strings.status}</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-slate-900">
+              {deals.map(d=>(
+                <tr key={d.id}>
+                  <td className="px-2 py-2 font-mono text-xs text-slate-400">{d.id}</td>
+                  <td className="px-2 py-2 text-slate-300">{d.contactId}</td>
+                  <td className="px-2 py-2 text-slate-300">{d.value ?? '—'}</td>
+                  <td className="px-2 py-2">
+                    <Select value={d.status} onValueChange={(s)=>updateStatus(d.id,s)} aria-label={strings.status}>
+                      <SelectItem value="open">Open</SelectItem>
+                      <SelectItem value="won">Won</SelectItem>
+                      <SelectItem value="lost">Lost</SelectItem>
+                    </Select>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </CardContent>
+      {showTemporal && (
+        <TemporalLayer
+          items={temporalItems}
+          onClose={() => setShowTemporal(false)}
+          anchorLabel={strings.title}
+        />
+      )}
+      <UndoToast
+        open={toastOpen && !!undoInfo}
+        title={undoInfo?.message || ''}
+        canUndo={!!undoInfo?.token}
+        onUndo={performUndo}
+        onClose={() => {
+          setToastOpen(false);
+          setUndoInfo(null);
+        }}
+      />
     </Card>
   );
 }

--- a/frontend/src/features/deals/strings.ts
+++ b/frontend/src/features/deals/strings.ts
@@ -1,0 +1,12 @@
+export const dealsStrings = {
+  title: "Avtaler",
+  status: "Status",
+  value: "Verdi",
+  contact: "Kontakt",
+  id: "ID",
+  toast: {
+    statusChanged: (id: string, status: string) => `Avtale ${id} satt til ${status}`,
+  },
+  overlayToggle: "Tidslag",
+};
+export type DealsStrings = typeof dealsStrings;

--- a/frontend/src/features/integrations/o365/O365Panel.test.tsx
+++ b/frontend/src/features/integrations/o365/O365Panel.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+import NaviGrid from "@/features/navi/NaviGrid";
+import { Flags } from "@/lib/flags";
+
+const apiFetch = vi.fn();
+
+vi.mock("@/api", () => ({
+  apiFetch: (...args: any[]) => apiFetch(...args),
+}));
+
+describe("O365 panel flag", () => {
+  const originalFlag = Flags.enableO365Panel;
+  beforeEach(() => {
+    Flags.enableO365Panel = originalFlag;
+    apiFetch.mockReset();
+    apiFetch.mockImplementation((path: string) => {
+      if (path === "/api/addons") {
+        return Promise.resolve([
+          { id: "o365", name: "Office 365", icon: "📧", category: "integrasjoner", enabled: true },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+  });
+
+  afterAll(() => {
+    Flags.enableO365Panel = originalFlag;
+  });
+
+  it("does not open panel when flag disabled", async () => {
+    Flags.enableO365Panel = false;
+    render(<NaviGrid />);
+    const tile = await screen.findByText("Office 365");
+    fireEvent.click(tile);
+    expect(screen.queryByText("Siste e-poster og dokumenter")).not.toBeInTheDocument();
+  });
+
+  it("opens panel when flag enabled", async () => {
+    Flags.enableO365Panel = true;
+    render(<NaviGrid />);
+    const tile = await screen.findByText("Office 365");
+    fireEvent.click(tile);
+    expect(await screen.findByText("Siste e-poster og dokumenter")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/integrations/o365/O365Panel.tsx
+++ b/frontend/src/features/integrations/o365/O365Panel.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import WhyDrawer from "@/features/buoy/WhyDrawer";
+import { o365Strings as strings } from "./strings";
+
+type Item = {
+  id: string;
+  subject: string;
+  updatedAt: string;
+  kind: "email" | "document";
+};
+
+type Props = {
+  onClose?: () => void;
+};
+
+const mockItems: Item[] = [
+  { id: "m1", subject: "Statusmøte med Nordtek", updatedAt: "2025-09-18 08:42", kind: "email" },
+  { id: "m2", subject: "Q4 Forecast.xlsx", updatedAt: "2025-09-17 15:20", kind: "document" },
+  { id: "m3", subject: "Kontrakt ACME — utkast", updatedAt: "2025-09-17 11:04", kind: "document" },
+  { id: "m4", subject: "Oppfølgingsmail: Pilotprosjekt", updatedAt: "2025-09-16 09:55", kind: "email" },
+];
+
+export default function O365Panel({ onClose }: Props) {
+  const [whyOpen, setWhyOpen] = useState(false);
+  const explanations = useMemo(
+    () =>
+      mockItems.map((item) => ({
+        title: item.subject,
+        quote: strings.lastUpdated(item.updatedAt),
+        source: item.kind === "email" ? "Outlook" : "SharePoint",
+      })),
+    []
+  );
+
+  return (
+    <section className="space-y-4" aria-label={strings.title}>
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-100">{strings.title}</h2>
+          <p className="text-sm text-slate-400">{strings.subtitle}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" onClick={() => setWhyOpen(true)}>{strings.openWhy}</Button>
+          <Button variant="ghost" onClick={onClose}>{strings.close}</Button>
+        </div>
+      </header>
+      <div className="grid gap-3" role="list">
+        {mockItems.map((item) => (
+          <article
+            key={item.id}
+            role="listitem"
+            className="rounded-lg border border-slate-800 bg-slate-900/60 p-4"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <div className="font-medium text-slate-100">{item.subject}</div>
+                <div className="text-xs text-slate-400">{strings.lastUpdated(item.updatedAt)}</div>
+              </div>
+              <span className="rounded-full border border-slate-700 px-3 py-1 text-xs text-slate-300">
+                {item.kind === "email" ? strings.emailBadge : strings.documentBadge}
+              </span>
+            </div>
+          </article>
+        ))}
+      </div>
+      {whyOpen && (
+        <WhyDrawer
+          explanations={explanations}
+          onClose={() => setWhyOpen(false)}
+          title={strings.subtitle}
+        />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/integrations/o365/strings.ts
+++ b/frontend/src/features/integrations/o365/strings.ts
@@ -1,0 +1,10 @@
+export const o365Strings = {
+  title: "Office 365",
+  subtitle: "Siste e-poster og dokumenter",
+  openWhy: "Vis forklaring",
+  close: "Lukk",
+  lastUpdated: (date: string) => `Oppdatert ${date}`,
+  emailBadge: "E-post",
+  documentBadge: "Dokument",
+};
+export type O365Strings = typeof o365Strings;

--- a/frontend/src/features/navi/AddOnTile.tsx
+++ b/frontend/src/features/navi/AddOnTile.tsx
@@ -1,18 +1,65 @@
 import React from "react";
-type Props = { id:string; name:string; icon:string; enabled:boolean; onOpen:()=>void };
-export default function AddOnTile({ name, icon, enabled, onOpen }: Props) {
+
+type Props = {
+  id: string;
+  name: string;
+  icon: string;
+  enabled: boolean;
+  onOpen: () => void;
+  onToggle?: (next: boolean) => void;
+  connectedLabel: string;
+  disconnectedLabel: string;
+  toggleOn: string;
+  toggleOff: string;
+};
+
+export default function AddOnTile({
+  name,
+  icon,
+  enabled,
+  onOpen,
+  onToggle,
+  connectedLabel,
+  disconnectedLabel,
+  toggleOn,
+  toggleOff,
+}: Props) {
   return (
-    <button onClick={onOpen} aria-label={`${name}${enabled?"":" (ikke koblet)"}`}
-      style={{
-        width:"100%", textAlign:"left", background:"rgba(255,255,255,.03)",
-        border:"1px solid rgba(255,255,255,.08)", borderRadius:14, padding:14,
-        display:"grid", gridTemplateColumns:"32px 1fr", gap:10, color:"inherit", opacity:enabled?1:.5
-      }}>
-      <span style={{fontSize:20}}>{icon}</span>
-      <div>
-        <div style={{fontWeight:600}}>{name}</div>
-        <div className="chip" style={{display:"inline-block", marginTop:6}}>{enabled ? "Koblet" : "Koble til"}</div>
+    <article
+      aria-label={name}
+      className="flex h-full flex-col justify-between rounded-xl border border-slate-800 bg-slate-900/50 p-4 text-left text-slate-100 transition hover:border-indigo-500/60"
+    >
+      <button
+        onClick={onOpen}
+        aria-label={name}
+        className="flex flex-1 items-start gap-3 text-left"
+      >
+        <span aria-hidden className="text-2xl">{icon}</span>
+        <div>
+          <div className="font-semibold">{name}</div>
+          <div className="mt-2 inline-flex rounded-full border border-slate-700 px-2 py-1 text-xs">
+            {enabled ? connectedLabel : disconnectedLabel}
+          </div>
+        </div>
+      </button>
+      <div className="mt-4 flex items-center justify-end">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          aria-label={enabled ? toggleOn : toggleOff}
+          onClick={() => onToggle?.(!enabled)}
+          className={`relative h-6 w-12 rounded-full border border-slate-700 transition ${
+            enabled ? 'bg-indigo-600' : 'bg-slate-800'
+          }`}
+        >
+          <span
+            className={`absolute left-0 top-0 m-1 h-4 w-4 rounded-full bg-white transition-transform ${
+              enabled ? 'translate-x-6' : 'translate-x-0'
+            }`}
+          />
+        </button>
       </div>
-    </button>
+    </article>
   );
 }

--- a/frontend/src/features/navi/NaviGrid.test.tsx
+++ b/frontend/src/features/navi/NaviGrid.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+import NaviGrid from "./NaviGrid";
+
+const apiFetch = vi.fn();
+
+vi.mock("@/api", () => ({
+  apiFetch: (...args: any[]) => apiFetch(...args),
+}));
+
+beforeEach(() => {
+  apiFetch.mockReset();
+});
+
+test("renders addons from manifest and toggles locally", async () => {
+  apiFetch.mockImplementation((path: string) => {
+    if (path === "/api/addons") {
+      return Promise.resolve([
+        { id: "crm", name: "CRM", icon: "📇", category: "core", enabled: true },
+        { id: "demo", name: "Demo", icon: "🧪", category: "demo", enabled: false },
+      ]);
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<NaviGrid />);
+
+  expect(await screen.findByText("Demo")).toBeInTheDocument();
+
+  const toggle = await screen.findByRole("switch", { name: "Av" });
+  expect(toggle).toHaveAttribute("aria-checked", "false");
+
+  fireEvent.click(toggle);
+
+  await waitFor(() => {
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/frontend/src/features/navi/NaviGrid.tsx
+++ b/frontend/src/features/navi/NaviGrid.tsx
@@ -1,37 +1,90 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
 import AddOnTile from "./AddOnTile";
 import SynchBadge from "./SynchBadge";
 import ContactsPanel from "../CRMPanel";
-type AddOn = { id:string; name:string; icon:string; category:string; enabled:boolean };
+import { useAddonsStore } from "../addons/AddonsStore";
+import { naviStrings as strings } from "./strings";
+import { Flags } from "@/lib/flags";
+import O365Panel from "@/features/integrations/o365/O365Panel";
+import Preferences from "@/features/settings/Preferences";
+
 export default function NaviGrid() {
-  const [addons, setAddons] = useState<AddOn[]>([]);
-  const [filter, setFilter] = useState("alle");
-  const [open, setOpen] = useState<string|null>(null);
-  useEffect(() => { fetch("/api/addons").then(r=>r.json()).then(setAddons); }, []);
-  const cats = ["alle", ...Array.from(new Set(addons.map(a=>a.category)))];
-  const show = addons.filter(a => filter==="alle" ? true : a.category===filter);
+  const { addons, loading, error, toggle } = useAddonsStore();
+  const [filter, setFilter] = useState(strings.filterAll);
+  const [open, setOpen] = useState<string | null>(null);
+
+  const categories = useMemo(() => {
+    const unique = new Set<string>();
+    addons.forEach((addon) => unique.add(addon.category));
+    return [strings.filterAll, ...Array.from(unique)];
+  }, [addons]);
+
+  const visibleAddons = useMemo(() => {
+    if (filter === strings.filterAll) return addons;
+    return addons.filter((addon) => addon.category === filter);
+  }, [addons, filter]);
+
+  function handleOpen(addonId: string, name: string) {
+    if (addonId === "crm") {
+      setOpen("crm");
+      return;
+    }
+    if (addonId === "o365" && Flags.enableO365Panel) {
+      setOpen("o365");
+      return;
+    }
+    window.alert?.(strings.openAddon(name));
+  }
+
   return (
-    <div role="region" aria-label="Navi-oversikt" style={{display:"grid",gridTemplateRows:"auto 1fr",height:"100%"}}>
+    <div role="region" aria-label={strings.regionLabel} style={{display:"grid",gridTemplateRows:"auto auto 1fr",height:"100%"}}>
       <div style={{display:"flex", gap:10, padding:12, alignItems:"center"}}>
         <span className="chip">Navi</span>
-        <select aria-label="Kategori" value={filter} onChange={e=>setFilter(e.target.value)}
+        <select aria-label={strings.filterLabel} value={filter} onChange={e=>setFilter(e.target.value)}
                 style={{background:"transparent", color:"var(--ink)", border:"1px solid rgba(255,255,255,.14)", borderRadius:8,
 padding:"6px 8px"}}>
-          {cats.map(c=> <option key={c} value={c} style={{color:"#000"}}>{c}</option>)}
+          {categories.map(c=> <option key={c} value={c} style={{color:"#000"}}>{c}</option>)}
         </select>
         <span style={{flex:1}}/>
-        <SynchBadge status="ok"/>
+        <SynchBadge status={loading ? "wait" : "ok"}/>
+      </div>
+      <div style={{padding:"0 12px"}}>
+        <Preferences />
       </div>
       <div style={{position:"relative", padding:12, height:"100%"}}>
+        {error && (
+          <div role="alert" className="mb-4 rounded-md border border-red-500/60 bg-red-900/30 p-3 text-sm text-red-200">
+            {strings.manifestError}
+          </div>
+        )}
         {!open ? (
           <div style={{display:"grid", gap:12, gridTemplateColumns:"repeat(auto-fill, minmax(220px,1fr))", overflow:"auto", height:"100%"}}>
-            {show.map(a=> <AddOnTile key={a.id} {...a} onOpen={()=>{
-              if (a.id==="crm") setOpen("crm"); else alert(`Åpne ${a.name} (intent)`);
-            }} />)}
+            {visibleAddons.length === 0 && !loading ? (
+              <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-6 text-center text-sm text-slate-300">
+                {strings.emptyState}
+              </div>
+            ) : (
+              visibleAddons.map((addon) => (
+                <AddOnTile
+                  key={addon.id}
+                  id={addon.id}
+                  name={addon.name}
+                  icon={addon.icon || "🧩"}
+                  enabled={addon.enabled}
+                  onOpen={() => handleOpen(addon.id, addon.name)}
+                  onToggle={(next) => toggle(addon.id, next)}
+                  connectedLabel={strings.connectedLabel}
+                  disconnectedLabel={strings.disconnectedLabel}
+                  toggleOn={strings.toggleOn}
+                  toggleOff={strings.toggleOff}
+                />
+              ))
+            )}
           </div>
         ) : (
           <div style={{position:"absolute", inset:12, overflow:"auto", border:"1px solid rgba(255,255,255,.08)", borderRadius:12, padding:12}}>
             {open==="crm" && <ContactsPanel onClose={()=>setOpen(null)}/>}
+            {open==="o365" && Flags.enableO365Panel && <O365Panel onClose={()=>setOpen(null)} />}
           </div>
         )}
       </div>

--- a/frontend/src/features/navi/strings.ts
+++ b/frontend/src/features/navi/strings.ts
@@ -1,0 +1,14 @@
+export const naviStrings = {
+  regionLabel: "Navi-oversikt",
+  filterLabel: "Kategori",
+  filterAll: "alle",
+  emptyState: "Ingen utvidelser tilgjengelig",
+  toggleOn: "På",
+  toggleOff: "Av",
+  openAddon: (name: string) => `Åpne ${name}`,
+  manifestError: "Kunne ikke laste utvidelser",
+  enabledLabel: "Aktivert",
+  connectedLabel: "Koblet",
+  disconnectedLabel: "Koble til",
+};
+export type NaviStrings = typeof naviStrings;

--- a/frontend/src/features/peripheral/AudioCue.test.ts
+++ b/frontend/src/features/peripheral/AudioCue.test.ts
@@ -1,0 +1,71 @@
+import { vi } from "vitest";
+import { AudioCue } from "./AudioCue";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var matchMedia: ((query: string) => MediaQueryList) | undefined;
+}
+
+describe("AudioCue", () => {
+  const createMockContext = () => {
+    const start = vi.fn();
+    const stop = vi.fn();
+    const oscillator = {
+      type: "sine" as OscillatorType,
+      frequency: { setValueAtTime: vi.fn() },
+      connect: vi.fn(),
+      start,
+      stop,
+    } as unknown as OscillatorNode;
+
+    const gain = {
+      gain: {
+        setValueAtTime: vi.fn(),
+        exponentialRampToValueAtTime: vi.fn(),
+      },
+      connect: vi.fn(),
+    } as unknown as GainNode;
+
+    return {
+      context: {
+        state: "running" as AudioContextState,
+        currentTime: 0,
+        createOscillator: vi.fn(() => oscillator),
+        createGain: vi.fn(() => gain),
+        resume: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+        destination: {} as AudioDestinationNode,
+      } as unknown as AudioContext,
+      oscillator,
+    };
+  };
+
+  beforeEach(() => {
+    (global as any).matchMedia = undefined;
+  });
+
+  it("plays cue when enabled", () => {
+    const mock = createMockContext();
+    const cue = new AudioCue({ contextFactory: () => mock.context });
+    cue.setEnabled(true);
+    cue.play("success");
+    expect(mock.context.createOscillator).toHaveBeenCalled();
+  });
+
+  it("does not play when disabled", () => {
+    const mock = createMockContext();
+    const cue = new AudioCue({ contextFactory: () => mock.context });
+    cue.setEnabled(false);
+    cue.play("success");
+    expect(mock.context.createOscillator).not.toHaveBeenCalled();
+  });
+
+  it("respects reduced audio preference", () => {
+    (global as any).matchMedia = () => ({ matches: true, addEventListener: vi.fn() }) as any;
+    const mock = createMockContext();
+    const cue = new AudioCue({ contextFactory: () => mock.context });
+    cue.setEnabled(true);
+    cue.play("success");
+    expect(mock.context.createOscillator).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/peripheral/AudioCue.ts
+++ b/frontend/src/features/peripheral/AudioCue.ts
@@ -1,0 +1,111 @@
+export type AudioCueName = 'success' | 'error';
+
+type AudioCueOptions = {
+  contextFactory?: () => AudioContext | undefined;
+};
+
+const reduceQueries = [
+  '(prefers-reduced-motion: reduce)',
+  '(prefers-reduced-transparency: reduce)',
+  '(prefers-reduced-sound: reduce)',
+];
+
+export function prefersReducedAudio(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return reduceQueries.some((query) => {
+    try {
+      return window.matchMedia(query).matches;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export class AudioCue {
+  private context?: AudioContext;
+  private enabled = false;
+  private readonly options: AudioCueOptions;
+  private reduced = prefersReducedAudio();
+
+  constructor(options: AudioCueOptions = {}) {
+    this.options = options;
+    if (typeof window !== 'undefined') {
+      reduceQueries.forEach((query) => {
+        try {
+          const mediaQuery = window.matchMedia(query);
+          const listener = () => {
+            this.reduced = prefersReducedAudio();
+          };
+          if (mediaQuery.addEventListener) {
+            mediaQuery.addEventListener('change', listener);
+          } else if ((mediaQuery as any).addListener) {
+            (mediaQuery as any).addListener(listener);
+          }
+        } catch {
+          /* noop */
+        }
+      });
+    }
+  }
+
+  private ensureContext(): AudioContext | undefined {
+    if (this.context) return this.context;
+    const factory = this.options.contextFactory;
+    if (factory) {
+      this.context = factory();
+    } else if (typeof window !== 'undefined' && 'AudioContext' in window) {
+      this.context = new window.AudioContext();
+    }
+    return this.context;
+  }
+
+  setEnabled(next: boolean) {
+    this.enabled = next;
+    if (!next && this.context) {
+      try {
+        this.context.close();
+      } catch {
+        /* ignore */
+      }
+      this.context = undefined;
+    }
+  }
+
+  play(name: AudioCueName) {
+    if (!this.enabled || this.reduced) return;
+    const ctx = this.ensureContext();
+    if (!ctx) return;
+    if (ctx.state === 'suspended') {
+      ctx.resume().catch(() => undefined);
+    }
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+
+    const now = ctx.currentTime;
+    const { frequency, type } = this.resolveSettings(name);
+
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, now);
+
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.12, now + 0.03);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.4);
+
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+
+    oscillator.start(now);
+    oscillator.stop(now + 0.45);
+  }
+
+  private resolveSettings(name: AudioCueName) {
+    if (name === 'success') {
+      return { frequency: 660, type: 'sine' as OscillatorType };
+    }
+    return { frequency: 220, type: 'triangle' as OscillatorType };
+  }
+}
+
+export const audioCue = new AudioCue();

--- a/frontend/src/features/settings/Preferences.tsx
+++ b/frontend/src/features/settings/Preferences.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { audioCue, prefersReducedAudio } from "@/features/peripheral/AudioCue";
+import { preferencesStrings as strings } from "./strings";
+
+const STORAGE_KEY = "wb.audioCues";
+
+type ToggleState = "on" | "off";
+
+function readStoredState(): ToggleState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return value === "on" || value === "off" ? (value as ToggleState) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredState(value: ToggleState) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function Preferences() {
+  const [state, setState] = useState<ToggleState>(() => readStoredState() ?? "off");
+  const reduced = useMemo(() => prefersReducedAudio(), []);
+
+  useEffect(() => {
+    const enabled = state === "on" && !reduced;
+    audioCue.setEnabled(enabled);
+    writeStoredState(state);
+  }, [state, reduced]);
+
+  useEffect(() => {
+    if (reduced) {
+      setState("off");
+    }
+  }, [reduced]);
+
+  const descriptionId = "audio-cue-description";
+  const reducedId = "audio-cue-reduced";
+
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-100">
+      <header className="mb-3">
+        <h2 className="text-base font-semibold">{strings.title}</h2>
+      </header>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <div className="font-medium" id={descriptionId}>{strings.audioCueDescription}</div>
+          {reduced && (
+            <p id={reducedId} className="text-xs text-slate-400">
+              <strong className="block font-semibold text-slate-300">{strings.reducedLabel}</strong>
+              {strings.reducedDescription}
+            </p>
+          )}
+        </div>
+        <label className="inline-flex cursor-pointer items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-400">{strings.audioCueLabel}</span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={state === "on"}
+            aria-describedby={reduced ? `${descriptionId} ${reducedId}` : descriptionId}
+            onClick={() => setState((prev) => (prev === "on" ? "off" : "on"))}
+            disabled={reduced}
+            className={`relative h-6 w-11 rounded-full border border-slate-700 transition ${
+              state === "on" && !reduced ? "bg-indigo-600" : "bg-slate-800"
+            } ${reduced ? "opacity-60" : ""}`}
+          >
+            <span
+              className={`absolute left-0 top-0 m-1 h-4 w-4 rounded-full bg-white transition-transform ${
+                state === "on" && !reduced ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/settings/strings.ts
+++ b/frontend/src/features/settings/strings.ts
@@ -1,0 +1,8 @@
+export const preferencesStrings = {
+  title: "Preferanser",
+  audioCueLabel: "Diskré lydhint",
+  audioCueDescription: "Gi et forsiktig lydsignal ved viktige hendelser",
+  reducedLabel: "Systemet har redusert lyd aktivert",
+  reducedDescription: "Audio cues er avslått fordi brukerens system foretrekker redusert lyd.",
+};
+export type PreferencesStrings = typeof preferencesStrings;

--- a/frontend/src/features/time/TemporalLayer.test.tsx
+++ b/frontend/src/features/time/TemporalLayer.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+import TemporalLayer from "./TemporalLayer";
+
+describe("TemporalLayer", () => {
+  const original = HTMLElement.prototype.scrollIntoView;
+  const scrollSpy = vi.fn();
+
+  beforeAll(() => {
+    HTMLElement.prototype.scrollIntoView = scrollSpy;
+  });
+
+  afterAll(() => {
+    HTMLElement.prototype.scrollIntoView = original;
+  });
+
+  it("places items by temporal section and handles N key", () => {
+    const now = new Date().toISOString();
+    render(
+      <TemporalLayer
+        items={[
+          { id: "p", title: "Past", start: "2020-01-01" },
+          { id: "n", title: "Now", start: now },
+          { id: "f", title: "Future", start: "2100-01-01" },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Past")).toBeInTheDocument();
+    expect(screen.getByText("Now")).toBeInTheDocument();
+    expect(screen.getByText("Future")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "n" });
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/time/TemporalLayer.tsx
+++ b/frontend/src/features/time/TemporalLayer.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { temporalStrings as strings } from "./strings";
+import { Button } from "@/components/ui/button";
+
+type TemporalState = "past" | "now" | "future";
+
+type TemporalItem = {
+  id: string;
+  title: string;
+  start: string;
+  end?: string;
+  state?: TemporalState;
+};
+
+type Props = {
+  items: TemporalItem[];
+  onClose?: () => void;
+  anchorLabel?: string;
+};
+
+function resolveState(item: TemporalItem): TemporalState {
+  if (item.state) return item.state;
+  const now = Date.now();
+  const start = new Date(item.start).getTime();
+  const end = item.end ? new Date(item.end).getTime() : start;
+  if (end < now) return "past";
+  if (start > now) return "future";
+  return "now";
+}
+
+function categorize(items: TemporalItem[]) {
+  const groups: Record<TemporalState, TemporalItem[]> = {
+    past: [],
+    now: [],
+    future: [],
+  };
+  items.forEach((item) => {
+    const state = resolveState(item);
+    groups[state].push(item);
+  });
+  (Object.keys(groups) as TemporalState[]).forEach((key) => {
+    groups[key] = groups[key].sort((a, b) => a.start.localeCompare(b.start));
+  });
+  return groups;
+}
+
+export default function TemporalLayer({ items, onClose, anchorLabel }: Props) {
+  const groups = useMemo(() => categorize(items), [items]);
+  const nowRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (event.key.toLowerCase() === "n") {
+        event.preventDefault();
+        nowRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+      if (event.key === "Escape") {
+        onClose?.();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const label = anchorLabel ? `${strings.title} – ${anchorLabel}` : strings.title;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={label}
+      className="absolute inset-0 z-40 flex flex-col bg-slate-950/85 backdrop-blur-sm"
+    >
+      <div className="flex items-center justify-between px-4 py-3">
+        <h2 className="text-sm font-semibold text-slate-100">{label}</h2>
+        <Button variant="ghost" size="sm" onClick={onClose} aria-label={strings.overlayClose}>
+          {strings.overlayClose}
+        </Button>
+      </div>
+      <div className="relative flex-1 overflow-y-auto px-4 pb-6">
+        <div className="grid gap-4 md:grid-cols-3" role="list">
+          <Section
+            id="temporal-past"
+            title={strings.sections.past}
+            items={groups.past}
+          />
+          <Section
+            id="temporal-now"
+            title={strings.sections.now}
+            items={groups.now}
+            markerRef={nowRef}
+          />
+          <Section
+            id="temporal-future"
+            title={strings.sections.future}
+            items={groups.future}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type SectionProps = {
+  id: string;
+  title: string;
+  items: TemporalItem[];
+  markerRef?: React.RefObject<HTMLDivElement>;
+};
+
+function Section({ id, title, items, markerRef }: SectionProps) {
+  return (
+    <section
+      aria-labelledby={id}
+      className="rounded-lg border border-slate-800 bg-slate-900/70 p-3"
+    >
+      <div className="sticky top-0 z-10 flex items-center justify-between bg-slate-900/80 px-1 py-2">
+        <h3 id={id} className="text-sm font-semibold text-slate-200">
+          {title}
+        </h3>
+        {markerRef && (
+          <div ref={markerRef} className="rounded-full bg-indigo-500/30 px-3 py-1 text-xs text-indigo-100">
+            {strings.nowMarker}
+          </div>
+        )}
+      </div>
+      <ul role="list" className="mt-2 space-y-2">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            role="listitem"
+            className="rounded-md border border-slate-800/60 bg-slate-900/80 px-3 py-2"
+          >
+            <div className="flex items-center justify-between">
+              <span>{item.title}</span>
+              <span className="text-xs text-slate-400">{item.start}</span>
+            </div>
+          </li>
+        ))}
+        {items.length === 0 && (
+          <li className="rounded-md border border-dashed border-slate-800/60 px-3 py-2 text-xs text-slate-500">
+            —
+          </li>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/features/time/strings.ts
+++ b/frontend/src/features/time/strings.ts
@@ -1,0 +1,11 @@
+export const temporalStrings = {
+  title: "Tidslag",
+  sections: {
+    past: "Fortid",
+    now: "Nå",
+    future: "Fremtid",
+  },
+  nowMarker: "Nå",
+  overlayClose: "Lukk",
+};
+export type TemporalStrings = typeof temporalStrings;

--- a/frontend/src/features/why/WhyDrawer.test.tsx
+++ b/frontend/src/features/why/WhyDrawer.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 import { WhyDrawer } from './WhyDrawer';
 
-jest.mock('@/api', ()=>({
-  apiFetch: jest.fn(async ()=>({ log: [ {id:'a1', action:'create', ts:123, method:'POST', route:'/x'} ] }))
+vi.mock('@/api', ()=>({
+  apiFetch: vi.fn(async ()=>({ log: [ {id:'a1', action:'create', ts:123, method:'POST', route:'/x'} ] }))
 }));
 
 it('renders audit drawer', async ()=>{

--- a/frontend/src/features/zoom/SemanticZoom.test.tsx
+++ b/frontend/src/features/zoom/SemanticZoom.test.tsx
@@ -1,0 +1,13 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import SemanticZoom from "./SemanticZoom";
+
+test("switches levels and groups items", () => {
+  render(<SemanticZoom />);
+
+  fireEvent.keyDown(window, { key: "2" });
+  expect(screen.getByRole("group", { name: /Uke/ })).toBeInTheDocument();
+
+  fireEvent.keyDown(window, { key: "3" });
+  expect(screen.getByText(/Salg/)).toBeInTheDocument();
+});

--- a/frontend/src/features/zoom/SemanticZoom.tsx
+++ b/frontend/src/features/zoom/SemanticZoom.tsx
@@ -1,76 +1,219 @@
-import React, { useMemo, useState } from "react";
-type Task = { id:string; title:string; due?:string; project?:string; status?:"todo"|"doing"|"done" };
-const demo: Task[] = [
-  { id:"t1", title:"Ring kunde A", due:"2025-09-18", project:"Q3 pipeline", status:"todo" },
-  { id:"t2", title:"Send tilbud B", due:"2025-09-19", project:"Q3 pipeline", status:"doing" },
-  { id:"t3", title:"Forbered statusmøte", due:"2025-09-22", project:"Account X", status:"todo" },
-  { id:"t4", title:"Oppfølging faktura", due:"2025-09-23", project:"Billing", status:"todo" },
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { semanticZoomStrings as strings } from "./strings";
+
+type SemanticZoomItem = {
+  id: string;
+  title: string;
+  when: string;
+  weight: number;
+  type: string;
+};
+
+type Props = {
+  items?: SemanticZoomItem[];
+};
+
+const defaultItems: SemanticZoomItem[] = [
+  { id: "z1", title: "Ring kunde A", when: "2025-09-18", weight: 3, type: "Salg" },
+  { id: "z2", title: "Send tilbud B", when: "2025-09-19", weight: 5, type: "Salg" },
+  { id: "z3", title: "Workshop med Ops", when: "2025-09-22", weight: 2, type: "Leveranse" },
+  { id: "z4", title: "Strategimøte Q4", when: "2025-09-28", weight: 4, type: "Strategi" },
+  { id: "z5", title: "Onboarding Kunde C", when: "2025-10-02", weight: 3, type: "Leveranse" },
+  { id: "z6", title: "Retrospektiv", when: "2025-10-04", weight: 1, type: "Team" },
 ];
-export default function SemanticZoom(){
-  const [level, setLevel] = useState<0|1|2>(0);
-  const byProject = useMemo(()=> {
-    const m: Record<string, Task[]> = {};
-    demo.forEach(t => { const k = t.project || "Uten prosjekt"; (m[k]||(m[k]=[])).push(t); });
-    return m;
+
+const levelOrder = ["list", "timeline", "strategy"] as const;
+type Level = typeof levelOrder[number];
+
+function clampLevel(level: number) {
+  return Math.min(Math.max(level, 0), levelOrder.length - 1);
+}
+
+function startOfWeek(date: Date) {
+  const copy = new Date(date);
+  const day = copy.getDay();
+  const diff = (day + 6) % 7;
+  copy.setDate(copy.getDate() - diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+function getISOWeek(date: Date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return weekNo;
+}
+
+function formatWeekLabel(date: Date) {
+  const formatter = new Intl.DateTimeFormat("nb-NO", { day: "2-digit", month: "short" });
+  const month = new Intl.DateTimeFormat("nb-NO", { month: "long" }).format(date);
+  const weekNumber = getISOWeek(date);
+  return `${strings.timelineLabel(`Uke ${weekNumber}`)} · ${formatter.format(date)} (${month})`;
+}
+
+function groupByWeek(items: SemanticZoomItem[]) {
+  const groups: Record<string, { label: string; items: SemanticZoomItem[] }> = {};
+  items.forEach((item) => {
+    const date = new Date(item.when);
+    const weekStart = startOfWeek(date);
+    const key = weekStart.toISOString().slice(0, 10);
+    if (!groups[key]) {
+      groups[key] = { label: formatWeekLabel(weekStart), items: [] };
+    }
+    groups[key].items.push(item);
+  });
+  return Object.entries(groups)
+    .map(([key, value]) => ({ key, ...value }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function groupByType(items: SemanticZoomItem[]) {
+  const map = new Map<string, SemanticZoomItem[]>();
+  items.forEach((item) => {
+    const entry = map.get(item.type) ?? [];
+    entry.push(item);
+    map.set(item.type, entry);
+  });
+  return Array.from(map.entries()).map(([type, list]) => ({
+    type,
+    items: list.sort((a, b) => b.weight - a.weight),
+  }));
+}
+
+export default function SemanticZoom({ items = defaultItems }: Props) {
+  const [level, setLevel] = useState<number>(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const sortedItems = useMemo(() => items.slice().sort((a, b) => a.when.localeCompare(b.when)), [items]);
+  const weekGroups = useMemo(() => groupByWeek(sortedItems), [sortedItems]);
+  const typeGroups = useMemo(() => groupByType(items), [items]);
+
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent) {
+      if (event.ctrlKey || event.metaKey) {
+        if (event.key === "+" || event.key === "=") {
+          event.preventDefault();
+          setLevel((prev) => clampLevel(prev - 1));
+        }
+        if (event.key === "-") {
+          event.preventDefault();
+          setLevel((prev) => clampLevel(prev + 1));
+        }
+      }
+      if (event.key === "1") setLevel(0);
+      if (event.key === "2") setLevel(1);
+      if (event.key === "3") setLevel(2);
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
   }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) {
+        event.preventDefault();
+        setLevel((prev) =>
+          clampLevel(prev + (event.deltaY > 0 ? 1 : -1))
+        );
+      }
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel as any);
+  }, []);
+
+  const currentLevel = levelOrder[level];
+
   return (
-    <div className="cardbg" style={{borderRadius:12, padding:12, display:"grid", gap:10}}>
-      <header style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
-        <strong>Semantic Zoom</strong>
-        <div style={{display:"flex", gap:6}}>
-          <button className="chip" aria-pressed={level===0} onClick={()=>setLevel(0)}>Liste</button>
-          <button className="chip" aria-pressed={level===1} onClick={()=>setLevel(1)}>Tidslinje</button>
-          <button className="chip" aria-pressed={level===2} onClick={()=>setLevel(2)}>Strategi</button>
+    <section
+      ref={containerRef}
+      className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-slate-100"
+      aria-label={strings.title}
+    >
+      <header className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">{strings.title}</h2>
+          <p className="text-xs text-slate-400">
+            {strings.shortcuts.zoomIn} · {strings.shortcuts.zoomOut} · {strings.shortcuts.levelKeys}
+          </p>
         </div>
-      </header>
-      {level===0 && <TaskList tasks={demo}/>}
-      {level===1 && <WeekTimeline tasks={demo}/>}
-      {level===2 && <StrategyOverview groups={byProject}/>}
-    </div>
-  );
-}
-function TaskList({ tasks }:{ tasks: Task[] }){
-  return (
-    <div style={{display:"grid", gap:8}}>
-      {tasks.map(t => (
-        <div key={t.id} className="row" style={{display:"grid", gridTemplateColumns:"1fr auto auto", alignItems:"center", gap:8}}>
-          <div><div style={{fontWeight:600}}>{t.title}</div><div style={{opacity:.8, fontSize:12}}>{t.project||"—"}</div></div>
-          <div style={{opacity:.8}}>{t.due||"—"}</div><span className="chip">{t.status||"todo"}</span>
-        </div>
-      ))}
-    </div>
-  );
-}
-function WeekTimeline({ tasks }:{ tasks: Task[] }){
-  const days = ["Man","Tir","Ons","Tor","Fre","Lør","Søn"];
-  return (
-    <div style={{display:"grid", gridTemplateColumns:"repeat(7, 1fr)", gap:6}}>
-      {days.map((d,i)=>(
-        <div key={i} style={{padding:8, border:"1px solid rgba(255,255,255,.1)", borderRadius:8}}>
-          <div style={{opacity:.8, marginBottom:6}}>{d}</div>
-          {tasks.filter(t => new Date(t.due||"").getDay()===((i+1)%7)).map(t => (
-            <div key={t.id} className="chip" style={{display:"block", marginBottom:6}}>{t.title}</div>
+        <div className="inline-flex gap-2" role="tablist" aria-label="Zoom nivå">
+          {levelOrder.map((name, index) => (
+            <button
+              key={name}
+              type="button"
+              role="tab"
+              aria-selected={level === index}
+              className={`rounded-full border px-3 py-1 text-xs ${level === index ? 'border-indigo-400 bg-indigo-500/20' : 'border-slate-700 bg-transparent'}`}
+              onClick={() => setLevel(index)}
+            >
+              {strings.levels[name]}
+            </button>
           ))}
         </div>
-      ))}
-    </div>
-  );
-}
-function StrategyOverview({ groups }:{ groups: Record<string, Task[]> }){
-  const entries = Object.entries(groups);
-  return (
-    <div style={{display:"grid", gap:10}}>
-      {entries.map(([project, list])=> (
-        <div key={project} style={{border:"1px solid rgba(255,255,255,.1)", borderRadius:10, padding:10}}>
-          <div style={{display:"flex", justifyContent:"space-between", alignItems:"center", marginBottom:8}}>
-            <strong>{project}</strong>
-            <span className="chip">{list.length} oppgaver</span>
-          </div>
-          <div style={{display:"flex", gap:6, flexWrap:"wrap"}}>
-            {list.map(t => <span key={t.id} className="chip">{t.title}</span>)}
-          </div>
+      </header>
+
+      {currentLevel === "list" && (
+        <ul role="list" className="grid gap-3">
+          {sortedItems.map((item) => (
+            <li
+              key={item.id}
+              role="listitem"
+              className="rounded-lg border border-slate-800 bg-slate-900/80 p-3"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{item.title}</span>
+                <span className="text-xs text-slate-400">{item.when}</span>
+              </div>
+              <div className="mt-2 text-xs text-slate-400">{strings.clusterLabel(item.type)}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {currentLevel === "timeline" && (
+        <div className="grid gap-4" role="list">
+          {weekGroups.map((group) => (
+            <section key={group.key} role="group" aria-labelledby={`week-${group.key}`} className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+              <h3 id={`week-${group.key}`} className="text-sm font-semibold text-slate-200">
+                {group.label}
+              </h3>
+              <ul role="list" className="mt-2 space-y-2">
+                {group.items.map((item) => (
+                  <li key={item.id} className="flex items-center justify-between rounded-md border border-slate-800/60 bg-slate-900/80 px-3 py-2">
+                    <span>{item.title}</span>
+                    <span className="text-xs text-slate-400">{item.when}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
         </div>
-      ))}
-    </div>
+      )}
+
+      {currentLevel === "strategy" && (
+        <div className="grid gap-4 md:grid-cols-3">
+          {typeGroups.map((group) => (
+            <article key={group.type} className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+              <h3 className="text-sm font-semibold text-slate-200">{strings.clusterLabel(group.type)}</h3>
+              <ul role="list" className="mt-2 space-y-2">
+                {group.items.map((item) => (
+                  <li key={item.id} className="rounded-md border border-slate-800/60 bg-slate-900/80 px-3 py-2" role="listitem">
+                    <div className="flex items-center justify-between">
+                      <span>{item.title}</span>
+                      <span className="text-xs text-slate-400">{item.weight.toFixed(1)}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }

--- a/frontend/src/features/zoom/strings.ts
+++ b/frontend/src/features/zoom/strings.ts
@@ -1,0 +1,16 @@
+export const semanticZoomStrings = {
+  title: "Semantisk zoom",
+  levels: {
+    list: "Liste",
+    timeline: "Tidslinje",
+    strategy: "Strategi",
+  },
+  shortcuts: {
+    zoomIn: "Ctrl/Cmd + +",
+    zoomOut: "Ctrl/Cmd + -",
+    levelKeys: "1-3",
+  },
+  timelineLabel: (label: string) => label,
+  clusterLabel: (type: string) => type,
+};
+export type SemanticZoomStrings = typeof semanticZoomStrings;

--- a/frontend/src/lib/flags.ts
+++ b/frontend/src/lib/flags.ts
@@ -1,4 +1,5 @@
 export const Flags = {
   realBackend: false, // flip to true when server routes are ready
   sendContextHeaders: true,
+  enableO365Panel: false,
 };

--- a/frontend/src/test-utils/jest-dom.ts
+++ b/frontend/src/test-utils/jest-dom.ts
@@ -1,0 +1,20 @@
+import { expect } from "vitest";
+
+declare module "vitest" {
+  interface Assertion<T = any> {
+    toBeInTheDocument(): T;
+  }
+}
+
+expect.extend({
+  toBeInTheDocument(received: HTMLElement) {
+    const pass = !!received && document.body.contains(received);
+    return {
+      pass,
+      message: () =>
+        pass
+          ? "Expected element not to be in the document"
+          : "Expected element to be present in the document",
+    };
+  },
+});

--- a/frontend/src/test-utils/testing-library.ts
+++ b/frontend/src/test-utils/testing-library.ts
@@ -1,0 +1,165 @@
+import React from "react";
+import { createRoot, Root } from "react-dom/client";
+
+type Matcher = string | RegExp;
+
+type RenderResult = {
+  container: HTMLElement;
+  rerender: (ui: React.ReactElement) => void;
+  unmount: () => void;
+};
+
+const roots = new Set<Root>();
+
+function matchesText(node: Element, matcher: Matcher): boolean {
+  const text = node.textContent ?? "";
+  if (typeof matcher === "string") {
+    return text.trim() === matcher.trim();
+  }
+  return matcher.test(text);
+}
+
+function queryAllByText(matcher: Matcher) {
+  const nodes: Element[] = [];
+  document.body.querySelectorAll<HTMLElement>("*").forEach((node) => {
+    if (matchesText(node, matcher)) nodes.push(node);
+  });
+  return nodes;
+}
+
+function getByText(matcher: Matcher) {
+  const result = queryAllByText(matcher);
+  if (result.length === 0) throw new Error(`Unable to find text: ${matcher}`);
+  return result[0] as HTMLElement;
+}
+
+function getByPlaceholderText(matcher: Matcher) {
+  const elements = Array.from(document.body.querySelectorAll<HTMLElement>("input,textarea"));
+  const match = elements.find((el) => {
+    const placeholder = el.getAttribute("placeholder") || "";
+    if (typeof matcher === "string") return placeholder === matcher;
+    return matcher.test(placeholder);
+  });
+  if (!match) throw new Error(`Unable to find placeholder: ${matcher}`);
+  return match;
+}
+
+function getByLabelText(matcher: Matcher) {
+  const ariaMatches = Array.from(document.body.querySelectorAll<HTMLElement>("*")).find((el) => {
+    const ariaLabel = el.getAttribute("aria-label");
+    if (!ariaLabel) return false;
+    if (typeof matcher === "string") return ariaLabel === matcher;
+    return matcher.test(ariaLabel);
+  });
+  if (ariaMatches) return ariaMatches;
+
+  const labels = Array.from(document.body.querySelectorAll<HTMLLabelElement>("label"));
+  for (const label of labels) {
+    if (matchesText(label, matcher)) {
+      const id = label.getAttribute("for");
+      if (id) {
+        const control = document.getElementById(id);
+        if (control) return control as HTMLElement;
+      }
+      if (label.firstElementChild) return label.firstElementChild as HTMLElement;
+    }
+  }
+  throw new Error(`Unable to find label: ${matcher}`);
+}
+
+function getByRole(role: string, { name }: { name?: Matcher } = {}) {
+  const elements = Array.from(document.body.querySelectorAll<HTMLElement>("*"));
+  for (const el of elements) {
+    if (el.getAttribute("role") === role) {
+      if (!name) return el;
+      const accessible = el.getAttribute("aria-label") || el.textContent || "";
+      if (typeof name === "string" ? accessible.includes(name) : name.test(accessible)) {
+        return el;
+      }
+    }
+  }
+  throw new Error(`Unable to find role: ${role}`);
+}
+
+async function waitFor<T>(callback: () => T, { timeout = 1000, interval = 25 } = {}): Promise<T> {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return callback();
+    } catch (error) {
+      if (Date.now() - start > timeout) throw error;
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+}
+
+function findByText(matcher: Matcher) {
+  return waitFor(() => getByText(matcher));
+}
+
+function findByLabelText(matcher: Matcher) {
+  return waitFor(() => getByLabelText(matcher));
+}
+
+function findByRole(role: string, options?: { name?: Matcher }) {
+  return waitFor(() => getByRole(role, options));
+}
+
+export function render(ui: React.ReactElement): RenderResult {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.add(root);
+  root.render(ui);
+
+  return {
+    container,
+    rerender(next) {
+      root.render(next);
+    },
+    unmount() {
+      root.unmount();
+      roots.delete(root);
+      container.remove();
+    },
+  };
+}
+
+export async function cleanup() {
+  roots.forEach((root) => root.unmount());
+  roots.clear();
+  document.body.innerHTML = "";
+}
+
+export const fireEvent = {
+  click(element: Element) {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  },
+  change(element: Element, init: { target?: { value?: any } } = {}) {
+    const target = element as HTMLInputElement;
+    if (init.target && "value" in init.target) {
+      target.value = init.target.value;
+    }
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  },
+  keyDown(element: Element, init: KeyboardEventInit) {
+    element.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init }));
+  },
+  keyUp(element: Element, init: KeyboardEventInit) {
+    element.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true, cancelable: true, ...init }));
+  },
+};
+
+export const screen = {
+  getByText,
+  findByText,
+  getByLabelText,
+  findByLabelText,
+  getByRole,
+  findByRole,
+  getByPlaceholderText,
+};
+
+export { waitFor };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,22 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@testing-library/react": path.resolve(__dirname, "src/test-utils/testing-library.ts"),
+      "@testing-library/jest-dom": path.resolve(__dirname, "src/test-utils/jest-dom.ts"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./vitest.setup.ts",
+  },
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Summary
### Wave 9
- Added SmartUndo toast component and wired Contacts/Deals to surface undo flows with /core/undo support.
- Delivered MorphingInput v2 with inline contact picker and calculator, integrated into Buoy Chat.
- Implemented Peripheral Vision audio cues with opt-in preference respecting reduced-sound settings.

### Wave 10
- Introduced AddonsStore manifest loader and updated Navi to render tiles from /api/addons with local enable toggles.
- Built Office 365 panel surfaced via feature flag within Navi, exposing mocked mail/document feed in Why drawer.

### Wave 11
- Implemented Semantic Zoom v2 with list/timeline/strategy levels and keyboard/gesture controls.
- Added Temporal Layer overlay for CRM/Deals showing past/now/future groupings with keyboard navigation.

## Screenshots / Recordings
- Unable to capture screenshots or GIFs in this environment.

## Testing
- `pnpm install` *(fails: registry 403 in container)*
- `pnpm lint` *(fails: missing React typings before install)*
- `pnpm test` *(fails: vitest binary unavailable prior to install)*
- `pnpm build` *(fails: vite binary unavailable prior to install)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5929352c832aa5dca95445061a9a