### PR TITLE
Include policy guard tests in meta Jest config

### DIFF
--- a/backend/jest.meta.config.cjs
+++ b/backend/jest.meta.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
     '<rootDir>/tests/genesis.autonomy.test.ts',
     '<rootDir>/tests/eventBus.stats.shape.test.ts',
     '<rootDir>/tests/mvp.crm-baseline.test.ts',
-    '<rootDir>/../tests/meta/**/*.test.ts'
+    '<rootDir>/../tests/meta/**/*.test.ts',
+    '<rootDir>/../tests/policy/**/*.test.ts'
   ],
 };


### PR DESCRIPTION
## Summary
- add the meta policy test glob to the backend Jest meta configuration so audit guard specs run with the existing suites

## Testing
- npm test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68ce5e5cb70c832aaf05bd67b0989d0a