### PR TITLE
Add WorkBuoy audit tooling and report

### DIFF
--- a/WORKBUOY_AUDIT.md
+++ b/WORKBUOY_AUDIT.md
@@ -1,0 +1,61 @@
+# WorkBuoy Suite Audit (47bea11)
+
+## Pillar coverage
+| Pillar | Status | Highlights |
+| --- | --- | --- |
+| Core | ✅ Present | Express CRM CRUD with RBAC audit logging anchors the domain API surface.【F:backend/src/app.ts†L1-L88】 |
+| Flex | ✅ Present | Dynamics connector orchestrates OAuth/mapping/metrics while the TS SDK wraps CRM endpoints for integrators.【F:connectors/dynamics/connector.js†L1-L39】【F:sdk/ts/workbuoy.ts†L1-L21】 |
+| Secure | ✅ Present | Secure bootstrap enables helmet/CORS/rate limiting and META scope checks on protected routes.【F:backend/src/app.secure.ts†L1-L22】【F:backend/meta/security.ts†L1-L21】 |
+| Navi | ✅ Present | Flip-card stitches Buoy chat with Navi grid, exposes keyboard flip controls, and surfaces introspection/health badges.【F:frontend/src/components/FlipCard.tsx†L1-L52】【F:frontend/src/features/navi/NaviGrid.tsx†L1-L74】 |
+| Buoy AI | ✅ Present | Single agent builds request context and runs plan/execute pipeline consumed by the chat UI.【F:src/buoy/agent.ts†L1-L95】【F:frontend/src/features/buoy/useBuoy.ts†L1-L18】 |
+| Roles | ✅ Present | Role registry composes feature caps from seeded profiles and drives role-aware proactivity APIs.【F:src/roles/registry.ts†L1-L49】【F:roles/roles.json†L10880-L10915】【F:backend/routes/proactivity.ts†L1-L60】 |
+| Proactivity | ✅ Present | Six named modes with degrade rails flow through context builders and telemetry-backed REST endpoints.【F:src/core/proactivity/modes.ts†L1-L170】【F:src/core/proactivity/context.ts†L1-L86】【F:backend/routes/proactivity.ts†L1-L60】 |
+| Meta | ✅ Present | META router instruments health/policy metrics and the genesis gatekeeper enforces `.evolution/APPROVED` before execution.【F:backend/meta/router.ts†L1-L123】【F:observability/metrics/meta.ts†L76-L118】【F:src/routes/genesis.autonomy.ts†L70-L118】 |
+| Infra | ✅ Present | Helm deployment, Prometheus alert rules, and a Grafana proactivity dashboard ship with the repo.【F:deploy/helm/workbuoy/templates/deployment.yaml†L1-L22】【F:observability/alerts/workbuoy_alerts.yaml†L1-L10】【F:grafana/dashboards/proactivity.json†L1-L30】 |
+| Adoption | ✅ Present | Multi-step onboarding, guarded demo seeding API, and deterministic insight nudges are delivered as code.【F:enterprise/onboarding.js†L1-L23】【F:crm/pages/api/onboarding/demo.ts†L1-L15】【F:src/insights/engine.ts†L1-L59】 |
+
+## Buoy AI (single assistant)
+- `src/buoy/agent.ts` is the sole orchestrator: it builds a `BuoyContext`, calls the planner/executor stack, logs events, and returns one explanation payload.【F:src/buoy/agent.ts†L5-L95】
+- The chat hook in `frontend/src/features/buoy/useBuoy.ts` seeds a single assistant thread and stubs responses without spinning up parallel agents.【F:frontend/src/features/buoy/useBuoy.ts†L3-L17】
+- The analysis tool confirms no plural assistant references in the tree (`plural_hits` is empty).【F:workbuoy-analysis.json†L7300-L7325】
+
+## Navi Flip-card UX
+- `frontend/src/components/FlipCard.tsx` renders Buoy (front) and Navi (back) faces with keyboard-driven flips, embeds `IntrospectionBadge`, and shows live health chips in the header.【F:frontend/src/components/FlipCard.tsx†L1-L52】
+- `IntrospectionBadge` fetches awareness snapshots (stubbed today) and adjusts UI states; wiring is ready for live data.【F:frontend/src/components/IntrospectionBadge.tsx†L1-L52】【F:frontend/src/api/introspection.ts†L1-L24】
+- `NaviGrid` + `useAddonsStore` hydrate the back of the card with manifest-driven tiles, filters, and CRM/O365 panels to emulate contextual navigation.【F:frontend/src/features/navi/NaviGrid.tsx†L1-L74】【F:frontend/src/features/addons/AddonsStore.ts†L20-L76】
+
+## Proactivity modes
+- `src/core/proactivity/modes.ts` enumerates the six required modes (usynlig→tsunami) with copy, UI hints, and degrade rail definitions.【F:src/core/proactivity/modes.ts†L1-L145】
+- `buildProactivityContext` composes subscription caps, role feature caps, and policy overrides into an effective mode with traceable basis strings.【F:src/core/proactivity/context.ts†L1-L86】
+- `backend/routes/proactivity.ts` exposes GET/POST APIs that resolve requested vs effective modes per tenant/role, logging telemetry via `logModusskift`.【F:backend/routes/proactivity.ts†L1-L60】【F:src/core/proactivity/telemetry.ts†L1-L24】
+- Proactivity data also powers Grafana dashboards and enterprise config presets (e.g., `core.config.json`), showing the modes are baked into config and observability layers.【F:grafana/dashboards/proactivity.json†L1-L30】【F:enterprise/public/config/core.config.json†L1-L44】
+
+## Meta rails
+- `backend/meta/router.ts` instruments every META endpoint with rate limits, `meta:read` scope enforcement, and histogram logging for metrics collection.【F:backend/meta/router.ts†L1-L123】【F:observability/metrics/meta.ts†L76-L118】
+- The `metaGenesisRouter` (exposed under `/genesis/*`) serves awareness snapshots, proposal scaffolding, and strictly requires `.evolution/APPROVED` before acknowledging evolution implementation, responding with a manual checklist instead of merging anything automatically.【F:src/routes/genesis.autonomy.ts†L70-L118】
+- META observability is backed by Prometheus counters/histograms and Grafana dashboards documented in `META_ROUTE_RUNBOOK.md`, aligning with the platform’s “rails” expectations.【F:observability/metrics/meta.ts†L1-L129】【F:META_ROUTE_RUNBOOK.md†L1-L60】
+
+## Roles
+- The seeded role library (`roles/roles.json`) captures domains, KPIs, autonomy caps, and policy hints consumed by runtime services.【F:roles/roles.json†L10880-L10915】
+- `RoleRegistry` resolves inherited roles, tenant overrides, and feature caps; it is wired directly into proactivity APIs and feature activation routes.【F:src/roles/registry.ts†L1-L49】【F:backend/routes/proactivity.ts†L1-L33】【F:backend/routes/features.ts†L1-L16】
+- Capability execution uses `runCapabilityWithRole` to enforce policy and proactivity behavior per resolved caps, linking role context back to Buoy AI/autonomy flows.【F:src/core/capabilityRunnerRole.ts†L1-L79】
+
+## Infra & observability
+- The Helm chart (`deploy/helm/workbuoy`) and Kubernetes deployment manifest set up container images, env vars, and services for cluster operation.【F:deploy/helm/workbuoy/templates/deployment.yaml†L1-L22】
+- Prometheus alerting (`observability/alerts/workbuoy_alerts.yaml`) and Grafana dashboards (e.g., `grafana/dashboards/proactivity.json`) provide telemetry for API health and autonomy degradations.【F:observability/alerts/workbuoy_alerts.yaml†L1-L10】【F:grafana/dashboards/proactivity.json†L1-L30】
+- META metrics expose counters/histograms via `observability/metrics/meta.ts`, ensuring telemetry is emitted even when Prometheus is absent (no-op fallbacks).【F:observability/metrics/meta.ts†L1-L129】
+
+## Adoption
+- The enterprise onboarding wizard walks operators through account creation, plan selection, connector setup, and provides progress affordances.【F:enterprise/onboarding.js†L1-L23】
+- `crm/pages/api/onboarding/demo.ts` seeds demo data only when `WB_DEMO_ENABLE` is true and the caller passes `requireWriteRole`, illustrating guardrails on onboarding flows.【F:crm/pages/api/onboarding/demo.ts†L1-L15】
+- The insights engine emits deterministic nudges with recommendations and policy rationale, ready to surface in Navi or Buoy chips.【F:src/insights/engine.ts†L1-L59】
+
+## Violations
+- `enterprise/pages/api/meta/apply.js` writes patches directly to disk from an HTTP handler, breaching the “no git/fs writes from HTTP” rail.【F:enterprise/pages/api/meta/apply.js†L1-L21】【F:workbuoy-analysis.json†L7327-L7333】
+- `enterprise/pages/api/wb2wb/policy.update.js` persists tenant policy JSON via `fs.writeFileSync` inside a Next.js API route, also violating the rails requirement.【F:enterprise/pages/api/wb2wb/policy.update.js†L1-L25】【F:workbuoy-analysis.json†L7334-L7338】
+
+## What’s next
+- [ ] Move the meta patching/policy update flows behind CLI or queue processors so HTTP routes no longer perform filesystem writes.【F:enterprise/pages/api/meta/apply.js†L1-L21】【F:enterprise/pages/api/wb2wb/policy.update.js†L1-L25】【F:workbuoy-analysis.json†L7327-L7338】
+- [ ] Replace the stubbed `fetchIntrospectionReport` with calls to the live `metaGenesis` endpoints to surface real awareness snapshots in the flip-card header.【F:frontend/src/api/introspection.ts†L1-L24】【F:src/routes/genesis.autonomy.ts†L77-L118】
+- [ ] Extend Buoy’s runtime (`runCapabilityWithRole` + connectors) to power the chat surface instead of the hard-coded stub responses, closing the loop between agent actions and backend capabilities.【F:src/core/capabilityRunnerRole.ts†L14-L79】【F:frontend/src/features/buoy/useBuoy.ts†L3-L17】
+- [ ] Apply the `.evolution/APPROVED` gate or retire the legacy `/api/meta-evolution` POST handlers that currently simulate evolution without approval checks.【F:backend/src/meta-evolution/routes/evolution.routes.ts†L13-L74】

--- a/tools/analyze-workbuoy.mjs
+++ b/tools/analyze-workbuoy.mjs
@@ -1,0 +1,597 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const skipDirNames = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  '.cache',
+  '.venv',
+  'venv',
+  'coverage',
+  'out',
+  'tmp',
+  'temp',
+  '__pycache__',
+  '.idea',
+  '.vscode',
+  '.DS_Store'
+]);
+
+const pillarConfig = {
+  CORE: {
+    indicators: [
+      'backend',
+      'core',
+      'services',
+      'src',
+      'types',
+      'db',
+      'database',
+      'prisma',
+      'api',
+      'data'
+    ]
+  },
+  FLEX: {
+    indicators: [
+      'integrations',
+      'integration',
+      'connectors',
+      'connector',
+      'sdk',
+      'automation',
+      'automations',
+      'workflow',
+      'workflows',
+      'examples',
+      'prototypes',
+      'plugins',
+      'extensions'
+    ]
+  },
+  SECURE: {
+    indicators: [
+      'secure',
+      'security',
+      'roles',
+      'policy',
+      'governance',
+      'auth',
+      'rbac',
+      'abac',
+      'compliance',
+      'meta_route',
+      'meta-route',
+      'meta_route',
+      'meta-route'
+    ]
+  },
+  NAVI: {
+    indicators: [
+      'frontend',
+      'ui',
+      'desktop',
+      'desktop_demo',
+      'navi',
+      'ux',
+      'client',
+      'web',
+      'cards',
+      'ui-kit'
+    ]
+  },
+  BUOY_AI: {
+    indicators: [
+      'ai',
+      'assistant',
+      'llm',
+      'chat',
+      'prompt',
+      'meta',
+      'openai',
+      'buoy'
+    ]
+  },
+  ROLES: {
+    indicators: [
+      'roles',
+      'role',
+      'rbac',
+      'abac',
+      'authz',
+      'access'
+    ]
+  },
+  PROACTIVITY: {
+    indicators: [
+      'proactivity',
+      'proactive',
+      'proaktiv',
+      'assistive',
+      'automated',
+      'tsunami',
+      'kraken',
+      'rolig',
+      'usynlig',
+      'ambisi',
+      'nudges'
+    ]
+  },
+  META: {
+    indicators: [
+      'meta',
+      '.evolution',
+      'evolution',
+      'genesis',
+      'autonomous',
+      'gatekeeper'
+    ]
+  },
+  INFRA: {
+    indicators: [
+      'deploy',
+      'deployment',
+      'manifests',
+      'manifest',
+      'ops',
+      'infra',
+      'helm',
+      'k8s',
+      'kubernetes',
+      'docker',
+      'observability',
+      'grafana',
+      'alert',
+      'telemetry',
+      'monitoring'
+    ]
+  },
+  ADOPTION: {
+    indicators: [
+      'adoption',
+      'onboarding',
+      'templates',
+      'template',
+      'nudges',
+      'playbooks',
+      'samples',
+      'examples',
+      'starter',
+      'tutorial',
+      'guides'
+    ]
+  }
+};
+
+const docExtensions = new Set(['.md', '.mdx', '.txt', '.rst', '.adoc']);
+const codeExtensions = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.go',
+  '.java',
+  '.rb',
+  '.rs',
+  '.cs',
+  '.php',
+  '.kt',
+  '.swift',
+  '.scala',
+  '.sql',
+  '.prisma',
+  '.sh',
+  '.ps1'
+]);
+const configExtensions = new Set([
+  '.json',
+  '.yml',
+  '.yaml',
+  '.toml',
+  '.ini',
+  '.env',
+  '.cfg',
+  '.conf',
+  '.xml',
+  '.properties',
+  '.proto',
+  '.graphql'
+]);
+
+const httpMethodRegex = /(app|router|route|server|fastify|express|koa|h3|handler)\s*[\.\[]\s*(get|post|put|delete|patch|options|head)/i;
+const nextRouteRegex = /export\s+async\s+function\s+(GET|POST|PUT|DELETE|PATCH)/i;
+const httpPathSegments = new Set(['api', 'routes', 'route', 'router', 'controllers', 'handlers', 'endpoints']);
+const httpRouteFileNames = new Set([
+  'route.ts',
+  'route.tsx',
+  'route.js',
+  'route.jsx',
+  'route.mjs',
+  'route.cjs'
+]);
+const fsWriteRegex = /\bfs(?:\.promises)?\.(writeFile|appendFile|createWriteStream|writeFileSync|appendFileSync|rm|rmdir|mkdir|unlink|rename|copyFile|cp|mv|chmod|chown|outputFile|outputJson)\b/;
+const fsExtraWriteRegex = /\bfsExtra\.(write|output|ensure|copy|move|mkdirp)/i;
+const childProcessGitRegex = /(exec|spawn|execSync|spawnSync)\([^\)]*git/i;
+
+const signalRegexes = {
+  META_SAFEGUARDS: [
+    /genesis\/[a-z0-9_-]*introspection-report/i,
+    /genesis\/[a-z0-9_-]*autonomous/i,
+    /genetics\/[a-z0-9_-]*evolution/i,
+    /\.evolution\/?approved/i,
+    /evolution\s+gatekeeper/i,
+    /approval[_-]?required/i,
+    /meta[_-]?evolution/i,
+    /no\s+git/i,
+    /no\s+fs/i,
+    /http\s+merge/i
+  ],
+  FLIPCARD: [
+    /flip\s*-?card/i,
+    /flipcard/i,
+    /flipkort/i,
+    /front\s*=\s*buoy/i,
+    /back\s*=\s*navi/i,
+    /card\s+flip/i
+  ],
+  PROACTIVITY: [
+    /proactiv/i,
+    /usynlig/i,
+    /rolig/i,
+    /ambisi[øo]s/i,
+    /kraken/i,
+    /tsunami/i,
+    /silent\s+mode/i,
+    /suggestive/i,
+    /advisory/i,
+    /assistive/i,
+    /automated/i
+  ],
+  ROLES: [
+    /\bRBAC\b/i,
+    /\bABAC\b/i,
+    /role-based/i,
+    /role\s+library/i,
+    /role\s+map/i,
+    /role\s+guard/i,
+    /role\s+check/i,
+    /\bRole[A-Z][A-Za-z0-9_]*/
+  ],
+  SECURE_RAILS: [
+    /approval\s+gate/i,
+    /approval[_-]?required/i,
+    /guardrail/i,
+    /guard\s*rail/i,
+    /governance/i,
+    /policy\s+(engine|enforcement|check|guard)/i,
+    /meta\s+route/i,
+    /evolution\s+gatekeeper/i,
+    /role\s+guard/i,
+    /no\s+git/i,
+    /no\s+fs/i
+  ]
+};
+
+const pluralAssistantRegexes = [
+  /\bassistants\b/i,
+  /multiple\s+assistants/i,
+  /multi-?assistant/i,
+  /assistant\s+pool/i
+];
+const singularAssistantRegexes = [
+  /buoy\s+ai/i,
+  /single\s+assistant/i,
+  /the\s+assistant/i
+];
+
+const pillarState = {};
+for (const key of Object.keys(pillarConfig)) {
+  pillarState[key] = {
+    dirs: new Set(),
+    code: new Set(),
+    docs: new Set()
+  };
+}
+
+const signals = {
+  META_SAFEGUARDS: [],
+  FLIPCARD: [],
+  PROACTIVITY: [],
+  ROLES: [],
+  SECURE_RAILS: [],
+  BUOY_ASSISTANT_SINGULAR: {
+    singular_mentions: [],
+    plural_hits: []
+  }
+};
+
+const signalSeen = {};
+for (const key of Object.keys(signalRegexes)) {
+  signalSeen[key] = new Set();
+}
+
+const violations = {
+  http_write_ops: [],
+  missing_approval_gate: []
+};
+
+function matchesIndicator(relPath, indicator) {
+  const lower = relPath.toLowerCase();
+  const key = indicator.toLowerCase();
+  if (lower === key) return true;
+  if (lower.endsWith('/' + key)) return true;
+  if (lower.includes('/' + key + '/')) return true;
+  if (lower.startsWith(key + '/')) return true;
+  if (lower.includes('/' + key + '-')) return true;
+  if (lower.includes('/' + key + '_')) return true;
+  if (lower.includes('-' + key + '/')) return true;
+  if (lower.includes('_' + key + '/')) return true;
+  if (lower.includes('/' + key + '.')) return true;
+  if (lower.includes('/' + key + '\\')) return true;
+  return lower.includes(key) && key.length > 3;
+}
+
+function isDocFile(relPath) {
+  const ext = path.extname(relPath).toLowerCase();
+  if (docExtensions.has(ext)) return true;
+  const base = path.basename(relPath).toLowerCase();
+  if (base.startsWith('readme')) return true;
+  if (base === 'license' || base === 'changelog' || base === 'contributing') return true;
+  if (base.endsWith('.md')) return true;
+  return false;
+}
+
+function isCodeFile(relPath) {
+  const ext = path.extname(relPath).toLowerCase();
+  if (codeExtensions.has(ext)) return true;
+  const base = path.basename(relPath).toLowerCase();
+  if (base === 'dockerfile' || base === 'makefile' || base.endsWith('.make')) return true;
+  if (ext === '.tsconfig') return true;
+  return false;
+}
+
+function isConfigFile(relPath) {
+  const ext = path.extname(relPath).toLowerCase();
+  if (configExtensions.has(ext)) return true;
+  const base = path.basename(relPath).toLowerCase();
+  if (base === 'dockerfile' || base === 'makefile') return true;
+  if (base.endsWith('.config') || base.endsWith('.conf')) return true;
+  return false;
+}
+
+function trackPillar(pillar, type, relPath) {
+  if (!pillarState[pillar]) return;
+  if (type === 'dir') {
+    pillarState[pillar].dirs.add(relPath);
+  } else if (type === 'code') {
+    pillarState[pillar].code.add(relPath);
+  } else if (type === 'doc') {
+    pillarState[pillar].docs.add(relPath);
+  }
+}
+
+function addSignal(signal, relPath, lineNumber, lineText) {
+  if (!signals[signal]) return;
+  const snippet = lineText.trim().slice(0, 240);
+  signals[signal].push({ file: relPath, line: lineNumber, match: snippet });
+}
+
+function addAssistantSignal(type, relPath, lineNumber, lineText) {
+  if (relPath === 'tools/analyze-workbuoy.mjs') {
+    return;
+  }
+  const snippet = lineText.trim().slice(0, 240);
+  signals.BUOY_ASSISTANT_SINGULAR[type].push({ file: relPath, line: lineNumber, match: snippet });
+}
+
+function walk(currentDir) {
+  const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(currentDir, entry.name);
+    const relPath = path.relative(repoRoot, fullPath);
+    if (entry.isDirectory()) {
+      if (skipDirNames.has(entry.name)) continue;
+      for (const [pillar, config] of Object.entries(pillarConfig)) {
+        for (const indicator of config.indicators) {
+          if (matchesIndicator(relPath, indicator)) {
+            trackPillar(pillar, 'dir', relPath + '/');
+            break;
+          }
+        }
+      }
+      walk(fullPath);
+    } else if (entry.isFile()) {
+      processFile(fullPath, relPath);
+    }
+  }
+}
+
+function processFile(fullPath, relPath) {
+  const doc = isDocFile(relPath);
+  const code = isCodeFile(relPath) || isConfigFile(relPath);
+
+  for (const [pillar, config] of Object.entries(pillarConfig)) {
+    for (const indicator of config.indicators) {
+      if (matchesIndicator(relPath, indicator)) {
+        if (code) {
+          trackPillar(pillar, 'code', relPath);
+        } else if (doc) {
+          trackPillar(pillar, 'doc', relPath);
+        }
+        break;
+      }
+    }
+  }
+
+  const stats = fs.statSync(fullPath);
+  if (stats.size > 2 * 1024 * 1024) {
+    return;
+  }
+
+  let buffer;
+  try {
+    buffer = fs.readFileSync(fullPath);
+  } catch (err) {
+    return;
+  }
+
+  if (buffer.includes(0)) {
+    return;
+  }
+
+  let content;
+  try {
+    content = buffer.toString('utf8');
+  } catch (err) {
+    return;
+  }
+
+  const lowerPath = relPath.toLowerCase();
+  const pathSegments = lowerPath.split(/[\\/]/).filter(Boolean);
+  const isTestLike =
+    pathSegments.includes('__tests__') ||
+    pathSegments.includes('__mocks__') ||
+    /\.test\./.test(lowerPath) ||
+    /\.spec\./.test(lowerPath);
+
+  let httpByPath = false;
+  for (let i = 0; i < pathSegments.length; i += 1) {
+    const segment = pathSegments[i];
+    if (httpPathSegments.has(segment)) {
+      httpByPath = true;
+      break;
+    }
+    const next = pathSegments[i + 1];
+    if ((segment === 'pages' || segment === 'app') && next === 'api') {
+      httpByPath = true;
+      break;
+    }
+  }
+
+  const baseLower = path.basename(lowerPath);
+  if (!httpByPath && httpRouteFileNames.has(baseLower)) {
+    httpByPath = true;
+  }
+
+  let httpByContent = false;
+
+  const lines = content.split(/\r?\n/);
+  const pendingWriteOps = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (
+      !httpByContent &&
+      (httpMethodRegex.test(line) ||
+        nextRouteRegex.test(line) ||
+        /\bcreateRouter\b/i.test(line) ||
+        /\bNextApiRequest\b/i.test(line) ||
+        /\bRequestHandler\b/i.test(line) ||
+        /router\.use\(/i.test(line) ||
+        /export\s+const\s+GET\s*=\s*/i.test(line))
+    ) {
+      httpByContent = true;
+    }
+
+    if (fsWriteRegex.test(line) || fsExtraWriteRegex.test(line) || childProcessGitRegex.test(line)) {
+      pendingWriteOps.push({ line: i + 1, snippet: trimmed.slice(0, 200) });
+    }
+
+    for (const [signal, regexList] of Object.entries(signalRegexes)) {
+      for (let idx = 0; idx < regexList.length; idx += 1) {
+        const regex = regexList[idx];
+        if (regex.test(line)) {
+          const key = `${relPath}:${i + 1}:${idx}`;
+          if (!signalSeen[signal].has(key)) {
+            signalSeen[signal].add(key);
+            if (signal === 'ROLES' && doc) {
+              continue;
+            }
+            addSignal(signal, relPath, i + 1, line);
+          }
+        }
+      }
+    }
+
+    for (const regex of singularAssistantRegexes) {
+      if (regex.test(line)) {
+        addAssistantSignal('singular_mentions', relPath, i + 1, line);
+        break;
+      }
+    }
+
+    for (const regex of pluralAssistantRegexes) {
+      if (regex.test(line)) {
+        addAssistantSignal('plural_hits', relPath, i + 1, line);
+        break;
+      }
+    }
+  }
+
+  const isHttpFile = !isTestLike && (httpByPath || httpByContent);
+
+  if (isHttpFile) {
+    for (const op of pendingWriteOps) {
+      violations.http_write_ops.push({ file: relPath, line: op.line, snippet: op.snippet });
+    }
+  }
+}
+
+walk(repoRoot);
+
+const summary = {};
+const files = {};
+
+for (const [pillar, state] of Object.entries(pillarState)) {
+  const hasCode = state.code.size > 0;
+  const hasDocs = state.docs.size > 0;
+  const hasDirs = state.dirs.size > 0;
+  let status = 'missing';
+  if (hasCode) {
+    status = 'present';
+  } else if (hasDirs || hasDocs) {
+    status = 'partial';
+  }
+  summary[pillar] = status;
+  const combined = new Set([...state.dirs, ...state.code, ...state.docs]);
+  files[pillar] = Array.from(combined).sort().slice(0, 120);
+}
+
+const approvalPatterns = [/\.evolution\/?approved/i, /approval[_-]?required/i, /evolution\s+gatekeeper/i];
+const hasApprovalSignal = signals.META_SAFEGUARDS.some((entry) => approvalPatterns.some((regex) => regex.test(entry.match)));
+if (!hasApprovalSignal) {
+  violations.missing_approval_gate.push({ file: null, reason: 'No approval gate references detected (.evolution/APPROVED, approval_required, or evolution gatekeeper).' });
+}
+
+let head = null;
+try {
+  head = execSync('git rev-parse --short HEAD', { cwd: repoRoot }).toString().trim();
+} catch (err) {
+  head = null;
+}
+
+const result = {
+  head,
+  summary,
+  files,
+  signals,
+  violations
+};
+
+console.log(JSON.stringify(result, null, 2));

--- a/workbuoy-analysis.json
+++ b/workbuoy-analysis.json
@@ -1,0 +1,7342 @@
+{
+  "head": "47bea11",
+  "summary": {
+    "CORE": "present",
+    "FLEX": "present",
+    "SECURE": "present",
+    "NAVI": "present",
+    "BUOY_AI": "present",
+    "ROLES": "present",
+    "PROACTIVITY": "present",
+    "META": "present",
+    "INFRA": "present",
+    "ADOPTION": "present"
+  },
+  "files": {
+    "CORE": [
+      ".github/workflows/backend-ci.yml",
+      "PATCHES/DB_SETUP.md",
+      "README_PR6_CORE_POLICY_INTENTLOG.md",
+      "backend/",
+      "backend/README_PR_A.md",
+      "backend/README_PR_B.md",
+      "backend/README_PR_D.md",
+      "backend/README_PR_E.md",
+      "backend/README_PR_L.md",
+      "backend/README_PR_M.md",
+      "backend/README_PR_N.md",
+      "backend/api/",
+      "backend/api/meta.mount.ts",
+      "backend/jest.ci.config.cjs",
+      "backend/jest.config.cjs",
+      "backend/jest.config.js",
+      "backend/jest.meta.config.cjs",
+      "backend/meta/",
+      "backend/meta/auditStats.ts",
+      "backend/meta/capabilities.ts",
+      "backend/meta/health.ts",
+      "backend/meta/policy.ts",
+      "backend/meta/probes/",
+      "backend/meta/probes/baseProbe.ts",
+      "backend/meta/probes/dbProbe.ts",
+      "backend/meta/probes/index.ts",
+      "backend/meta/probes/outboundProbe.ts",
+      "backend/meta/probes/queueProbe.ts",
+      "backend/meta/probes/types.ts",
+      "backend/meta/readiness.ts",
+      "backend/meta/router.ts",
+      "backend/meta/runtimeState.ts",
+      "backend/meta/security.ts",
+      "backend/meta/types.ts",
+      "backend/meta/version.ts",
+      "backend/package.json",
+      "backend/prisma/",
+      "backend/prisma/extra/",
+      "backend/prisma/extra/audit_worm.sql",
+      "backend/prisma/migrations/",
+      "backend/prisma/migrations/20250827_initial/",
+      "backend/prisma/migrations/20250827_initial/migration.sql",
+      "backend/prisma/schema.prisma",
+      "backend/routes/",
+      "backend/routes/admin.subscription.ts",
+      "backend/routes/dev.runner.ts",
+      "backend/routes/explainability.ts",
+      "backend/routes/features.ts",
+      "backend/routes/jobboards.dev.ts",
+      "backend/routes/metrics.ts",
+      "backend/routes/proactivity.ts",
+      "backend/routes/usage.ts",
+      "backend/src/",
+      "backend/src/app.secure.ts",
+      "backend/src/app.ts",
+      "backend/src/audit/",
+      "backend/src/audit/audit.ts",
+      "backend/src/audit/export.ts",
+      "backend/src/audit/log.ts",
+      "backend/src/audit/logger.ts",
+      "backend/src/common/",
+      "backend/src/common/README_ADAPTIVE_INTEGRATION.md",
+      "backend/src/compliance/",
+      "backend/src/compliance/app.ts",
+      "backend/src/compliance/audit.ts",
+      "backend/src/compliance/server.ts",
+      "backend/src/compliance/webhooks.ts",
+      "backend/src/connectors/",
+      "backend/src/connectors/core/",
+      "backend/src/connectors/core/mapper.ts",
+      "backend/src/connectors/core/types.ts",
+      "backend/src/connectors/crmPush.ts",
+      "backend/src/connectors/dynamics/",
+      "backend/src/connectors/dynamics/auth.ts",
+      "backend/src/connectors/dynamics/mapping.ts",
+      "backend/src/connectors/dynamics/metrics.ts",
+      "backend/src/connectors/dynamics/upsert.ts",
+      "backend/src/connectors/dynamics/worker-cli.ts",
+      "backend/src/connectors/dynamics/worker.ts",
+      "backend/src/connectors/index.ts",
+      "backend/src/connectors/mapping.ts",
+      "backend/src/connectors/metrics.ts",
+      "backend/src/connectors/providers/",
+      "backend/src/connectors/providers/dynamics.ts",
+      "backend/src/connectors/providers/hubspot.ts",
+      "backend/src/connectors/providers/salesforce.ts",
+      "backend/src/connectors/queue.ts",
+      "backend/src/connectors/routes.ts",
+      "backend/src/connectors/salesforce/",
+      "backend/src/connectors/salesforce/auth.ts",
+      "backend/src/connectors/salesforce/mapping.ts",
+      "backend/src/connectors/salesforce/metrics.ts",
+      "backend/src/connectors/salesforce/upsert.ts",
+      "backend/src/connectors/salesforce/worker-cli.ts",
+      "backend/src/connectors/salesforce/worker.ts",
+      "backend/src/connectors/signature.ts",
+      "backend/src/connectors/types.ts",
+      "backend/src/connectors/webhooks.ts",
+      "backend/src/connectors/worker-cli.ts",
+      "backend/src/connectors/worker.ts",
+      "backend/src/connectors/worker_queue.ts",
+      "backend/src/crm/",
+      "backend/src/crm/dummy_mutations.ts",
+      "backend/src/crm/import_export.ts",
+      "backend/src/crm/import_export_routes.ts",
+      "backend/src/crm/models.ts",
+      "backend/src/crm/pipeline.ts",
+      "backend/src/crm/rbacGuard.ts",
+      "backend/src/crm/repo.ts",
+      "backend/src/crm/routes.db.ts",
+      "backend/src/crm/routes.ts",
+      "backend/src/crm/validation.ts",
+      "backend/src/db/",
+      "backend/src/db/knex.ts",
+      "backend/src/db/migrate.ts",
+      "backend/src/db/prisma.ts",
+      "backend/src/db/redis.ts",
+      "backend/src/docs/",
+      "backend/src/docs/swagger.ts",
+      "backend/src/identity/"
+    ],
+    "FLEX": [
+      ".github/workflows/",
+      ".github/workflows/auto-merge.yml",
+      ".github/workflows/backend-ci.yml",
+      ".github/workflows/meta-pr1-ci.yml",
+      ".github/workflows/meta-pr2-ci.yml",
+      ".github/workflows/openapi-lint.yml",
+      "api-docs/openapi_connectors.yaml",
+      "backend/src/common/README_ADAPTIVE_INTEGRATION.md",
+      "backend/src/connectors/",
+      "backend/src/connectors/core/",
+      "backend/src/connectors/core/mapper.ts",
+      "backend/src/connectors/core/types.ts",
+      "backend/src/connectors/crmPush.ts",
+      "backend/src/connectors/dynamics/",
+      "backend/src/connectors/dynamics/auth.ts",
+      "backend/src/connectors/dynamics/mapping.ts",
+      "backend/src/connectors/dynamics/metrics.ts",
+      "backend/src/connectors/dynamics/upsert.ts",
+      "backend/src/connectors/dynamics/worker-cli.ts",
+      "backend/src/connectors/dynamics/worker.ts",
+      "backend/src/connectors/index.ts",
+      "backend/src/connectors/mapping.ts",
+      "backend/src/connectors/metrics.ts",
+      "backend/src/connectors/providers/",
+      "backend/src/connectors/providers/dynamics.ts",
+      "backend/src/connectors/providers/hubspot.ts",
+      "backend/src/connectors/providers/salesforce.ts",
+      "backend/src/connectors/queue.ts",
+      "backend/src/connectors/routes.ts",
+      "backend/src/connectors/salesforce/",
+      "backend/src/connectors/salesforce/auth.ts",
+      "backend/src/connectors/salesforce/mapping.ts",
+      "backend/src/connectors/salesforce/metrics.ts",
+      "backend/src/connectors/salesforce/upsert.ts",
+      "backend/src/connectors/salesforce/worker-cli.ts",
+      "backend/src/connectors/salesforce/worker.ts",
+      "backend/src/connectors/signature.ts",
+      "backend/src/connectors/types.ts",
+      "backend/src/connectors/webhooks.ts",
+      "backend/src/connectors/worker-cli.ts",
+      "backend/src/connectors/worker.ts",
+      "backend/src/connectors/worker_queue.ts",
+      "backend/tests/connectors.hubspot.test.ts",
+      "backend/tests/connectors.test.ts",
+      "backend/tests/connectors.webhook.test.ts",
+      "connectors/",
+      "connectors/dynamics/",
+      "connectors/dynamics/__tests__/",
+      "connectors/dynamics/__tests__/upsert.test.js",
+      "connectors/dynamics/adaptive_fetch.js",
+      "connectors/dynamics/client.js",
+      "connectors/dynamics/connector.js",
+      "connectors/dynamics/dlq.js",
+      "connectors/dynamics/examples/",
+      "connectors/dynamics/examples/contact_event.json",
+      "connectors/dynamics/examples/opportunity_event.json",
+      "connectors/dynamics/jest.config.js",
+      "connectors/dynamics/mapper.js",
+      "connectors/dynamics/mapping.yaml",
+      "connectors/dynamics/metrics.js",
+      "connectors/dynamics/oauth.js",
+      "connectors/dynamics/package.json",
+      "connectors/dynamics/worker-cli.js",
+      "connectors/salesforce/",
+      "connectors/salesforce/__tests__/",
+      "connectors/salesforce/__tests__/upsert.test.js",
+      "connectors/salesforce/client.js",
+      "connectors/salesforce/connector.js",
+      "connectors/salesforce/dlq.js",
+      "connectors/salesforce/examples/",
+      "connectors/salesforce/examples/contact_event.json",
+      "connectors/salesforce/examples/opportunity_event.json",
+      "connectors/salesforce/jest.config.js",
+      "connectors/salesforce/mapper.js",
+      "connectors/salesforce/mapping.yaml",
+      "connectors/salesforce/metrics.js",
+      "connectors/salesforce/oauth.js",
+      "connectors/salesforce/package.json",
+      "connectors/salesforce/worker-cli.js",
+      "crm/.github/workflows/",
+      "crm/.github/workflows/ci.yml",
+      "desktop/.github/workflows/",
+      "desktop/.github/workflows/build.yml",
+      "desktop/.github/workflows/ci.yml",
+      "desktop/.github/workflows/release.yml",
+      "desktop/db/migrations/006_sync_queue_org_and_workflow.sql",
+      "desktop/docs/dashboards/plugins.json",
+      "desktop/examples/",
+      "desktop/examples/desktop/",
+      "desktop/examples/desktop/ai-insights/",
+      "desktop/examples/desktop/ai-insights/README.md",
+      "desktop/examples/desktop/offline-sync/",
+      "desktop/examples/desktop/offline-sync/README.md",
+      "desktop/examples/desktop/plugins/",
+      "desktop/examples/desktop/plugins/README.md",
+      "desktop/integrations/",
+      "desktop/integrations/google-calendar.js",
+      "desktop/integrations/hubspot.js",
+      "desktop/integrations/index.js",
+      "desktop/integrations/manifest/",
+      "desktop/integrations/manifest/google-calendar.json",
+      "desktop/integrations/manifest/hubspot.json",
+      "desktop/integrations/manifest/office365.json",
+      "desktop/integrations/office365.js",
+      "desktop/integrations/signature.js",
+      "desktop/renderer/plugins/",
+      "desktop/renderer/plugins/gallery.js",
+      "desktop/tests/e2e/plugins-signature.spec.mjs",
+      "desktop/tests/e2e/plugins-verify-badge.spec.mjs",
+      "desktop/tests/unit/plugins.test.js",
+      "docs/CONNECTORS.md",
+      "docs/CONNECTOR_DYNAMICS.md",
+      "docs/CONNECTOR_OBSERVABILITY.md",
+      "docs/CONNECTOR_SALESFORCE.md",
+      "docs/CONNECTOR_SFDC.md",
+      "docs/SDK_PUBLISHING.md",
+      "docs/integration-plan.md",
+      "docs/ui_undo_integration.md",
+      "enterprise/.github/workflows/",
+      "enterprise/.github/workflows/backlog.json"
+    ],
+    "SECURE": [
+      "META_ROUTE_README.md",
+      "META_ROUTE_RUNBOOK.md",
+      "PATCHES/CRM_POLICY.md",
+      "PR2_remove-legacy-routes-policy/",
+      "PR2_remove-legacy-routes-policy/PR_BODY.md",
+      "README_PR2_POLICY.md",
+      "README_PR6_CORE_POLICY_INTENTLOG.md",
+      "SECURITY.md",
+      "backend/meta/policy.ts",
+      "backend/meta/security.ts",
+      "backend/src/app.secure.ts",
+      "backend/src/compliance/",
+      "backend/src/compliance/app.ts",
+      "backend/src/compliance/audit.ts",
+      "backend/src/compliance/server.ts",
+      "backend/src/compliance/webhooks.ts",
+      "backend/src/connectors/dynamics/auth.ts",
+      "backend/src/connectors/salesforce/auth.ts",
+      "backend/src/crm/rbacGuard.ts",
+      "backend/src/middleware/rbac.ts",
+      "backend/src/middleware/security.ts",
+      "backend/src/rbac/",
+      "backend/src/rbac/audit.ts",
+      "backend/src/rbac/binding.ts",
+      "backend/src/rbac/enforce.ts",
+      "backend/src/rbac/middleware.ts",
+      "backend/src/rbac/policies.ts",
+      "backend/src/rbac/policy.ts",
+      "backend/src/rbac/routes.ts",
+      "backend/src/rbac/service.ts",
+      "backend/src/security/",
+      "backend/src/security/cors.ts",
+      "backend/src/security/helmet.ts",
+      "backend/src/security/rateLimit.ts",
+      "backend/src/security/secrets.ts",
+      "backend/tests/api.security.test.ts",
+      "backend/tests/compliance_api.test.ts",
+      "backend/tests/dyn_auth.test.ts",
+      "backend/tests/rbac.binding.test.ts",
+      "backend/tests/rbac.enforce.test.ts",
+      "backend/tests/rbac.routes.test.ts",
+      "backend/tests/rbac.test.ts",
+      "backend/tests/rbac_policy.test.ts",
+      "backend/tests/rbac_record_level.test.ts",
+      "backend/tests/sfdc_auth_jwt.test.ts",
+      "config/policy.rules.json",
+      "connectors/dynamics/oauth.js",
+      "connectors/salesforce/oauth.js",
+      "core/policy.ts",
+      "core/roles/",
+      "core/roles/README.md",
+      "core/roles/index.js",
+      "core/roles/role.schema.json",
+      "core/roles/roles.json",
+      "core/roles/validate_roles.js",
+      "crm/pages/api/auth/",
+      "crm/pages/api/auth/oidc/",
+      "crm/pages/api/auth/oidc/callback.ts",
+      "crm/pages/api/auth/oidc/initiate.ts",
+      "crm/pages/api/auth/saml/",
+      "crm/pages/api/auth/saml/acs.ts",
+      "db/migrations/roles.sql",
+      "deployment/linux/policy.json",
+      "desktop/auth-bridge.js",
+      "desktop/cache/secure_cache.js",
+      "desktop/crypto/secure_key.js",
+      "desktop/src/crypto/secureStorage.js",
+      "desktop/src/policy.ts",
+      "desktop/src/policy/",
+      "desktop/src/policy/index.ts",
+      "desktop/src/policy/loader.ts",
+      "desktop/src/policy/types.ts",
+      "desktop/src/storage/secureDb.ts",
+      "desktop/src/tests/policy_loader.test.ts",
+      "desktop/tests/e2e/rbac-deny.spec.mjs",
+      "desktop/tests/secure_cache.test.js",
+      "desktop/tests/unit/rbac.test.js",
+      "docs/DESKTOP_SECURITY.md",
+      "docs/POLICY_V2.md",
+      "docs/RBAC_ENFORCEMENT.md",
+      "docs/RBAC_POLICY.md",
+      "docs/RBAC_TESTS.md",
+      "docs/SECURITY.md",
+      "docs/SECURITY_HARDENING.md",
+      "docs/SECURITY_V1.md",
+      "docs/SSO_SCIM_RBAC.md",
+      "docs/auto/roles_gate_README.md",
+      "docs/compliance/",
+      "docs/compliance/GDPR_README.md",
+      "docs/compliance/PRIVACY_WEBHOOKS.md",
+      "docs/compliance/SOC2_ISO27001_PRACTICES.md",
+      "docs/compliance/openapi_compliance.yaml",
+      "docs/crm_policy_write.md",
+      "docs/secure.md",
+      "enterprise/.github/workflows/security.yml",
+      "enterprise/SECURE.md",
+      "enterprise/SECURE_CONTROLS.md",
+      "enterprise/SECURITY.md",
+      "enterprise/SECURITY_TESTING.md",
+      "enterprise/__tests__/auth.errors.test.js",
+      "enterprise/__tests__/auth.test.js",
+      "enterprise/__tests__/e2e/secure_flows.spec.ts",
+      "enterprise/__tests__/rbac.test.js",
+      "enterprise/__tests__/roles.errors.test.js",
+      "enterprise/__tests__/roles.test.js",
+      "enterprise/__tests__/unit/portal-rbac.test.js",
+      "enterprise/__tests__/unit/rbac-metrics.test.js",
+      "enterprise/__tests__/unit/rbac.tenant.test.js",
+      "enterprise/api/secure/",
+      "enterprise/api/secure/dsr/",
+      "enterprise/api/secure/dsr/index.js",
+      "enterprise/api/secure/dsr/router.js",
+      "enterprise/auth.js",
+      "enterprise/auth/",
+      "enterprise/auth/login.js",
+      "enterprise/auth/me.js",
+      "enterprise/auth/oidc-callback.js",
+      "enterprise/auth/oidc-login.js",
+      "enterprise/compliance/",
+      "enterprise/compliance/CHECKLIST.md"
+    ],
+    "NAVI": [
+      "backend/src/redis/client.ts",
+      "backend/tests/__mocks__/prom-client.ts",
+      "connectors/dynamics/client.js",
+      "connectors/salesforce/client.js",
+      "desktop/",
+      "desktop/.github/",
+      "desktop/.github/workflows/",
+      "desktop/.github/workflows/build.yml",
+      "desktop/.github/workflows/ci.yml",
+      "desktop/.github/workflows/release.yml",
+      "desktop/CHANGELOG.md",
+      "desktop/DESKTOP_GUIDE.md",
+      "desktop/DEVELOPER.md",
+      "desktop/PR_SUMMARY.md",
+      "desktop/README.md",
+      "desktop/README_PR_G.md",
+      "desktop/README_PR_H.md",
+      "desktop/README_PR_I.md",
+      "desktop/README_PR_J.md",
+      "desktop/RELEASE.md",
+      "desktop/ai-insights.js",
+      "desktop/auth-bridge.js",
+      "desktop/background.js",
+      "desktop/cache/",
+      "desktop/cache/secure_cache.js",
+      "desktop/conflict.js",
+      "desktop/crash.js",
+      "desktop/crdt/",
+      "desktop/crdt/strategy-pilot.js",
+      "desktop/crypto/",
+      "desktop/crypto/secure_key.js",
+      "desktop/db/",
+      "desktop/db/bootstrap.js",
+      "desktop/db/migrations/",
+      "desktop/db/migrations/001_init.sql",
+      "desktop/db/migrations/002_sync_queue.sql",
+      "desktop/db/migrations/003_conflict_resolutions.sql",
+      "desktop/db/migrations/004_sync_queue_qtype.sql",
+      "desktop/db/migrations/005_add_org_to_tables.sql",
+      "desktop/db/migrations/006_sync_queue_org_and_workflow.sql",
+      "desktop/docs/",
+      "desktop/docs/dashboards/",
+      "desktop/docs/dashboards/ai-insights.json",
+      "desktop/docs/dashboards/plugins.json",
+      "desktop/docs/dashboards/sync-health.json",
+      "desktop/electron-builder.yml",
+      "desktop/electron-src/",
+      "desktop/electron-src/main.ts",
+      "desktop/electron-src/preload.ts",
+      "desktop/electron-src/renderer/",
+      "desktop/electron-src/renderer/global.d.ts",
+      "desktop/examples/",
+      "desktop/examples/desktop/",
+      "desktop/examples/desktop/ai-insights/",
+      "desktop/examples/desktop/ai-insights/README.md",
+      "desktop/examples/desktop/offline-sync/",
+      "desktop/examples/desktop/offline-sync/README.md",
+      "desktop/examples/desktop/plugins/",
+      "desktop/examples/desktop/plugins/README.md",
+      "desktop/integrations/",
+      "desktop/integrations/google-calendar.js",
+      "desktop/integrations/hubspot.js",
+      "desktop/integrations/index.js",
+      "desktop/integrations/manifest/",
+      "desktop/integrations/manifest/google-calendar.json",
+      "desktop/integrations/manifest/hubspot.json",
+      "desktop/integrations/manifest/office365.json",
+      "desktop/integrations/office365.js",
+      "desktop/integrations/signature.js",
+      "desktop/jest.config.js",
+      "desktop/logger.js",
+      "desktop/main.js",
+      "desktop/metrics.js",
+      "desktop/otel.js",
+      "desktop/package.json",
+      "desktop/preload.js",
+      "desktop/renderer/",
+      "desktop/renderer/dash/",
+      "desktop/renderer/dash/dash.js",
+      "desktop/renderer/overlay/",
+      "desktop/renderer/overlay/overlay.js",
+      "desktop/renderer/plugins/",
+      "desktop/renderer/plugins/gallery.js",
+      "desktop/renderer/settings/",
+      "desktop/renderer/settings/settings.js",
+      "desktop/renderer/styles/",
+      "desktop/roaming.js",
+      "desktop/secrets.js",
+      "desktop/src/",
+      "desktop/src/autoUpdater.ts",
+      "desktop/src/crypto.ts",
+      "desktop/src/crypto/",
+      "desktop/src/crypto/secureStorage.js",
+      "desktop/src/main.ts",
+      "desktop/src/migrations/",
+      "desktop/src/migrations/migrate_to_encrypted.js",
+      "desktop/src/notifications.ts",
+      "desktop/src/notify.ts",
+      "desktop/src/otel.ts",
+      "desktop/src/policy.ts",
+      "desktop/src/policy/",
+      "desktop/src/policy/index.ts",
+      "desktop/src/policy/loader.ts",
+      "desktop/src/policy/types.ts",
+      "desktop/src/status.ts",
+      "desktop/src/storage/",
+      "desktop/src/storage/secureDb.ts",
+      "desktop/src/sync/",
+      "desktop/src/sync/SyncService.ts",
+      "desktop/src/sync/conflict.ts",
+      "desktop/src/sync/demo.ts",
+      "desktop/src/sync/syncEngine.ts",
+      "desktop/src/telemetry/",
+      "desktop/src/telemetry/crash.ts",
+      "desktop/src/telemetry/otel.ts",
+      "desktop/src/tests/",
+      "desktop/src/tests/otel_smoke.test.ts",
+      "desktop/src/tests/policy_loader.test.ts",
+      "desktop/src/ui/",
+      "desktop/src/ui/status.ts"
+    ],
+    "BUOY_AI": [
+      ".github/workflows/meta-pr1-ci.yml",
+      ".github/workflows/meta-pr2-ci.yml",
+      "META_ROUTE_README.md",
+      "META_ROUTE_RUNBOOK.md",
+      "PATCHES/WIRE_BUOY_ROUTE.md",
+      "README_BUOY_2.4.4.md",
+      "README_PR-BUOY-CHAT-SEARCH.md",
+      "README_PR10_EXPLAIN_BUOY.md",
+      "README_SUPERPROMPT.md",
+      "README_SUPERPROMPT_BC.md",
+      "ai/",
+      "ai/adapters/",
+      "ai/adapters/__init__.py",
+      "ai/adapters/base.py",
+      "ai/adapters/llm_openai.py",
+      "ai/adapters/sklearn_stub.py",
+      "ai/adapters/torch_stub.py",
+      "ai/registry/",
+      "ai/registry/__init__.py",
+      "ai/registry/models.yaml",
+      "ai/registry/registry.py",
+      "api-docs/collections/workbuoy_crm.postman.json",
+      "api-docs/collections/workbuoy_crm.postman_collection.json",
+      "backend/api/meta.mount.ts",
+      "backend/jest.meta.config.cjs",
+      "backend/meta/",
+      "backend/meta/auditStats.ts",
+      "backend/meta/capabilities.ts",
+      "backend/meta/health.ts",
+      "backend/meta/policy.ts",
+      "backend/meta/probes/",
+      "backend/meta/probes/baseProbe.ts",
+      "backend/meta/probes/dbProbe.ts",
+      "backend/meta/probes/index.ts",
+      "backend/meta/probes/outboundProbe.ts",
+      "backend/meta/probes/queueProbe.ts",
+      "backend/meta/probes/types.ts",
+      "backend/meta/readiness.ts",
+      "backend/meta/router.ts",
+      "backend/meta/runtimeState.ts",
+      "backend/meta/security.ts",
+      "backend/meta/types.ts",
+      "backend/meta/version.ts",
+      "backend/src/meta-evolution/",
+      "backend/src/meta-evolution/consciousness/",
+      "backend/src/meta-evolution/consciousness/awareness-engine.ts",
+      "backend/src/meta-evolution/consciousness/capability-mapper.ts",
+      "backend/src/meta-evolution/consciousness/self-analysis.ts",
+      "backend/src/meta-evolution/genesis/",
+      "backend/src/meta-evolution/genesis/feature-discovery.ts",
+      "backend/src/meta-evolution/genesis/need-analyzer.ts",
+      "backend/src/meta-evolution/genesis/solution-synthesizer.ts",
+      "backend/src/meta-evolution/genetics/",
+      "backend/src/meta-evolution/genetics/code-genome.ts",
+      "backend/src/meta-evolution/genetics/evolution-simulator.ts",
+      "backend/src/meta-evolution/genetics/mutation-engine.ts",
+      "backend/src/meta-evolution/neural/",
+      "backend/src/meta-evolution/neural/architecture-optimizer.ts",
+      "backend/src/meta-evolution/neural/decision-networks.ts",
+      "backend/src/meta-evolution/neural/intuition-engine.ts",
+      "backend/src/meta-evolution/routes/",
+      "backend/src/meta-evolution/routes/evolution.routes.ts",
+      "backend/src/meta-evolution/types.ts",
+      "dashboards/workbuoy_ops.json",
+      "deploy/helm/workbuoy/",
+      "deploy/helm/workbuoy/Chart.yaml",
+      "deploy/helm/workbuoy/templates/",
+      "deploy/helm/workbuoy/templates/deployment.yaml",
+      "deploy/helm/workbuoy/templates/service.yaml",
+      "deploy/helm/workbuoy/values.yaml",
+      "desktop/ai-insights.js",
+      "desktop/docs/dashboards/ai-insights.json",
+      "desktop/examples/desktop/ai-insights/",
+      "desktop/examples/desktop/ai-insights/README.md",
+      "desktop/tests/e2e/ai-insights.spec.mjs",
+      "desktop/tests/e2e/assistant.spec.mjs",
+      "desktop/tests/unit/ai.test.js",
+      "docker-compose.meta.yml",
+      "docs/BUOY_CHAT_SEARCH.md",
+      "docs/PR_CHECKLIST_BUOY.md",
+      "docs/ai/",
+      "docs/ai/ML_DL_READINESS.md",
+      "docs/buoy.md",
+      "enterprise/META.md",
+      "enterprise/META_EXPERIMENTS_README.md",
+      "enterprise/__tests__/e2e/meta_flow.spec.ts",
+      "enterprise/__tests__/meta.experiments.api.test.js",
+      "enterprise/__tests__/meta.experiments.test.js",
+      "enterprise/ai.js",
+      "enterprise/db/migrations/0015_meta_experiments.down.sql",
+      "enterprise/db/migrations/0015_meta_experiments.up.sql",
+      "enterprise/docs/META.md",
+      "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+      "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+      "enterprise/e2e/meta-experiments.spec.ts",
+      "enterprise/grafana/workbuoy_overview.json",
+      "enterprise/lib/ai/",
+      "enterprise/lib/ai/actions.js",
+      "enterprise/lib/ai/assist.js",
+      "enterprise/lib/ai/index.js",
+      "enterprise/lib/ai/pii_guard.js",
+      "enterprise/lib/ai/provider.js",
+      "enterprise/lib/ai/ranker.js",
+      "enterprise/lib/ai/router.js",
+      "enterprise/lib/ai/skills/",
+      "enterprise/lib/ai/skills/tickets.js",
+      "enterprise/lib/ai/suggestions.js",
+      "enterprise/lib/ai/tools/",
+      "enterprise/lib/ai/tools/export.js",
+      "enterprise/lib/ai/tools/map.js",
+      "enterprise/lib/ai/tools/search.js",
+      "enterprise/lib/config/ai-flags.js",
+      "enterprise/lib/meta/",
+      "enterprise/lib/meta/analyzer.js",
+      "enterprise/lib/meta/experiments.js",
+      "enterprise/lib/meta/metrics.js",
+      "enterprise/lib/meta/planner.js",
+      "enterprise/lib/meta/rollback-gate.js",
+      "enterprise/lib/meta/rollback.js",
+      "enterprise/lib/meta/slo-watch.js"
+    ],
+    "ROLES": [
+      "backend/src/crm/rbacGuard.ts",
+      "backend/src/middleware/rbac.ts",
+      "backend/src/rbac/",
+      "backend/src/rbac/audit.ts",
+      "backend/src/rbac/binding.ts",
+      "backend/src/rbac/enforce.ts",
+      "backend/src/rbac/middleware.ts",
+      "backend/src/rbac/policies.ts",
+      "backend/src/rbac/policy.ts",
+      "backend/src/rbac/routes.ts",
+      "backend/src/rbac/service.ts",
+      "backend/tests/rbac.binding.test.ts",
+      "backend/tests/rbac.enforce.test.ts",
+      "backend/tests/rbac.routes.test.ts",
+      "backend/tests/rbac.test.ts",
+      "backend/tests/rbac_policy.test.ts",
+      "backend/tests/rbac_record_level.test.ts",
+      "core/roles/",
+      "core/roles/README.md",
+      "core/roles/index.js",
+      "core/roles/role.schema.json",
+      "core/roles/roles.json",
+      "core/roles/validate_roles.js",
+      "db/migrations/roles.sql",
+      "desktop/tests/e2e/rbac-deny.spec.mjs",
+      "desktop/tests/unit/rbac.test.js",
+      "docs/RBAC_ENFORCEMENT.md",
+      "docs/RBAC_POLICY.md",
+      "docs/RBAC_TESTS.md",
+      "docs/SSO_SCIM_RBAC.md",
+      "docs/auto/roles_gate_README.md",
+      "enterprise/__tests__/rbac.test.js",
+      "enterprise/__tests__/roles.errors.test.js",
+      "enterprise/__tests__/roles.test.js",
+      "enterprise/__tests__/unit/portal-rbac.test.js",
+      "enterprise/__tests__/unit/rbac-metrics.test.js",
+      "enterprise/__tests__/unit/rbac.tenant.test.js",
+      "enterprise/data/roles/",
+      "enterprise/data/roles/account-manager.json",
+      "enterprise/data/roles/roles.json",
+      "enterprise/db/migrations/0004_roles_kpi.down.sql",
+      "enterprise/db/migrations/0004_roles_kpi.up.sql",
+      "enterprise/db/migrations/0028_user_roles.down.sql",
+      "enterprise/db/migrations/0028_user_roles.up.sql",
+      "enterprise/db/migrations/0029_user_roles_seed.down.sql",
+      "enterprise/db/migrations/0029_user_roles_seed.up.sql",
+      "enterprise/lib/auth/rbac.js",
+      "enterprise/lib/rbac.js",
+      "enterprise/lib/secure/rbac.js",
+      "enterprise/migrations/0004_roles_kpi.down.sql",
+      "enterprise/migrations/0004_roles_kpi.up.sql",
+      "enterprise/pages/api/roles/",
+      "enterprise/pages/api/roles/index.js",
+      "enterprise/pages/api/roles/kpi.js",
+      "enterprise/pages/api/secure/dsr/access.js",
+      "enterprise/public/data/roles.json",
+      "enterprise/public/js/roles.js",
+      "enterprise/rbac.js",
+      "enterprise/roles/",
+      "enterprise/roles/index.js",
+      "enterprise/roles/kpi.js",
+      "enterprise/scripts/rbac/",
+      "enterprise/scripts/rbac/seed-first-admin.js",
+      "enterprise/secure/dsr/access.js",
+      "enterprise/secure/rbac.js",
+      "enterprise/tests/e2e/rbac-403.spec.ts",
+      "enterprise/tests/jest/rbac-portal.test.js",
+      "reports/roles/",
+      "reports/roles/duplicates.json",
+      "reports/roles/missing_required.json",
+      "reports/roles/validation_report.md",
+      "reports/roles/validation_summary.json",
+      "roles/",
+      "roles/roles.json",
+      "scripts/run_roles_gate.sh",
+      "src/core/capabilityRunnerRole.ts",
+      "src/core/policyRoleAware.ts",
+      "src/core/roles/",
+      "src/core/roles/roleRegistry.ts",
+      "src/core/security/rbac.ts",
+      "src/roles/",
+      "src/roles/loader.ts",
+      "src/roles/registry.ts",
+      "src/roles/seed/",
+      "src/roles/seed/features.ts",
+      "src/roles/types.ts",
+      "tests/policy/rolecap.test.ts",
+      "tests/roles/",
+      "tests/roles/test_roles_schema.py",
+      "tests/security.rbac.test.ts",
+      "tools/roles/",
+      "tools/roles/normalize_roles.py"
+    ],
+    "PROACTIVITY": [
+      "backend/routes/proactivity.ts",
+      "dashboards/kraken_view.md",
+      "docs/proactivity.md",
+      "enterprise/__tests__/tsunami.approval.test.js",
+      "enterprise/modes/tsunami/",
+      "enterprise/modes/tsunami/approve.js",
+      "enterprise/pages/api/modes/tsunami/",
+      "enterprise/pages/api/modes/tsunami/approve.js",
+      "enterprise/public/js/modes/kraken.js",
+      "enterprise/public/js/modes/proactive.js",
+      "enterprise/public/js/modes/tsunami.js",
+      "grafana/dashboards/proactivity.json",
+      "openapi/proactivity.yaml",
+      "samples/kraken_sim_output.json",
+      "simulation/kraken_sim.py",
+      "src/core/proactivity/",
+      "src/core/proactivity/context.ts",
+      "src/core/proactivity/guards.ts",
+      "src/core/proactivity/modes.ts",
+      "src/core/proactivity/state.ts",
+      "src/core/proactivity/telemetry.ts",
+      "tests/proactivity/",
+      "tests/proactivity/api-state.test.ts",
+      "tests/proactivity/runner-paths.test.ts",
+      "tests/proactivity/state-resolver.test.ts",
+      "tsconfig.proactivity.json"
+    ],
+    "META": [
+      ".github/workflows/meta-pr1-ci.yml",
+      ".github/workflows/meta-pr2-ci.yml",
+      "META_ROUTE_README.md",
+      "META_ROUTE_RUNBOOK.md",
+      "backend/api/meta.mount.ts",
+      "backend/jest.meta.config.cjs",
+      "backend/meta/",
+      "backend/meta/auditStats.ts",
+      "backend/meta/capabilities.ts",
+      "backend/meta/health.ts",
+      "backend/meta/policy.ts",
+      "backend/meta/probes/",
+      "backend/meta/probes/baseProbe.ts",
+      "backend/meta/probes/dbProbe.ts",
+      "backend/meta/probes/index.ts",
+      "backend/meta/probes/outboundProbe.ts",
+      "backend/meta/probes/queueProbe.ts",
+      "backend/meta/probes/types.ts",
+      "backend/meta/readiness.ts",
+      "backend/meta/router.ts",
+      "backend/meta/runtimeState.ts",
+      "backend/meta/security.ts",
+      "backend/meta/types.ts",
+      "backend/meta/version.ts",
+      "backend/src/meta-evolution/",
+      "backend/src/meta-evolution/consciousness/",
+      "backend/src/meta-evolution/consciousness/awareness-engine.ts",
+      "backend/src/meta-evolution/consciousness/capability-mapper.ts",
+      "backend/src/meta-evolution/consciousness/self-analysis.ts",
+      "backend/src/meta-evolution/genesis/",
+      "backend/src/meta-evolution/genesis/feature-discovery.ts",
+      "backend/src/meta-evolution/genesis/need-analyzer.ts",
+      "backend/src/meta-evolution/genesis/solution-synthesizer.ts",
+      "backend/src/meta-evolution/genetics/",
+      "backend/src/meta-evolution/genetics/code-genome.ts",
+      "backend/src/meta-evolution/genetics/evolution-simulator.ts",
+      "backend/src/meta-evolution/genetics/mutation-engine.ts",
+      "backend/src/meta-evolution/neural/",
+      "backend/src/meta-evolution/neural/architecture-optimizer.ts",
+      "backend/src/meta-evolution/neural/decision-networks.ts",
+      "backend/src/meta-evolution/neural/intuition-engine.ts",
+      "backend/src/meta-evolution/routes/",
+      "backend/src/meta-evolution/routes/evolution.routes.ts",
+      "backend/src/meta-evolution/types.ts",
+      "backend/tests/genesis.autonomy.test.ts",
+      "docker-compose.meta.yml",
+      "enterprise/META.md",
+      "enterprise/META_EXPERIMENTS_README.md",
+      "enterprise/__tests__/e2e/meta_flow.spec.ts",
+      "enterprise/__tests__/meta.experiments.api.test.js",
+      "enterprise/__tests__/meta.experiments.test.js",
+      "enterprise/db/migrations/0015_meta_experiments.down.sql",
+      "enterprise/db/migrations/0015_meta_experiments.up.sql",
+      "enterprise/docs/META.md",
+      "enterprise/e2e/meta-experiments.spec.ts",
+      "enterprise/lib/meta/",
+      "enterprise/lib/meta/analyzer.js",
+      "enterprise/lib/meta/experiments.js",
+      "enterprise/lib/meta/metrics.js",
+      "enterprise/lib/meta/planner.js",
+      "enterprise/lib/meta/rollback-gate.js",
+      "enterprise/lib/meta/rollback.js",
+      "enterprise/lib/meta/slo-watch.js",
+      "enterprise/meta/",
+      "enterprise/meta/analyze.js",
+      "enterprise/meta/analyzer.js",
+      "enterprise/meta/apply.js",
+      "enterprise/meta/approve.js",
+      "enterprise/meta/backlog.js",
+      "enterprise/meta/experiments.js",
+      "enterprise/meta/experiments/",
+      "enterprise/meta/experiments/[id]/",
+      "enterprise/meta/experiments/[id]/metrics.js",
+      "enterprise/meta/experiments/start.js",
+      "enterprise/meta/experiments/stop.js",
+      "enterprise/meta/metrics.js",
+      "enterprise/meta/plan.js",
+      "enterprise/meta/planner.js",
+      "enterprise/meta/propose.js",
+      "enterprise/meta/rollback-gate.js",
+      "enterprise/meta/rollback.js",
+      "enterprise/meta/slo-watch.js",
+      "enterprise/meta/slo/",
+      "enterprise/meta/slo/trigger.js",
+      "enterprise/migrations/0015_meta_experiments.down.sql",
+      "enterprise/migrations/0015_meta_experiments.up.sql",
+      "enterprise/pages/api/auth/saml/metadata.js",
+      "enterprise/pages/api/meta/",
+      "enterprise/pages/api/meta/analyze.js",
+      "enterprise/pages/api/meta/apply.js",
+      "enterprise/pages/api/meta/approve.js",
+      "enterprise/pages/api/meta/backlog.js",
+      "enterprise/pages/api/meta/experiments/",
+      "enterprise/pages/api/meta/experiments/[id]/",
+      "enterprise/pages/api/meta/experiments/[id]/metrics.js",
+      "enterprise/pages/api/meta/experiments/start.js",
+      "enterprise/pages/api/meta/experiments/stop.js",
+      "enterprise/pages/api/meta/plan.js",
+      "enterprise/pages/api/meta/propose.js",
+      "enterprise/pages/api/meta/rollback.js",
+      "enterprise/pages/api/meta/slo/",
+      "enterprise/pages/api/meta/slo/trigger.js",
+      "enterprise/public/js/meta/",
+      "enterprise/public/js/meta/codeGenerator.js",
+      "enterprise/public/js/meta/documentation.js",
+      "enterprise/public/js/meta/learningEngine.js",
+      "enterprise/public/js/meta/metaInterface.js",
+      "enterprise/public/js/meta/selfAnalysis.js",
+      "frontend/src/components/evolution/",
+      "frontend/src/components/evolution/EvolutionDashboard.tsx",
+      "frontend/src/components/evolution/index.ts",
+      "frontend/src/components/evolution/types.ts",
+      "grafana/dashboards/meta.json",
+      "meta/",
+      "meta/ACTIVATION.md",
+      "meta/FOUNDATION.md",
+      "meta/KILL_SWITCH.md",
+      "meta/schema/",
+      "meta/schema/decision-log.schema.json",
+      "meta/schema/usage-log.schema.json"
+    ],
+    "INFRA": [
+      "Dockerfile",
+      "MERGE_MANIFEST.json",
+      "PATCHES/WIRE_OBSERVABILITY.md",
+      "alertmanager/",
+      "alertmanager/config.yaml",
+      "backend/src/observability/",
+      "backend/src/observability/metrics.ts",
+      "backend/src/security/helmet.ts",
+      "crm/docker-compose.yml",
+      "crm/grafana/",
+      "crm/grafana/dashboards/",
+      "crm/grafana/dashboards/crm.json",
+      "deploy/",
+      "deploy/helm/",
+      "deploy/helm/workbuoy/",
+      "deploy/helm/workbuoy/Chart.yaml",
+      "deploy/helm/workbuoy/templates/",
+      "deploy/helm/workbuoy/templates/deployment.yaml",
+      "deploy/helm/workbuoy/templates/service.yaml",
+      "deploy/helm/workbuoy/values.yaml",
+      "deployment/",
+      "deployment/intune/",
+      "deployment/intune/prepare_intunewin.ps1",
+      "deployment/jamf/",
+      "deployment/linux/",
+      "deployment/linux/policy.json",
+      "desktop/integrations/manifest/",
+      "desktop/integrations/manifest/google-calendar.json",
+      "desktop/integrations/manifest/hubspot.json",
+      "desktop/integrations/manifest/office365.json",
+      "desktop/src/telemetry/",
+      "desktop/src/telemetry/crash.ts",
+      "desktop/src/telemetry/otel.ts",
+      "desktop/telemetry/",
+      "desktop/telemetry/otel_client.js",
+      "desktop/tests/e2e/telemetry-opt.spec.mjs",
+      "desktop/tests/telemetry_verify.ts",
+      "docker-compose.meta.yml",
+      "docker-compose.yml",
+      "docs/ALERT_HYGIENE.md",
+      "docs/CONNECTOR_OBSERVABILITY.md",
+      "docs/DEPLOY_HELM.md",
+      "docs/DESKTOP_OBSERVABILITY.md",
+      "docs/DESKTOP_TELEMETRY.md",
+      "docs/ENTERPRISE_DEPLOYMENT.md",
+      "docs/GRAFANA_OBSERVABILITY.md",
+      "docs/HELM_DEPLOY.md",
+      "docs/MDM_DEPLOYMENT.md",
+      "docs/OBSERVABILITY.md",
+      "docs/OBSERVABILITY_CRM.md",
+      "docs/addons/manifest.md",
+      "docs/ops.md",
+      "docs/ops/",
+      "docs/ops/ci.md",
+      "enterprise/DEPLOYMENT.md",
+      "enterprise/Dockerfile",
+      "enterprise/OBSERVABILITY.md",
+      "enterprise/OPS.md",
+      "enterprise/docker-compose.yml",
+      "enterprise/docker/",
+      "enterprise/docker/Dockerfile",
+      "enterprise/docker/docker-compose.yml",
+      "enterprise/docs/DEPLOYMENT.md",
+      "enterprise/docs/OBSERVABILITY.md",
+      "enterprise/docs/observability/",
+      "enterprise/docs/observability/prometheus-alerts.yml",
+      "enterprise/grafana/",
+      "enterprise/grafana/workbuoy_overview.json",
+      "enterprise/helm/",
+      "enterprise/helm/Chart.yaml",
+      "enterprise/helm/templates/",
+      "enterprise/helm/templates/alertmanager.yaml",
+      "enterprise/helm/templates/cron-backup.yaml",
+      "enterprise/helm/templates/cron-signals.yaml",
+      "enterprise/helm/templates/deployment.yaml",
+      "enterprise/helm/templates/hpa.yaml",
+      "enterprise/helm/templates/ingress.yaml",
+      "enterprise/helm/templates/pdb.yaml",
+      "enterprise/helm/templates/podmonitor.yaml",
+      "enterprise/helm/templates/service.yaml",
+      "enterprise/helm/templates/servicemonitor.yaml",
+      "enterprise/helm/values.yaml",
+      "enterprise/infra/",
+      "enterprise/infra/alerts/",
+      "enterprise/infra/alerts/prometheus/",
+      "enterprise/infra/alerts/prometheus/wb.rules.yml",
+      "enterprise/infra/grafana/",
+      "enterprise/infra/grafana/dashboards/",
+      "enterprise/infra/grafana/dashboards/wb-multitenant.json",
+      "enterprise/infra/helm/",
+      "enterprise/infra/helm/Chart.yaml",
+      "enterprise/infra/helm/templates/",
+      "enterprise/infra/helm/templates/alertmanager-config.yaml",
+      "enterprise/infra/helm/templates/alertmanager.yaml",
+      "enterprise/infra/helm/templates/cron-backup.yaml",
+      "enterprise/infra/helm/templates/cron-signals.yaml",
+      "enterprise/infra/helm/templates/deployment.yaml",
+      "enterprise/infra/helm/templates/externalsecret.yaml",
+      "enterprise/infra/helm/templates/hpa.yaml",
+      "enterprise/infra/helm/templates/ingress.yaml",
+      "enterprise/infra/helm/templates/networkpolicy.yaml",
+      "enterprise/infra/helm/templates/pdb.yaml",
+      "enterprise/infra/helm/templates/podmonitor.yaml",
+      "enterprise/infra/helm/templates/service.yaml",
+      "enterprise/infra/helm/templates/servicemonitor.yaml",
+      "enterprise/infra/helm/values-slo-alerts.yaml",
+      "enterprise/infra/helm/values.yaml",
+      "enterprise/infra/terraform/",
+      "enterprise/integration/monitoring.js",
+      "enterprise/lib/integration/monitoring.js",
+      "enterprise/lib/jobs/alerts/",
+      "enterprise/lib/jobs/alerts/adminConsentTimeout.js",
+      "enterprise/lib/observability/",
+      "enterprise/lib/observability/metrics.data-int.js",
+      "enterprise/observability/",
+      "enterprise/observability/grafana/",
+      "enterprise/observability/grafana/workbuoy_overview.json",
+      "enterprise/observability/grafana/workbuoy_slo_freshness.json",
+      "enterprise/observability/grafana/workbuoy_slo_overview.json",
+      "enterprise/observability/metrics.data-int.js"
+    ],
+    "ADOPTION": [
+      "PULL_REQUEST_TEMPLATE.md",
+      "connectors/dynamics/examples/",
+      "connectors/dynamics/examples/contact_event.json",
+      "connectors/dynamics/examples/opportunity_event.json",
+      "connectors/salesforce/examples/",
+      "connectors/salesforce/examples/contact_event.json",
+      "connectors/salesforce/examples/opportunity_event.json",
+      "crm/__tests__/onboarding.demo.guard.test.ts",
+      "crm/pages/api/onboarding/",
+      "crm/pages/api/onboarding/demo.ts",
+      "crm/pages/portal/crm/onboarding.tsx",
+      "deploy/helm/workbuoy/templates/",
+      "deploy/helm/workbuoy/templates/deployment.yaml",
+      "deploy/helm/workbuoy/templates/service.yaml",
+      "desktop/examples/",
+      "desktop/examples/desktop/",
+      "desktop/examples/desktop/ai-insights/",
+      "desktop/examples/desktop/ai-insights/README.md",
+      "desktop/examples/desktop/offline-sync/",
+      "desktop/examples/desktop/offline-sync/README.md",
+      "desktop/examples/desktop/plugins/",
+      "desktop/examples/desktop/plugins/README.md",
+      "docs/STATUS.template.md",
+      "enterprise/compliance/DPA_TEMPLATE.md",
+      "enterprise/compliance/DPIA_TEMPLATE.md",
+      "enterprise/compliance/TIA_TEMPLATE.md",
+      "enterprise/docs/ONBOARDING.md",
+      "enterprise/docs/privacy/DPA_TEMPLATE.md",
+      "enterprise/e2e/connector_onboarding.spec.ts",
+      "enterprise/e2e/onboarding.systems.spec.ts",
+      "enterprise/examples/",
+      "enterprise/examples/home.demo.js",
+      "enterprise/examples/js/",
+      "enterprise/examples/js/node-quickstart/",
+      "enterprise/examples/js/node-quickstart/README.md",
+      "enterprise/examples/js/node-quickstart/index.js",
+      "enterprise/examples/python/",
+      "enterprise/examples/python/quickstart/",
+      "enterprise/examples/python/quickstart/README.md",
+      "enterprise/examples/python/quickstart/main.py",
+      "enterprise/examples/server.js",
+      "enterprise/helm/templates/",
+      "enterprise/helm/templates/alertmanager.yaml",
+      "enterprise/helm/templates/cron-backup.yaml",
+      "enterprise/helm/templates/cron-signals.yaml",
+      "enterprise/helm/templates/deployment.yaml",
+      "enterprise/helm/templates/hpa.yaml",
+      "enterprise/helm/templates/ingress.yaml",
+      "enterprise/helm/templates/pdb.yaml",
+      "enterprise/helm/templates/podmonitor.yaml",
+      "enterprise/helm/templates/service.yaml",
+      "enterprise/helm/templates/servicemonitor.yaml",
+      "enterprise/infra/helm/templates/",
+      "enterprise/infra/helm/templates/alertmanager-config.yaml",
+      "enterprise/infra/helm/templates/alertmanager.yaml",
+      "enterprise/infra/helm/templates/cron-backup.yaml",
+      "enterprise/infra/helm/templates/cron-signals.yaml",
+      "enterprise/infra/helm/templates/deployment.yaml",
+      "enterprise/infra/helm/templates/externalsecret.yaml",
+      "enterprise/infra/helm/templates/hpa.yaml",
+      "enterprise/infra/helm/templates/ingress.yaml",
+      "enterprise/infra/helm/templates/networkpolicy.yaml",
+      "enterprise/infra/helm/templates/pdb.yaml",
+      "enterprise/infra/helm/templates/podmonitor.yaml",
+      "enterprise/infra/helm/templates/service.yaml",
+      "enterprise/infra/helm/templates/servicemonitor.yaml",
+      "enterprise/onboarding.js",
+      "enterprise/pages/api/portal/onboarding/",
+      "enterprise/pages/api/portal/onboarding/complete.js",
+      "enterprise/pages/api/portal/onboarding/demo-data.js",
+      "enterprise/pages/portal/onboarding.js",
+      "enterprise/pages/portal/onboarding/",
+      "enterprise/pages/portal/onboarding/admin-consent.tsx",
+      "enterprise/pages/portal/onboarding/systems.tsx",
+      "enterprise/public/js/onboarding/",
+      "enterprise/public/js/onboarding/connectors.js",
+      "enterprise/public/js/onboarding/registration.js",
+      "enterprise/public/templates/",
+      "enterprise/public/templates/slides/",
+      "enterprise/templates/",
+      "enterprise/templates/kits/",
+      "enterprise/templates/kits/custom.md",
+      "enterprise/templates/kits/excel.json",
+      "enterprise/templates/kits/powerpoint.json",
+      "enterprise/templates/kits/sales.md",
+      "enterprise/tests/e2e/onboarding-wizard.spec.ts",
+      "examples/",
+      "examples/js/",
+      "examples/js/crm_crud.js",
+      "examples/js/package.json",
+      "examples/js_quickstart.js",
+      "examples/node/",
+      "examples/node/example.ts",
+      "examples/node_contacts.js",
+      "examples/py_quickstart.py",
+      "examples/python/",
+      "examples/python/crm_crud.py",
+      "examples/python/example.py",
+      "examples/python/list_contacts.py",
+      "examples/python/requirements.txt",
+      "examples/python_contacts.py",
+      "examples/ts/",
+      "examples/ts/list_contacts.ts",
+      "ops/helm/workbuoy/templates/",
+      "ops/helm/workbuoy/templates/NOTES.txt",
+      "ops/helm/workbuoy/templates/configmap.yaml",
+      "ops/helm/workbuoy/templates/connectors-worker-deployment.yaml",
+      "ops/helm/workbuoy/templates/crm-api-deployment.yaml",
+      "ops/helm/workbuoy/templates/deployment.yaml",
+      "ops/helm/workbuoy/templates/desktop-update.yaml",
+      "ops/helm/workbuoy/templates/hpa.yaml",
+      "ops/helm/workbuoy/templates/ingress.yaml",
+      "ops/helm/workbuoy/templates/networkpolicy.yaml",
+      "ops/helm/workbuoy/templates/secret.yaml",
+      "ops/helm/workbuoy/templates/service.yaml",
+      "ops/helm/workbuoy/templates/serviceaccount.yaml",
+      "ops/helm/workbuoy/templates/servicemonitor.yaml",
+      "samples/",
+      "samples/kraken_sim_output.json",
+      "services/planner/examples/"
+    ]
+  },
+  "signals": {
+    "META_SAFEGUARDS": [
+      {
+        "file": "README.md",
+        "line": 9,
+        "match": "- **Introspection report** – `GET /genesis/introspection-report` exposes the"
+      },
+      {
+        "file": "README.md",
+        "line": 13,
+        "match": "- **Autonomous development proposals** – `POST /genesis/autonomous-develop`"
+      },
+      {
+        "file": "README.md",
+        "line": 16,
+        "match": "- **Evolution gatekeeper** – `POST /genetics/implement-evolution` enforces"
+      },
+      {
+        "file": "README.md",
+        "line": 16,
+        "match": "- **Evolution gatekeeper** – `POST /genetics/implement-evolution` enforces"
+      },
+      {
+        "file": "README.md",
+        "line": 17,
+        "match": "manual approval via the `.evolution/APPROVED` token and responds with a manual"
+      },
+      {
+        "file": "README.md",
+        "line": 22,
+        "match": "- `.evolution/APPROVED` must exist for any evolution request to be accepted."
+      },
+      {
+        "file": "README.md",
+        "line": 23,
+        "match": "Without the token the endpoint returns `403 approval_required`."
+      },
+      {
+        "file": "README.md",
+        "line": 25,
+        "match": "describes the manual merge steps; no git actions are triggered from HTTP."
+      },
+      {
+        "file": "backend/src/app.ts",
+        "line": 5,
+        "match": "import { createEvolutionRouter } from './meta-evolution/routes/evolution.routes.js';"
+      },
+      {
+        "file": "backend/src/app.ts",
+        "line": 10,
+        "match": "app.use('/api/meta-evolution', createEvolutionRouter());"
+      },
+      {
+        "file": "backend/src/meta-evolution/routes/evolution.routes.ts",
+        "line": 5,
+        "match": "import { EvolutionSimulator } from '../genetics/evolution-simulator.js';"
+      },
+      {
+        "file": "backend/src/meta-evolution/routes/evolution.routes.ts",
+        "line": 61,
+        "match": "router.post('/genetics/implement-evolution', async (req, res, next) => {"
+      },
+      {
+        "file": "backend/src/meta-evolution/routes/evolution.routes.ts",
+        "line": 93,
+        "match": "router.post('/genesis/autonomous-develop', async (_req, res, next) => {"
+      },
+      {
+        "file": "backend/src/meta-evolution/routes/evolution.routes.ts",
+        "line": 145,
+        "match": "const candidates = [proposed, process.env.META_EVOLUTION_PROJECT_ROOT, path.resolve(process.cwd(), 'src'), path.resolve(process.cwd(), 'backend', 'src')];"
+      },
+      {
+        "file": "backend/tests/genesis.autonomy.test.ts",
+        "line": 16,
+        "match": "const res = await request(buildApp()).get('/genesis/introspection-report');"
+      },
+      {
+        "file": "backend/tests/genesis.autonomy.test.ts",
+        "line": 35,
+        "match": ".post('/genetics/implement-evolution')"
+      },
+      {
+        "file": "backend/tests/genesis.autonomy.test.ts",
+        "line": 42,
+        "match": "error: 'approval_required',"
+      },
+      {
+        "file": "frontend/src/components/IntrospectionBadge.test.tsx",
+        "line": 35,
+        "match": "if (url.endsWith('/genesis/introspection-report')) {"
+      },
+      {
+        "file": "frontend/src/components/IntrospectionBadge.test.tsx",
+        "line": 47,
+        "match": "'/genesis/introspection-report',"
+      },
+      {
+        "file": "frontend/src/components/evolution/EvolutionDashboard.tsx",
+        "line": 9,
+        "match": "const STREAM_ENDPOINT = '/api/meta-evolution/stream';"
+      },
+      {
+        "file": "frontend/src/components/evolution/EvolutionDashboard.tsx",
+        "line": 10,
+        "match": "const SELF_ANALYSIS_ENDPOINT = '/api/meta-evolution/consciousness/self-analysis';"
+      },
+      {
+        "file": "frontend/src/components/evolution/EvolutionDashboard.tsx",
+        "line": 11,
+        "match": "const AUTONOMOUS_DEVELOP_ENDPOINT = '/api/meta-evolution/genesis/autonomous-develop';"
+      },
+      {
+        "file": "frontend/src/components/evolution/EvolutionDashboard.tsx",
+        "line": 11,
+        "match": "const AUTONOMOUS_DEVELOP_ENDPOINT = '/api/meta-evolution/genesis/autonomous-develop';"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 71,
+        "match": "return process.env.EVOLUTION_APPROVAL_FILE || path.join(process.cwd(), '.evolution/APPROVED');"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 77,
+        "match": "router.get('/genesis/introspection-report', (_req: Request, res: Response) => {"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 81,
+        "match": "router.post('/genesis/autonomous-develop', (req: Request, res: Response) => {"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 92,
+        "match": "router.post('/genetics/implement-evolution', async (req: Request, res: Response) => {"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 99,
+        "match": "error: 'approval_required',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 579,
+        "match": "violations.missing_approval_gate.push({ file: null, reason: 'No approval gate references detected (.evolution/APPROVED, approval_required, or evolution gatekeeper).' });"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 579,
+        "match": "violations.missing_approval_gate.push({ file: null, reason: 'No approval gate references detected (.evolution/APPROVED, approval_required, or evolution gatekeeper).' });"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 579,
+        "match": "violations.missing_approval_gate.push({ file: null, reason: 'No approval gate references detected (.evolution/APPROVED, approval_required, or evolution gatekeeper).' });"
+      }
+    ],
+    "FLIPCARD": [
+      {
+        "file": "README.md",
+        "line": 12,
+        "match": "in the flip-card header."
+      },
+      {
+        "file": "assets/demo/flip.svg",
+        "line": 4,
+        "match": "<text x=\"60\" y=\"80\" fill=\"#ecf2ff\" font-family=\"sans-serif\" font-size=\"18\">FlipCard: Buoy ↔ Navi</text>"
+      },
+      {
+        "file": "assets/demo/flip.svg",
+        "line": 4,
+        "match": "<text x=\"60\" y=\"80\" fill=\"#ecf2ff\" font-family=\"sans-serif\" font-size=\"18\">FlipCard: Buoy ↔ Navi</text>"
+      },
+      {
+        "file": "docs/context.md",
+        "line": 13,
+        "match": "- `FlipCard` wrapper appen med `ActiveContextProvider` og viser en Context-debug (kan skjules)."
+      },
+      {
+        "file": "docs/context.md",
+        "line": 13,
+        "match": "- `FlipCard` wrapper appen med `ActiveContextProvider` og viser en Context-debug (kan skjules)."
+      },
+      {
+        "file": "docs/frontend.md",
+        "line": 19,
+        "match": "- Bruk **ModeSwitch** i FlipCard-headeren for å simulere policy-nivåer i UI."
+      },
+      {
+        "file": "docs/frontend.md",
+        "line": 19,
+        "match": "- Bruk **ModeSwitch** i FlipCard-headeren for å simulere policy-nivåer i UI."
+      },
+      {
+        "file": "docs/navi.md",
+        "line": 27,
+        "match": "- `FlipCard` wrapper hele kortet med `AutonomyProvider` og viser `ModeSwitch` i headeren."
+      },
+      {
+        "file": "docs/navi.md",
+        "line": 27,
+        "match": "- `FlipCard` wrapper hele kortet med `AutonomyProvider` og viser `ModeSwitch` i headeren."
+      },
+      {
+        "file": "docs/peripheral-ui.md",
+        "line": 9,
+        "match": "FlipCard monterer `StatusEdge` med demo-knapper."
+      },
+      {
+        "file": "docs/peripheral-ui.md",
+        "line": 9,
+        "match": "FlipCard monterer `StatusEdge` med demo-knapper."
+      },
+      {
+        "file": "docs/ux_a11y_appendix.md",
+        "line": 5,
+        "match": "- **ARIA:** FlipCard, BuoyChat, Navi har `role` + `aria-label` for skjermlesere."
+      },
+      {
+        "file": "docs/ux_a11y_appendix.md",
+        "line": 5,
+        "match": "- **ARIA:** FlipCard, BuoyChat, Navi har `role` + `aria-label` for skjermlesere."
+      },
+      {
+        "file": "docs/ux_a11y_appendix.md",
+        "line": 12,
+        "match": "- Flip kortet med Space/Enter når FlipCard er fokusert."
+      },
+      {
+        "file": "docs/ux_a11y_appendix.md",
+        "line": 12,
+        "match": "- Flip kortet med Space/Enter når FlipCard er fokusert."
+      },
+      {
+        "file": "frontend/PR_BODY.md",
+        "line": 1,
+        "match": "# feat(ux): frontend shell (FlipCard + BuoyChat + NaviGrid + micro-viz)"
+      },
+      {
+        "file": "frontend/PR_BODY.md",
+        "line": 1,
+        "match": "# feat(ux): frontend shell (FlipCard + BuoyChat + NaviGrid + micro-viz)"
+      },
+      {
+        "file": "frontend/PR_BODY.md",
+        "line": 4,
+        "match": "- Oppretter `frontend/` (Vite/React) med FlipCard-shell, BuoyChat (chat + “Vis hvorfor” + mikro-viz),"
+      },
+      {
+        "file": "frontend/PR_BODY.md",
+        "line": 4,
+        "match": "- Oppretter `frontend/` (Vite/React) med FlipCard-shell, BuoyChat (chat + “Vis hvorfor” + mikro-viz),"
+      },
+      {
+        "file": "frontend/e2e/smoke.spec.ts",
+        "line": 6,
+        "match": "// Wait for FlipCard to render (Buoy header visible)"
+      },
+      {
+        "file": "frontend/e2e/smoke.spec.ts",
+        "line": 6,
+        "match": "// Wait for FlipCard to render (Buoy header visible)"
+      },
+      {
+        "file": "frontend/src/App.tsx",
+        "line": 2,
+        "match": "import FlipCard from \"./components/FlipCard\";"
+      },
+      {
+        "file": "frontend/src/App.tsx",
+        "line": 2,
+        "match": "import FlipCard from \"./components/FlipCard\";"
+      },
+      {
+        "file": "frontend/src/App.tsx",
+        "line": 8,
+        "match": "<FlipCard/>"
+      },
+      {
+        "file": "frontend/src/App.tsx",
+        "line": 8,
+        "match": "<FlipCard/>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 7,
+        "match": "export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 7,
+        "match": "export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 25,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.a11y.patch.txt",
+        "line": 25,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.context.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.context.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.context.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.context.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.context.patch.txt",
+        "line": 17,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.context.patch.txt",
+        "line": 17,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.ghost.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.ghost.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.ghost.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.ghost.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 9,
+        "match": "-export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 9,
+        "match": "-export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 10,
+        "match": "+export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 10,
+        "match": "+export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 17,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.patch.txt",
+        "line": 17,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 11,
+        "match": "export default function FlipCard(){"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 11,
+        "match": "export default function FlipCard(){"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 18,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.peripheral.patch.txt",
+        "line": 18,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.tsx",
+        "line": 6,
+        "match": "export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.tsx",
+        "line": 6,
+        "match": "export default function FlipCard() {"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.tsx",
+        "line": 20,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.tsx",
+        "line": 20,
+        "match": "<div className=\"flipcard cardbg\" style={{position:\"absolute\", inset:0, borderRadius:16, transform: `rotateY(${flipped?180:0}deg)`}}>"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.undo.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.undo.patch.txt",
+        "line": 1,
+        "match": "--- a/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.undo.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/components/FlipCard.undo.patch.txt",
+        "line": 2,
+        "match": "+++ b/frontend/src/components/FlipCard.tsx"
+      },
+      {
+        "file": "frontend/src/styles/base.css",
+        "line": 10,
+        "match": ".flipcard{transform-style:preserve-3d; transition:transform 600ms cubic-bezier(.2,.8,.2,1)}"
+      },
+      {
+        "file": "frontend/src/styles/base.css",
+        "line": 10,
+        "match": ".flipcard{transform-style:preserve-3d; transition:transform 600ms cubic-bezier(.2,.8,.2,1)}"
+      },
+      {
+        "file": "frontend/src/styles/base.css",
+        "line": 11,
+        "match": "@media (prefers-reduced-motion: reduce){ .flipcard{transition:none} }"
+      },
+      {
+        "file": "frontend/src/styles/base.css",
+        "line": 11,
+        "match": "@media (prefers-reduced-motion: reduce){ .flipcard{transition:none} }"
+      },
+      {
+        "file": "frontend/src/styles/tokens.css",
+        "line": 50,
+        "match": ".flipcard{"
+      },
+      {
+        "file": "frontend/src/styles/tokens.css",
+        "line": 50,
+        "match": ".flipcard{"
+      },
+      {
+        "file": "frontend/src/styles/tokens.css",
+        "line": 59,
+        "match": ".flipcard { transition: none !important; }"
+      },
+      {
+        "file": "frontend/src/styles/tokens.css",
+        "line": 59,
+        "match": ".flipcard { transition: none !important; }"
+      },
+      {
+        "file": "frontend/src/styles/tokens.css",
+        "line": 70,
+        "match": ".flipcard { transform: none !important; }"
+      },
+      {
+        "file": "frontend/src/styles/tokens.css",
+        "line": 70,
+        "match": ".flipcard { transform: none !important; }"
+      },
+      {
+        "file": "prototypes/FlipCardPrototype.tsx",
+        "line": 3,
+        "match": "export const FlipCardPrototype: React.FC = () => {"
+      },
+      {
+        "file": "prototypes/FlipCardPrototype.tsx",
+        "line": 3,
+        "match": "export const FlipCardPrototype: React.FC = () => {"
+      },
+      {
+        "file": "prototypes/FlipCardPrototype.tsx",
+        "line": 4,
+        "match": "return <div>Flip Card Prototype Placeholder</div>;"
+      },
+      {
+        "file": "prototypes/FlipCardPrototype.tsx",
+        "line": 7,
+        "match": "export default FlipCardPrototype;"
+      },
+      {
+        "file": "prototypes/FlipCardPrototype.tsx",
+        "line": 7,
+        "match": "export default FlipCardPrototype;"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 243,
+        "match": "FLIPCARD: ["
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 243,
+        "match": "FLIPCARD: ["
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 245,
+        "match": "/flipcard/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 245,
+        "match": "/flipcard/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 246,
+        "match": "/flipkort/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 312,
+        "match": "FLIPCARD: [],"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 312,
+        "match": "FLIPCARD: [],"
+      }
+    ],
+    "PROACTIVITY": [
+      {
+        "file": "MERGE_GUIDE.md",
+        "line": 6,
+        "match": "- workbuoy_suite_kraken_step1_4.zip"
+      },
+      {
+        "file": "MERGE_MANIFEST.json",
+        "line": 10,
+        "match": "\"/mnt/data/workbuoy_suite_kraken_step1_4.zip\","
+      },
+      {
+        "file": "README_PR10-EXPLAINABILITY.md",
+        "line": 26,
+        "match": "\"reasoning\": \"Prepare allowed at Ambisiøs (>=4)\","
+      },
+      {
+        "file": "backend/routes/admin.subscription.ts",
+        "line": 4,
+        "match": "import { parseProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "backend/routes/admin.subscription.ts",
+        "line": 43,
+        "match": "maxOverride: overrideValue !== undefined ? parseProactivityMode(overrideValue) : undefined,"
+      },
+      {
+        "file": "backend/routes/dev.runner.ts",
+        "line": 6,
+        "match": "import { parseProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "backend/routes/dev.runner.ts",
+        "line": 26,
+        "match": "const requestedHeader = req.header('x-proactivity');"
+      },
+      {
+        "file": "backend/routes/dev.runner.ts",
+        "line": 36,
+        "match": "requestedMode: parseProactivityMode(requestedHeader ?? req.body?.mode),"
+      },
+      {
+        "file": "backend/routes/explainability.ts",
+        "line": 2,
+        "match": "import { getRecentProactivityEvents } from '../../src/core/proactivity/telemetry';"
+      },
+      {
+        "file": "backend/routes/explainability.ts",
+        "line": 7,
+        "match": "const events = getRecentProactivityEvents(10);"
+      },
+      {
+        "file": "backend/routes/metrics.ts",
+        "line": 7,
+        "match": "res.send('proactivity_dummy 1\\n');"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 4,
+        "match": "import { buildProactivityContext } from '../../src/core/proactivity/context';"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 5,
+        "match": "import { parseProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 6,
+        "match": "import { logModusskift } from '../../src/core/proactivity/telemetry';"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 15,
+        "match": "const requestedHeader = req.header('x-proactivity');"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 23,
+        "match": "const state = buildProactivityContext({"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 27,
+        "match": "requestedMode: parseProactivityMode(requested),"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 30,
+        "match": "req.proactivity = state;"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 31,
+        "match": "logModusskift(state, { tenantId, userId, source: 'api/proactivity' });"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 35,
+        "match": "function toResponse(state: ReturnType<typeof buildProactivityContext>) {"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 52,
+        "match": "router.get('/proactivity/state', (req: any, res: any) => {"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 57,
+        "match": "router.post('/proactivity/state', (req: any, res: any) => {"
+      },
+      {
+        "file": "backend/src/meta-evolution/genesis/solution-synthesizer.ts",
+        "line": 14,
+        "match": "id: `${need.id}-assistive-ai`,"
+      },
+      {
+        "file": "backend/src/meta-evolution/genesis/solution-synthesizer.ts",
+        "line": 15,
+        "match": "summary: `Introduce assistive intelligence flows for ${need.description}.`,"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7789,
+        "match": "\"ai_assists\": [\"Process optimization recommendations\", \"Automated data mapping\", \"Compliance monitoring\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7819,
+        "match": "\"ai_assists\": [\"Automated test case generation\", \"User behavior analysis\", \"Process optimization suggestions\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7879,
+        "match": "\"ai_assists\": [\"Predictive analytics\", \"Anomaly detection\", \"Automated insights generation\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8107,
+        "match": "\"Design and maintain CI/CD pipelines for automated deployment\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8119,
+        "match": "\"ai_assists\": [\"Anomaly detection in logs\", \"Predictive scaling\", \"Automated incident response\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8352,
+        "match": "\"stakeholders_external\": [\"Advisory board\", \"Key customers\"],"
+      },
+      {
+        "file": "dashboards/kraken_view.md",
+        "line": 1,
+        "match": "# Kraken Simulation View (Stub)"
+      },
+      {
+        "file": "dashboards/kraken_view.md",
+        "line": 10,
+        "match": "> Source: logs/kraken_sim.json (generated when you run simulation/kraken_sim.py)"
+      },
+      {
+        "file": "docs/api.md",
+        "line": 8,
+        "match": "- Proactivity: `openapi/proactivity.yaml`"
+      },
+      {
+        "file": "docs/buoy.md",
+        "line": 13,
+        "match": "Passiv → Proaktiv → Ambisiøs → Kraken (policy-styrt)."
+      },
+      {
+        "file": "docs/buoy.md",
+        "line": 13,
+        "match": "Passiv → Proaktiv → Ambisiøs → Kraken (policy-styrt)."
+      },
+      {
+        "file": "docs/navi.md",
+        "line": 8,
+        "match": "- **Ambisiøs:** Forbered utkast automatisk."
+      },
+      {
+        "file": "docs/navi.md",
+        "line": 9,
+        "match": "- **Kraken:** Kan auto-utføre (policy-styrt)."
+      },
+      {
+        "file": "docs/navi.md",
+        "line": 16,
+        "match": "| Ambisiøs  | ✓       | ✓          | ✓           | –          |"
+      },
+      {
+        "file": "docs/navi.md",
+        "line": 17,
+        "match": "| Kraken    | ✓       | ✓          | ✓           | ✓          |"
+      },
+      {
+        "file": "docs/ops.md",
+        "line": 1,
+        "match": "# Ops Notes: Proactivity"
+      },
+      {
+        "file": "docs/ops.md",
+        "line": 5,
+        "match": "`GET /metrics` now exposes Prometheus text. Today we export a placeholder gauge `proactivity_dummy 1`. Future work will replace this with `prom-client` metrics (mode distribution, degradations, overrides). Scrape interval: 15s."
+      },
+      {
+        "file": "docs/ops.md",
+        "line": 9,
+        "match": "Import `grafana/dashboards/proactivity.json` into your Grafana instance. The stub contains panels for:"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 1,
+        "match": "# Proactivity Modes"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 3,
+        "match": "Workbuoy automation is orchestrated through six proactivity modes. Each mode controls what the runner is allowed to do and what the UI should surface."
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 7,
+        "match": "| 1     | `usynlig` | Observe silently with no UI footprint             | Collect signals only                           | Hide surfaces |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 8,
+        "match": "| 2     | `rolig`   | Observe + passive telemetry                       | Emit telemetry, no call-to-action              | Read-only banners |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 10,
+        "match": "| 4     | `ambisiøs`| Prepare previews pending approval                 | Call `impl.prepare()`                          | Show approval modals |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 11,
+        "match": "| 5     | `kraken`  | Execute under policy guardrails                   | Call `impl.execute()`                          | Stream execution log |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 12,
+        "match": "| 6     | `tsunami` | Execute + overlay + health checks                 | Call `impl.execute()` then `impl.overlay()`    | Overlay DOM + health badge |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 16,
+        "match": "Degradation follows a fixed rail: `tsunami → kraken → ambisiøs → proaktiv`. When a cap or error forces a downgrade we step along this rail instead of free-falling to zero. Below `proaktiv` we fall back to `rolig` and finally `usynlig` if th"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 16,
+        "match": "Degradation follows a fixed rail: `tsunami → kraken → ambisiøs → proaktiv`. When a cap or error forces a downgrade we step along this rail instead of free-falling to zero. Below `proaktiv` we fall back to `rolig` and finally `usynlig` if th"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 16,
+        "match": "Degradation follows a fixed rail: `tsunami → kraken → ambisiøs → proaktiv`. When a cap or error forces a downgrade we step along this rail instead of free-falling to zero. Below `proaktiv` we fall back to `rolig` and finally `usynlig` if th"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 16,
+        "match": "Degradation follows a fixed rail: `tsunami → kraken → ambisiøs → proaktiv`. When a cap or error forces a downgrade we step along this rail instead of free-falling to zero. Below `proaktiv` we fall back to `rolig` and finally `usynlig` if th"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 16,
+        "match": "Degradation follows a fixed rail: `tsunami → kraken → ambisiøs → proaktiv`. When a cap or error forces a downgrade we step along this rail instead of free-falling to zero. Below `proaktiv` we fall back to `rolig` and finally `usynlig` if th"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 18,
+        "match": "`degradeOnError(mode)` uses the same rail. Errors encountered in `tsunami` drop to `kraken`, errors in `kraken` drop to `ambisiøs`, etc."
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 18,
+        "match": "`degradeOnError(mode)` uses the same rail. Errors encountered in `tsunami` drop to `kraken`, errors in `kraken` drop to `ambisiøs`, etc."
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 18,
+        "match": "`degradeOnError(mode)` uses the same rail. Errors encountered in `tsunami` drop to `kraken`, errors in `kraken` drop to `ambisiøs`, etc."
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 24,
+        "match": "- **flex** → `ambisiøs` (4)"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 26,
+        "match": "- **enterprise** → `tsunami` (6)"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 28,
+        "match": "The `/api/admin/subscription` endpoint lets operations teams change plan, engage a kill-switch (`maxMode` becomes `usynlig`) or mark a tenant as secure-only (forcing the cap back to `proaktiv`). A `maxOverride` can temporarily tighten the c"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 32,
+        "match": "`policyCheckRoleAware` now evaluates policy with the *effective* proactivity mode. Role feature caps still apply: the registry resolves feature autonomy caps, and the cap is injected into the resolution pipeline. Policy guardrails can provi"
+      },
+      {
+        "file": "docs/ui.md",
+        "line": 1,
+        "match": "# UI Integration for Proactivity"
+      },
+      {
+        "file": "docs/ui.md",
+        "line": 3,
+        "match": "1. Call `GET /api/proactivity/state` on app bootstrap (headers: `x-tenant`, `x-user`, `x-role`). Store the response in UI state."
+      },
+      {
+        "file": "docs/ui.md",
+        "line": 4,
+        "match": "2. Subscribe to user actions that request higher modes (e.g. \"Go hands-free\"). POST the desired `requestedMode` to `/api/proactivity/state` and re-render with the response."
+      },
+      {
+        "file": "docs/ui.md",
+        "line": 11,
+        "match": "5. Hit `GET /api/explain/last` when the Why Drawer opens to fetch the last 10 telemetry events. Each event includes the requested/effective keys so you can display \"Requested Kraken → Effective Proaktiv (subscription:flex)\"."
+      },
+      {
+        "file": "docs/ui.md",
+        "line": 12,
+        "match": "6. When mode >= `ambisiøs`, render approval UX. When >= `kraken`, show execution progress and allow cancel. When `tsunami`, show overlay and health status."
+      },
+      {
+        "file": "docs/ui.md",
+        "line": 12,
+        "match": "6. When mode >= `ambisiøs`, render approval UX. When >= `kraken`, show execution progress and allow cancel. When `tsunami`, show overlay and health status."
+      },
+      {
+        "file": "docs/ui.md",
+        "line": 12,
+        "match": "6. When mode >= `ambisiøs`, render approval UX. When >= `kraken`, show execution progress and allow cancel. When `tsunami`, show overlay and health status."
+      },
+      {
+        "file": "enterprise/.github/workflows/backlog.json",
+        "line": 28,
+        "match": "\"title\": \"Kraken stub\","
+      },
+      {
+        "file": "enterprise/.github/workflows/backlog.json",
+        "line": 34,
+        "match": "\"title\": \"Tsunami overlay stub\","
+      },
+      {
+        "file": "enterprise/README_HUBSPOT_CXM_PATCH.md",
+        "line": 75,
+        "match": "- **Approval flow:** If a `tsunami/approve.js` module is present and exports `prepare({ connector, action, payload, preview })` it will be used. Otherwise the response still indicates approval is required."
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 112,
+        "match": "-  <script src=\"/js/modes/proactive.js\"></script>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 118,
+        "match": "-  <script src=\"/js/modes/kraken.js\"></script>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 119,
+        "match": "-  <script src=\"/js/modes/tsunami.js\"></script>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 345,
+        "match": "+                <p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 345,
+        "match": "+                <p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 484,
+        "match": "+            usynlig: {"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 485,
+        "match": "+                title: \"Usynlig Modus\","
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 499,
+        "match": "+            kraken: {"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 500,
+        "match": "+                title: \"Kraken Modus\","
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 504,
+        "match": "+            tsunami: {"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 505,
+        "match": "+                title: \"Tsunami Modus\","
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1395,
+        "match": "-                <p>Navi setter hele plattformen i modus – fra stille observatør til tsunami av automasjon. Dra for å utforske hvordan intelligensen tilpasser seg dine behov.</p>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1400,
+        "match": "-                    <div class=\"mode-step active\" data-mode=\"usynlig\">"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1402,
+        "match": "-                        <div class=\"mode-title\">Usynlig</div>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1415,
+        "match": "-                    <div class=\"mode-step\" data-mode=\"kraken\">"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1417,
+        "match": "-                        <div class=\"mode-title\">Kraken</div>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1420,
+        "match": "-                    <div class=\"mode-step\" data-mode=\"tsunami\">"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1422,
+        "match": "-                        <div class=\"mode-title\">Tsunami</div>"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1428,
+        "match": "-                    <h3>Usynlig Modus</h3>"
+      },
+      {
+        "file": "enterprise/__tests__/modes.test.js",
+        "line": 1,
+        "match": "const { handleMode, Proactivity } = require('../lib/modes.js');"
+      },
+      {
+        "file": "enterprise/__tests__/modes.test.js",
+        "line": 4,
+        "match": "const out = handleMode({mode: Proactivity.CALM, input:'hi', context:{}, user:{}});"
+      },
+      {
+        "file": "enterprise/__tests__/tsunami.approval.test.js",
+        "line": 1,
+        "match": "const handler = require('../pages/api/modes/tsunami/approve.js').default;"
+      },
+      {
+        "file": "enterprise/__tests__/tsunami.approval.test.js",
+        "line": 7,
+        "match": "process.env.TSUNAMI_WRITEBACK_ENABLED = 'false';"
+      },
+      {
+        "file": "enterprise/__tests__/tsunami.approval.test.js",
+        "line": 16,
+        "match": "process.env.TSUNAMI_WRITEBACK_ENABLED = 'true';"
+      },
+      {
+        "file": "enterprise/connectors/jira.js",
+        "line": 3,
+        "match": "return [{ key:'WB-101', summary:'Add Tsunami approvals', status:'To Do', jql }];"
+      },
+      {
+        "file": "enterprise/connectors/notion.js",
+        "line": 3,
+        "match": "return [{ id:'n1', title:'Project Brief: Kraken', matched: query }];"
+      },
+      {
+        "file": "enterprise/cxm/crm/notes.preview.js",
+        "line": 7,
+        "match": "// Optional: tsunami/approve.js integration (best-effort)."
+      },
+      {
+        "file": "enterprise/cxm/crm/notes.preview.js",
+        "line": 11,
+        "match": "approver = require('../../../../tsunami/approve.js');"
+      },
+      {
+        "file": "enterprise/cxm/crm/notes.preview.js",
+        "line": 36,
+        "match": "approval = { required: true, flow: 'tsunami/approve', id: prep.id };"
+      },
+      {
+        "file": "enterprise/cxm/crm/notes.preview.js",
+        "line": 38,
+        "match": "approval = { required: true, flow: 'tsunami/approve', error: e.message };"
+      },
+      {
+        "file": "enterprise/cxm/crm/notes.preview.js",
+        "line": 41,
+        "match": "approval = { required: true, flow: 'none', hint: 'tsunami/approve.js not available' };"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7789,
+        "match": "\"ai_assists\": [\"Process optimization recommendations\", \"Automated data mapping\", \"Compliance monitoring\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7819,
+        "match": "\"ai_assists\": [\"Automated test case generation\", \"User behavior analysis\", \"Process optimization suggestions\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7879,
+        "match": "\"ai_assists\": [\"Predictive analytics\", \"Anomaly detection\", \"Automated insights generation\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8107,
+        "match": "\"Design and maintain CI/CD pipelines for automated deployment\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8119,
+        "match": "\"ai_assists\": [\"Anomaly detection in logs\", \"Predictive scaling\", \"Automated incident response\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8352,
+        "match": "\"stakeholders_external\": [\"Advisory board\", \"Key customers\"],"
+      },
+      {
+        "file": "enterprise/docs/META.md",
+        "line": 17,
+        "match": "- Rollback must be human-approved in Tsunami mode (flag-gated)."
+      },
+      {
+        "file": "enterprise/docs/SECURE.md",
+        "line": 17,
+        "match": "- Tsunami write-back remains behind a feature flag."
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 20,
+        "match": "- **Core**: Adjust proactivity suggestions based on mode usage patterns"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 65,
+        "match": "- Mode restrictions are value-adds, not limitations (e.g., \"Tsunami disabled for compliance safety\")"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 168,
+        "match": "- **Automated Testing**: Self-generated tests for all meta-improvements with comprehensive validation"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 214,
+        "match": "- Day 2: CHAT 2 (Complete Core modes + Tsunami overlay)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 219,
+        "match": "- **Track B**: CHAT 4 (Role intelligence + Kraken automation playbooks)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 251,
+        "match": "- 6 proactivity modes (Invisible→Tsunami) giving users precise control over AI autonomy"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 251,
+        "match": "- 6 proactivity modes (Invisible→Tsunami) giving users precise control over AI autonomy"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 275,
+        "match": "**CORE MODULE** provides organizations with precise control over AI proactivity - from passive observer (Invisible) to fully autonomous assistant (Tsunami) with complete transparency and safety rails."
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 275,
+        "match": "**CORE MODULE** provides organizations with precise control over AI proactivity - from passive observer (Invisible) to fully autonomous assistant (Tsunami) with complete transparency and safety rails."
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 295,
+        "match": "**Week 2**: Flex consultation system operational + Role-aware Kraken playbooks functional + Kit value validated across modules"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 316,
+        "match": "- **Core**: Fundamentet med 6 proaktivitetsmodi (Invisible→Tsunami)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 339,
+        "match": "- Core = Foundation with 6 modes (Invisible→Tsunami)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 351,
+        "match": "- CHAT 4 (Role intelligence + Kraken playbooks) - Core mode enhancement + automation"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 379,
+        "match": "I'm developing WorkBuoy - a revolutionary AI work assistant with configurable proactivity levels and multiple operational modules."
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 387,
+        "match": "3. **Proactive** (2): Suggests via chips/nudges, never executes"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 389,
+        "match": "5. **Kraken** (4): API-driven, orchestrates data from external systems"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 390,
+        "match": "6. **Tsunami** (5): Most proactive, can write back to systems (always with approval)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 390,
+        "match": "6. **Tsunami** (5): Most proactive, can write back to systems (always with approval)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 400,
+        "match": "- Stricter mode limitations (e.g., only Invisible-Proactive available)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 446,
+        "match": "### CHAT 2: Core Modes Implementation + Tsunami Overlay"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 447,
+        "match": "**Goal: Complete Core module with all 6 modes + advanced Tsunami features**"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 451,
+        "match": "Implement the complete Core module with all 6 proactivity modes, with special focus on Tsunami overlay system:"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 451,
+        "match": "Implement the complete Core module with all 6 proactivity modes, with special focus on Tsunami overlay system:"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 454,
+        "match": "All 6 modes must behave distinctly different, with Tsunami requiring special overlay capabilities:"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 456,
+        "match": "1-3. Invisible/Calm/Proactive: Standard suggestion-based interaction"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 458,
+        "match": "5. Kraken: API orchestration with task approval queue"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 459,
+        "match": "6. **Tsunami: Full overlay system + autonomous capabilities**"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 461,
+        "match": "TSUNAMI OVERLAY REQUIREMENTS:"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 462,
+        "match": "- Visual overlay warning when entering Tsunami mode"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 467,
+        "match": "- Automatic fallback to Kraken if user dismisses too many actions"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 471,
+        "match": "- **Log button**: Enhanced logging especially for Kraken/Tsunami with impact assessments"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 471,
+        "match": "- **Log button**: Enhanced logging especially for Kraken/Tsunami with impact assessments"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 475,
+        "match": "- Enhanced core.config.json with Tsunami overlay specifications"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 478,
+        "match": "- Tsunami-specific logging with risk indicators"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 480,
+        "match": "Make each mode feel dramatically different, with Tsunami being appropriately powerful but safe."
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 519,
+        "match": "- Core: Continuous assistance with configurable proactivity"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 533,
+        "match": "### CHAT 4: Role Intelligence + Kraken Playbooks"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 536,
+        "match": "#### Prompt 4A: Enhanced Role Integration + Kraken Automation Playbooks"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 538,
+        "match": "Implement advanced role intelligence for Core module with Kraken-specific automation playbooks."
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 541,
+        "match": "Enhance Core modes (especially Kraken) with deep role understanding:"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 547,
+        "match": "KRAKEN PLAYBOOKS - FULL ROLE AUTOMATION:"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 548,
+        "match": "Kraken mode gets pre-built automation sequences that can handle entire job functions:"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 575,
+        "match": "1. User selects role-appropriate playbook from Kraken interface"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 589,
+        "match": "- js/kraken/playbooks/ automation engine"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 593,
+        "match": "Create role-intelligent system where Kraken can effectively handle entire job functions autonomously."
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 666,
+        "match": "- Integration with proactivity modes (Ambitious creates drafts, Kraken can auto-generate)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 666,
+        "match": "- Integration with proactivity modes (Ambitious creates drafts, Kraken can auto-generate)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 722,
+        "match": "- **Core**: \"Users dismiss email templates 80% in Proactive mode - reduce email suggestions?\""
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 727,
+        "match": "- \"Users prefer Flex for analysis tasks vs Core Kraken - suggest Flex for similar requests?\""
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 879,
+        "match": "- **Automated testing**: Self-generated tests for all meta-improvements"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 912,
+        "match": "- Day 2: CHAT 2 (Core modes + Tsunami overlay)"
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 917,
+        "match": "- **Track B**: CHAT 4 (Role intelligence + Kraken playbooks)"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 48,
+        "match": "│       │   └── overlay.js           # Tsunami overlay system (Chat 2C)"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 50,
+        "match": "│       ├── modes/                   # 🆕 6 PROACTIVITY MODES (Chat 2)"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 54,
+        "match": "│       │   ├── proactive.js         # Mode 2: Suggest via chips"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 56,
+        "match": "│       │   ├── kraken.js            # Mode 4: API orchestration"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 57,
+        "match": "│       │   └── tsunami.js           # Mode 5: System integration"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 66,
+        "match": "│       │   ├── playbooks.js         # Kraken workflow automation"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 69,
+        "match": "│       ├── adapters/                # 🆕 KRAKEN INTEGRATIONS (Chat 2D, 4C)"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 95,
+        "match": "│   │       ├── KrakenFeed.tsx"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 149,
+        "match": "│   │   └── overlay.ts             # 🆕 Tsunami overlay"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 205,
+        "match": "│   └── workflows/                # 🆕 KRAKEN WORKFLOW TEMPLATES"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 262,
+        "match": "│   │   ├── modes.config.json      # 6 proactivity modes config"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 268,
+        "match": "│   │   ├── playbooks.json         # Kraken workflow definitions"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 337,
+        "match": "- `js/modes/` - 6 proactivity mode implementations"
+      },
+      {
+        "file": "enterprise/docs/system/workbuoy_complete_root_system 230825.md",
+        "line": 340,
+        "match": "- `js/adapters/` - Kraken API integrations"
+      },
+      {
+        "file": "enterprise/examples/home.demo.js",
+        "line": 41,
+        "match": "<h2>Proactivity</h2>"
+      },
+      {
+        "file": "enterprise/examples/home.demo.js",
+        "line": 43,
+        "match": "{['Invisible','Calm','Proactive','Ambitious','Kraken','Tsunami'].map(m=> <option key={m}>{m}</option>)}"
+      },
+      {
+        "file": "enterprise/examples/home.demo.js",
+        "line": 43,
+        "match": "{['Invisible','Calm','Proactive','Ambitious','Kraken','Tsunami'].map(m=> <option key={m}>{m}</option>)}"
+      },
+      {
+        "file": "enterprise/examples/home.demo.js",
+        "line": 43,
+        "match": "{['Invisible','Calm','Proactive','Ambitious','Kraken','Tsunami'].map(m=> <option key={m}>{m}</option>)}"
+      },
+      {
+        "file": "enterprise/lib/connectors/notion.js",
+        "line": 3,
+        "match": "return [{ id:'n1', title:'Project Brief: Kraken', matched: query }];"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 7,
+        "match": "export const Proactivity = {"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 10,
+        "match": "PROACTIVE: 'Proactive',"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 12,
+        "match": "KRAKEN: 'Kraken',"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 13,
+        "match": "TSUNAMI: 'Tsunami'"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 18,
+        "match": "case Proactivity.INVISIBLE:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 21,
+        "match": "case Proactivity.CALM:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 23,
+        "match": "case Proactivity.PROACTIVE:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 25,
+        "match": "case Proactivity.AMBITIOUS:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 27,
+        "match": "case Proactivity.KRAKEN:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 27,
+        "match": "case Proactivity.KRAKEN:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 28,
+        "match": "return krakenOrchestrate({ input, context, user });"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 29,
+        "match": "case Proactivity.TSUNAMI:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 29,
+        "match": "case Proactivity.TSUNAMI:"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 30,
+        "match": "return tsunamiOverlay({ input, context, user });"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 45,
+        "match": "async function krakenOrchestrate({ input, context, user }){"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 56,
+        "match": "auditLog({user_email:user?.email, action:'kraken_aggregate', details:{ ms, sizes:{issues:merged.issues.length,pages:merged.pages.length,tickets:merged.tickets.length} }});"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 60,
+        "match": "function tsunamiOverlay({ input, context, user }){"
+      },
+      {
+        "file": "enterprise/lib/modes.js",
+        "line": 69,
+        "match": "auditLog({user_email:user?.email, action:'tsunami_plan', details:{ steps: plan.length }});"
+      },
+      {
+        "file": "enterprise/modes/handle.js",
+        "line": 2,
+        "match": "import { handleMode, Proactivity } from '../../../lib/modes.js';"
+      },
+      {
+        "file": "enterprise/modes/handle.js",
+        "line": 9,
+        "match": "if(!mode || !Object.values(Proactivity).includes(mode)) return res.status(400).json({error:'bad_mode'});"
+      },
+      {
+        "file": "enterprise/modes/tsunami/approve.js",
+        "line": 11,
+        "match": "const enabled = (process.env.TSUNAMI_WRITEBACK_ENABLED || 'false').toLowerCase() === 'true';"
+      },
+      {
+        "file": "enterprise/modes/tsunami/approve.js",
+        "line": 40,
+        "match": "auditLog({ user_email:user.email, action:'tsunami_writeback', details:{ writes } });"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 7,
+        "match": "export const Proactivity = {"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 10,
+        "match": "PROACTIVE: 'Proactive',"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 12,
+        "match": "KRAKEN: 'Kraken',"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 13,
+        "match": "TSUNAMI: 'Tsunami'"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 18,
+        "match": "case Proactivity.INVISIBLE:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 21,
+        "match": "case Proactivity.CALM:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 23,
+        "match": "case Proactivity.PROACTIVE:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 25,
+        "match": "case Proactivity.AMBITIOUS:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 27,
+        "match": "case Proactivity.KRAKEN:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 27,
+        "match": "case Proactivity.KRAKEN:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 28,
+        "match": "return krakenOrchestrate({ input, context, user });"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 29,
+        "match": "case Proactivity.TSUNAMI:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 29,
+        "match": "case Proactivity.TSUNAMI:"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 30,
+        "match": "return tsunamiOverlay({ input, context, user });"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 45,
+        "match": "async function krakenOrchestrate({ input, context, user }){"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 56,
+        "match": "auditLog({user_email:user?.email, action:'kraken_aggregate', details:{ ms, sizes:{issues:merged.issues.length,pages:merged.pages.length,tickets:merged.tickets.length} }});"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 60,
+        "match": "function tsunamiOverlay({ input, context, user }){"
+      },
+      {
+        "file": "enterprise/modes.js",
+        "line": 69,
+        "match": "auditLog({user_email:user?.email, action:'tsunami_plan', details:{ steps: plan.length }});"
+      },
+      {
+        "file": "enterprise/pages/api/cxm/crm/notes.preview.js",
+        "line": 7,
+        "match": "// Optional: tsunami/approve.js integration (best-effort)."
+      },
+      {
+        "file": "enterprise/pages/api/cxm/crm/notes.preview.js",
+        "line": 11,
+        "match": "approver = require('../../../../tsunami/approve.js');"
+      },
+      {
+        "file": "enterprise/pages/api/cxm/crm/notes.preview.js",
+        "line": 36,
+        "match": "approval = { required: true, flow: 'tsunami/approve', id: prep.id };"
+      },
+      {
+        "file": "enterprise/pages/api/cxm/crm/notes.preview.js",
+        "line": 38,
+        "match": "approval = { required: true, flow: 'tsunami/approve', error: e.message };"
+      },
+      {
+        "file": "enterprise/pages/api/cxm/crm/notes.preview.js",
+        "line": 41,
+        "match": "approval = { required: true, flow: 'none', hint: 'tsunami/approve.js not available' };"
+      },
+      {
+        "file": "enterprise/pages/api/modes/handle.js",
+        "line": 2,
+        "match": "import { handleMode, Proactivity } from '../../../lib/modes.js';"
+      },
+      {
+        "file": "enterprise/pages/api/modes/handle.js",
+        "line": 9,
+        "match": "if(!mode || !Object.values(Proactivity).includes(mode)) return res.status(400).json({error:'bad_mode'});"
+      },
+      {
+        "file": "enterprise/pages/api/modes/tsunami/approve.js",
+        "line": 11,
+        "match": "const enabled = (process.env.TSUNAMI_WRITEBACK_ENABLED || 'false').toLowerCase() === 'true';"
+      },
+      {
+        "file": "enterprise/pages/api/modes/tsunami/approve.js",
+        "line": 40,
+        "match": "auditLog({ user_email:user.email, action:'tsunami_writeback', details:{ writes } });"
+      },
+      {
+        "file": "enterprise/public/config/core.config.json",
+        "line": 25,
+        "match": "\"id\": \"proactive\","
+      },
+      {
+        "file": "enterprise/public/config/core.config.json",
+        "line": 26,
+        "match": "\"label\": \"Proactive\","
+      },
+      {
+        "file": "enterprise/public/config/core.config.json",
+        "line": 47,
+        "match": "\"id\": \"kraken\","
+      },
+      {
+        "file": "enterprise/public/config/core.config.json",
+        "line": 48,
+        "match": "\"label\": \"Kraken\","
+      },
+      {
+        "file": "enterprise/public/config/core.config.json",
+        "line": 68,
+        "match": "\"id\": \"tsunami\","
+      },
+      {
+        "file": "enterprise/public/config/core.config.json",
+        "line": 69,
+        "match": "\"label\": \"Tsunami\","
+      },
+      {
+        "file": "enterprise/public/config/secure.policy.json",
+        "line": 42,
+        "match": "\"Tsunami\": {"
+      },
+      {
+        "file": "enterprise/public/config/secure.policy.json",
+        "line": 46,
+        "match": "\"Kraken\": {"
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 262,
+        "match": "<p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 262,
+        "match": "<p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 401,
+        "match": "usynlig: {"
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 402,
+        "match": "title: \"Usynlig Modus\","
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 416,
+        "match": "kraken: {"
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 417,
+        "match": "title: \"Kraken Modus\","
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 421,
+        "match": "tsunami: {"
+      },
+      {
+        "file": "enterprise/public/index.html",
+        "line": 422,
+        "match": "title: \"Tsunami Modus\","
+      },
+      {
+        "file": "enterprise/public/index.html.bak",
+        "line": 73,
+        "match": "<script src=\"/js/modes/proactive.js\"></script>"
+      },
+      {
+        "file": "enterprise/public/index.html.bak",
+        "line": 79,
+        "match": "<script src=\"/js/modes/kraken.js\"></script>"
+      },
+      {
+        "file": "enterprise/public/index.html.bak",
+        "line": 80,
+        "match": "<script src=\"/js/modes/tsunami.js\"></script>"
+      },
+      {
+        "file": "enterprise/public/js/chat.js",
+        "line": 7,
+        "match": "const saved = localStorage.getItem('wb.coreMode') || 'proactive'; modeSel.value=saved;"
+      },
+      {
+        "file": "enterprise/public/js/chat.js",
+        "line": 12,
+        "match": "const m = (localStorage.getItem('wb.coreMode')||'proactive');"
+      },
+      {
+        "file": "enterprise/public/js/chat.js",
+        "line": 13,
+        "match": "if(m==='invisible') return '(Usynlig) — ingen forslag.';"
+      },
+      {
+        "file": "enterprise/public/js/marketing.js",
+        "line": 100,
+        "match": "usynlig: {"
+      },
+      {
+        "file": "enterprise/public/js/marketing.js",
+        "line": 101,
+        "match": "title: \"Usynlig Modus\","
+      },
+      {
+        "file": "enterprise/public/js/marketing.js",
+        "line": 115,
+        "match": "kraken: {"
+      },
+      {
+        "file": "enterprise/public/js/marketing.js",
+        "line": 116,
+        "match": "title: \"Kraken Modus\","
+      },
+      {
+        "file": "enterprise/public/js/marketing.js",
+        "line": 120,
+        "match": "tsunami: {"
+      },
+      {
+        "file": "enterprise/public/js/marketing.js",
+        "line": 121,
+        "match": "title: \"Tsunami Modus\","
+      },
+      {
+        "file": "enterprise/public/js/modes/kraken.js",
+        "line": 19,
+        "match": "window.Kraken = {runPlaybook};"
+      },
+      {
+        "file": "enterprise/public/js/modes/tsunami.js",
+        "line": 2,
+        "match": "// same as Kraken, but with overlay HUD always on & user choices"
+      },
+      {
+        "file": "enterprise/public/js/modes/tsunami.js",
+        "line": 4,
+        "match": "Overlay.show({content:{title:'Tsunami HUD',summary:'Autonom kjøring aktiv'}, suggestion:{actions:[{id:'pause',label:'Pause'},{id:'stop',label:'Stopp'}]}, live_feed:true});"
+      },
+      {
+        "file": "enterprise/public/js/modes/tsunami.js",
+        "line": 11,
+        "match": "if((localStorage.getItem('wb.coreMode')||'proactive')!=='tsunami') return;"
+      },
+      {
+        "file": "enterprise/public/js/modes/tsunami.js",
+        "line": 11,
+        "match": "if((localStorage.getItem('wb.coreMode')||'proactive')!=='tsunami') return;"
+      },
+      {
+        "file": "enterprise/public/js/policies.js",
+        "line": 22,
+        "match": "function getCoreMode(){ return localStorage.getItem('wb.coreMode') || 'proactive'; }"
+      },
+      {
+        "file": "enterprise/public/js/transparency.js",
+        "line": 24,
+        "match": "const mode = localStorage.getItem('wb.coreMode') || 'proactive';"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 952,
+        "match": "<p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 952,
+        "match": "<p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 965,
+        "match": "<li style=\"display: flex; align-items: center; gap: 0.5rem;\"><span style=\"color: #10b981;\">✓</span> Navi (Usynlig, Passiv, Aktiv)</li>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1001,
+        "match": "<li style=\"display: flex; align-items: center; gap: 0.5rem;\"><span style=\"color: #f59e0b;\">⚡</span> <strong>Kraken & Tsunami moduser</strong></li>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1001,
+        "match": "<li style=\"display: flex; align-items: center; gap: 0.5rem;\"><span style=\"color: #f59e0b;\">⚡</span> <strong>Kraken & Tsunami moduser</strong></li>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1123,
+        "match": "usynlig: {"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1124,
+        "match": "title: \"Usynlig Modus\","
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1138,
+        "match": "kraken: {"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1139,
+        "match": "title: \"Kraken Modus\","
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1143,
+        "match": "tsunami: {"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1144,
+        "match": "title: \"Tsunami Modus\","
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1191,
+        "match": "<p>Navi setter hele plattformen i modus – fra stille observatør til tsunami av automasjon. Dra for å utforske hvordan intelligensen tilpasser seg dine behov.</p>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1196,
+        "match": "<div class=\"mode-step active\" data-mode=\"usynlig\">"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1198,
+        "match": "<div class=\"mode-title\">Usynlig</div>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1211,
+        "match": "<div class=\"mode-step\" data-mode=\"kraken\">"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1213,
+        "match": "<div class=\"mode-title\">Kraken</div>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1216,
+        "match": "<div class=\"mode-step\" data-mode=\"tsunami\">"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1218,
+        "match": "<div class=\"mode-title\">Tsunami</div>"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1224,
+        "match": "<h3>Usynlig Modus</h3>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 979,
+        "match": "<p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 979,
+        "match": "<p>Fra oppstart til enterprise - WorkBuoy skalerer med dine behov. Kraken og Tsunami-moduser kun tilgjengelig i Enterprise.</p>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1117,
+        "match": "usynlig: {"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1118,
+        "match": "title: \"Usynlig Modus\","
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1132,
+        "match": "kraken: {"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1133,
+        "match": "title: \"Kraken Modus\","
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1137,
+        "match": "tsunami: {"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1138,
+        "match": "title: \"Tsunami Modus\","
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1185,
+        "match": "<p>Navi setter hele plattformen i modus – fra stille observatør til tsunami av automasjon. Dra for å utforske hvordan intelligensen tilpasser seg dine behov.</p>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1190,
+        "match": "<div class=\"mode-step active\" data-mode=\"usynlig\">"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1192,
+        "match": "<div class=\"mode-title\">Usynlig</div>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1205,
+        "match": "<div class=\"mode-step\" data-mode=\"kraken\">"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1207,
+        "match": "<div class=\"mode-title\">Kraken</div>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1210,
+        "match": "<div class=\"mode-step\" data-mode=\"tsunami\">"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1212,
+        "match": "<div class=\"mode-title\">Tsunami</div>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1218,
+        "match": "<h3>Usynlig Modus</h3>"
+      },
+      {
+        "file": "enterprise/secure.policy.json",
+        "line": 3,
+        "match": "\"Tsunami\": {"
+      },
+      {
+        "file": "enterprise/secure.policy.json",
+        "line": 6,
+        "match": "\"Kraken\": {"
+      },
+      {
+        "file": "enterprise/workflows/backlog.json",
+        "line": 28,
+        "match": "\"title\": \"Kraken stub\","
+      },
+      {
+        "file": "enterprise/workflows/backlog.json",
+        "line": 34,
+        "match": "\"title\": \"Tsunami overlay stub\","
+      },
+      {
+        "file": "frontend/src/features/navi/ModeSwitch.tsx",
+        "line": 5,
+        "match": "const ORDER: AutonomyMode[] = [\"passiv\",\"proaktiv\",\"ambisiøs\",\"kraken\"];"
+      },
+      {
+        "file": "frontend/src/features/navi/ModeSwitch.tsx",
+        "line": 5,
+        "match": "const ORDER: AutonomyMode[] = [\"passiv\",\"proaktiv\",\"ambisiøs\",\"kraken\"];"
+      },
+      {
+        "file": "frontend/src/features/navi/ModeSwitch.tsx",
+        "line": 27,
+        "match": "case \"ambisiøs\": return \"Forbered utkast automatisk.\";"
+      },
+      {
+        "file": "frontend/src/features/navi/ModeSwitch.tsx",
+        "line": 28,
+        "match": "case \"kraken\": return \"Kan auto-utføre (policy-styrt).\";"
+      },
+      {
+        "file": "frontend/src/features/navi/policy.ts",
+        "line": 1,
+        "match": "export type AutonomyMode = \"passiv\" | \"proaktiv\" | \"ambisiøs\" | \"kraken\";"
+      },
+      {
+        "file": "frontend/src/features/navi/policy.ts",
+        "line": 1,
+        "match": "export type AutonomyMode = \"passiv\" | \"proaktiv\" | \"ambisiøs\" | \"kraken\";"
+      },
+      {
+        "file": "frontend/src/features/navi/policy.ts",
+        "line": 6,
+        "match": "ambisiøs: \"Ambisiøs\","
+      },
+      {
+        "file": "frontend/src/features/navi/policy.ts",
+        "line": 7,
+        "match": "kraken: \"Kraken\","
+      },
+      {
+        "file": "frontend/src/features/navi/policy.ts",
+        "line": 20,
+        "match": "ambisiøs: { canShowSuggestions: true,  canShowActions: true,  canAutoDraft: true,  canAutoExecute: false },"
+      },
+      {
+        "file": "frontend/src/features/navi/policy.ts",
+        "line": 21,
+        "match": "kraken:   { canShowSuggestions: true,  canShowActions: true,  canAutoDraft: true,  canAutoExecute: true  },"
+      },
+      {
+        "file": "grafana/dashboards/proactivity.json",
+        "line": 2,
+        "match": "\"title\": \"Proactivity Overview\","
+      },
+      {
+        "file": "grafana/dashboards/proactivity.json",
+        "line": 3,
+        "match": "\"uid\": \"proactivity\","
+      },
+      {
+        "file": "grafana/dashboards/proactivity.json",
+        "line": 10,
+        "match": "{ \"expr\": \"proactivity_dummy\" }"
+      },
+      {
+        "file": "grafana/dashboards/proactivity.json",
+        "line": 18,
+        "match": "{ \"expr\": \"proactivity_degrade_total\" }"
+      },
+      {
+        "file": "grafana/dashboards/proactivity.json",
+        "line": 26,
+        "match": "{ \"expr\": \"proactivity_overrides\" }"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 3,
+        "match": "title: Workbuoy Proactivity API"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 8,
+        "match": "/api/proactivity/state:"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 10,
+        "match": "summary: Get proactivity state for current tenant/user"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 22,
+        "match": "name: x-proactivity"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 28,
+        "match": "description: Current proactivity posture"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 32,
+        "match": "$ref: '#/components/schemas/ProactivityState'"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 34,
+        "match": "summary: Request a new proactivity mode"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 59,
+        "match": "description: Resolved proactivity state"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 63,
+        "match": "$ref: '#/components/schemas/ProactivityState'"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 112,
+        "match": "summary: Fetch recent proactivity events for explainability UI"
+      },
+      {
+        "file": "openapi/proactivity.yaml",
+        "line": 127,
+        "match": "ProactivityState:"
+      },
+      {
+        "file": "package.json",
+        "line": 5,
+        "match": "\"build\": \"tsc --noEmit -p tsconfig.proactivity.json\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7789,
+        "match": "\"ai_assists\": [\"Process optimization recommendations\", \"Automated data mapping\", \"Compliance monitoring\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7819,
+        "match": "\"ai_assists\": [\"Automated test case generation\", \"User behavior analysis\", \"Process optimization suggestions\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7879,
+        "match": "\"ai_assists\": [\"Predictive analytics\", \"Anomaly detection\", \"Automated insights generation\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8107,
+        "match": "\"Design and maintain CI/CD pipelines for automated deployment\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8119,
+        "match": "\"ai_assists\": [\"Anomaly detection in logs\", \"Predictive scaling\", \"Automated incident response\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8352,
+        "match": "\"stakeholders_external\": [\"Advisory board\", \"Key customers\"],"
+      },
+      {
+        "file": "simulation/kraken_sim.py",
+        "line": 2,
+        "match": "# Kraken Simulation (stub) — runs planner -> builder -> policy and logs events."
+      },
+      {
+        "file": "simulation/kraken_sim.py",
+        "line": 97,
+        "match": "with open(os.path.join(LOGS, \"kraken_sim.json\"), \"w\", encoding=\"utf-8\") as f:"
+      },
+      {
+        "file": "simulation/kraken_sim.py",
+        "line": 99,
+        "match": "print(\"Wrote logs/kraken_sim.json\")"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 3,
+        "match": "import { modeToKey, ProactivityMode } from './proactivity/modes';"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 24,
+        "match": "const { policy, proactivity } = await policyCheckRoleAware({ capability: capabilityId, featureId, payload }, ctx, rr, policyCheckImpl);"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 25,
+        "match": "const mode = proactivity.effective;"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 31,
+        "match": "proactivity: {"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 32,
+        "match": "requested: proactivity.requestedKey,"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 33,
+        "match": "effective: proactivity.effectiveKey,"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 34,
+        "match": "basis: proactivity.basis,"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 43,
+        "match": "return { policy, proactivity };"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 48,
+        "match": "case ProactivityMode.Usynlig:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 48,
+        "match": "case ProactivityMode.Usynlig:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 49,
+        "match": "case ProactivityMode.Rolig:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 49,
+        "match": "case ProactivityMode.Rolig:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 52,
+        "match": "case ProactivityMode.Proaktiv:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 55,
+        "match": "case ProactivityMode.Ambisiøs:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 55,
+        "match": "case ProactivityMode.Ambisiøs:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 58,
+        "match": "case ProactivityMode.Kraken:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 58,
+        "match": "case ProactivityMode.Kraken:"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 61,
+        "match": "case ProactivityMode.Tsunami: {"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 61,
+        "match": "case ProactivityMode.Tsunami: {"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 79,
+        "match": "return { outcome, policy, proactivity };"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 3,
+        "match": "import { buildProactivityContext, ProactivityState } from './proactivity/context';"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 4,
+        "match": "import { ProactivityMode } from './proactivity/modes';"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 9,
+        "match": "requestedMode?: ProactivityMode | number | string;"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 10,
+        "match": "degradeRail?: ProactivityMode[];"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 11,
+        "match": "policyCap?: ProactivityMode;"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 16,
+        "match": "proactivity: ProactivityState;"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 29,
+        "match": "const proactivity = buildProactivityContext({"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 41,
+        "match": "{ autonomy_level: proactivity.effective, tenantId: ctx.tenantId, role: userCtx.roles[0]?.role_id ?? 'unknown' }"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 44,
+        "match": "const basisSet = new Set<string>([...(policy.basis ?? []), ...proactivity.basis]);"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 49,
+        "match": "proactivity,"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 3,
+        "match": "import { PROACTIVITY_MODE_META, ProactivityMode, modeToKey, parseProactivityMode, DEFAULT_DEGRADE_RAIL } from './modes';"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 4,
+        "match": "import { resolveEffectiveMode, ProactivityCap, ProactivityResolution } from './state';"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 8,
+        "match": "export interface ProactivityContextInput {"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 13,
+        "match": "requestedMode?: string | number | ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 14,
+        "match": "policyCap?: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 15,
+        "match": "degradeRail?: ProactivityMode[];"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 19,
+        "match": "export interface ProactivityState extends ProactivityResolution {"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 23,
+        "match": "uiHints: typeof PROACTIVITY_MODE_META[ProactivityMode.Proaktiv]['uiHints'];"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 24,
+        "match": "meta: typeof PROACTIVITY_MODE_META[ProactivityMode.Proaktiv];"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 35,
+        "match": "): { cap?: ProactivityMode; featureId?: string } {"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 40,
+        "match": ": userCtx.features.reduce<{ feature?: typeof userCtx.features[number]; cap?: ProactivityMode }>((best, f) => {"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 41,
+        "match": "const cap = (userCtx.featureCaps[f.id] ?? f.autonomyCap ?? f.defaultAutonomyCap ?? ProactivityMode.Proaktiv) as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 42,
+        "match": "if (!best.feature || (best.cap ?? ProactivityMode.Usynlig) < cap) {"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 42,
+        "match": "if (!best.feature || (best.cap ?? ProactivityMode.Usynlig) < cap) {"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 46,
+        "match": "}, {} as { feature?: typeof userCtx.features[number]; cap?: ProactivityMode }).feature;"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 49,
+        "match": "const cap = (userCtx.featureCaps[featureWithCap.id] ?? featureWithCap.autonomyCap ?? featureWithCap.defaultAutonomyCap ?? ProactivityMode.Proaktiv) as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 53,
+        "match": "export function buildProactivityContext(input: ProactivityContextInput): ProactivityState {"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 55,
+        "match": "const caps: ProactivityCap[] = ["
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 63,
+        "match": "const requested = parseProactivityMode(input.requestedMode);"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 84,
+        "match": "const meta = PROACTIVITY_MODE_META[resolution.effective];"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 85,
+        "match": "const state: ProactivityState = {"
+      },
+      {
+        "file": "src/core/proactivity/guards.ts",
+        "line": 1,
+        "match": "import { ProactivityMode, modeToKey } from './modes';"
+      },
+      {
+        "file": "src/core/proactivity/guards.ts",
+        "line": 2,
+        "match": "import type { ProactivityState } from './context';"
+      },
+      {
+        "file": "src/core/proactivity/guards.ts",
+        "line": 4,
+        "match": "type BasicRequest = { proactivity?: ProactivityState; [key: string]: any };"
+      },
+      {
+        "file": "src/core/proactivity/guards.ts",
+        "line": 8,
+        "match": "export function requiresProMode(required: ProactivityMode) {"
+      },
+      {
+        "file": "src/core/proactivity/guards.ts",
+        "line": 10,
+        "match": "const state = req.proactivity;"
+      },
+      {
+        "file": "src/core/proactivity/guards.ts",
+        "line": 13,
+        "match": "error: 'proactivity_required',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 1,
+        "match": "export enum ProactivityMode {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 2,
+        "match": "Usynlig = 1,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 3,
+        "match": "Rolig = 2,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 5,
+        "match": "Ambisiøs = 4,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 6,
+        "match": "Kraken = 5,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 7,
+        "match": "Tsunami = 6,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 10,
+        "match": "export type ProactivityModeKey ="
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 11,
+        "match": "| 'usynlig'"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 12,
+        "match": "| 'rolig'"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 14,
+        "match": "| 'ambisiøs'"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 15,
+        "match": "| 'kraken'"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 16,
+        "match": "| 'tsunami';"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 18,
+        "match": "export interface ProactivityModeMeta {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 19,
+        "match": "id: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 20,
+        "match": "key: ProactivityModeKey;"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 34,
+        "match": "export const PROACTIVITY_MODE_META: Record<ProactivityMode, ProactivityModeMeta> = {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 35,
+        "match": "[ProactivityMode.Usynlig]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 35,
+        "match": "[ProactivityMode.Usynlig]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 36,
+        "match": "id: ProactivityMode.Usynlig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 36,
+        "match": "id: ProactivityMode.Usynlig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 37,
+        "match": "key: 'usynlig',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 38,
+        "match": "label: 'Usynlig',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 50,
+        "match": "[ProactivityMode.Rolig]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 50,
+        "match": "[ProactivityMode.Rolig]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 51,
+        "match": "id: ProactivityMode.Rolig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 51,
+        "match": "id: ProactivityMode.Rolig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 52,
+        "match": "key: 'rolig',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 53,
+        "match": "label: 'Rolig',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 65,
+        "match": "[ProactivityMode.Proaktiv]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 66,
+        "match": "id: ProactivityMode.Proaktiv,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 80,
+        "match": "[ProactivityMode.Ambisiøs]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 80,
+        "match": "[ProactivityMode.Ambisiøs]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 81,
+        "match": "id: ProactivityMode.Ambisiøs,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 81,
+        "match": "id: ProactivityMode.Ambisiøs,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 82,
+        "match": "key: 'ambisiøs',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 83,
+        "match": "label: 'Ambisiøs',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 95,
+        "match": "[ProactivityMode.Kraken]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 95,
+        "match": "[ProactivityMode.Kraken]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 96,
+        "match": "id: ProactivityMode.Kraken,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 96,
+        "match": "id: ProactivityMode.Kraken,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 97,
+        "match": "key: 'kraken',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 98,
+        "match": "label: 'Kraken',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 110,
+        "match": "[ProactivityMode.Tsunami]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 110,
+        "match": "[ProactivityMode.Tsunami]: {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 111,
+        "match": "id: ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 111,
+        "match": "id: ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 112,
+        "match": "key: 'tsunami',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 113,
+        "match": "label: 'Tsunami',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 115,
+        "match": "degradeHint: 'will degrade to Kraken on overlay or health-check failure',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 127,
+        "match": "export const DEFAULT_PROACTIVITY_MODE = ProactivityMode.Proaktiv;"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 129,
+        "match": "export const PROACTIVITY_MODE_ORDER: ProactivityMode[] = ["
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 130,
+        "match": "ProactivityMode.Usynlig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 130,
+        "match": "ProactivityMode.Usynlig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 131,
+        "match": "ProactivityMode.Rolig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 131,
+        "match": "ProactivityMode.Rolig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 132,
+        "match": "ProactivityMode.Proaktiv,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 133,
+        "match": "ProactivityMode.Ambisiøs,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 133,
+        "match": "ProactivityMode.Ambisiøs,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 134,
+        "match": "ProactivityMode.Kraken,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 134,
+        "match": "ProactivityMode.Kraken,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 135,
+        "match": "ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 135,
+        "match": "ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 138,
+        "match": "export const DEFAULT_DEGRADE_RAIL: ProactivityMode[] = ["
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 139,
+        "match": "ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 139,
+        "match": "ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 140,
+        "match": "ProactivityMode.Kraken,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 140,
+        "match": "ProactivityMode.Kraken,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 141,
+        "match": "ProactivityMode.Ambisiøs,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 141,
+        "match": "ProactivityMode.Ambisiøs,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 142,
+        "match": "ProactivityMode.Proaktiv,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 143,
+        "match": "ProactivityMode.Rolig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 143,
+        "match": "ProactivityMode.Rolig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 144,
+        "match": "ProactivityMode.Usynlig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 144,
+        "match": "ProactivityMode.Usynlig,"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 147,
+        "match": "export function modeToKey(mode: ProactivityMode): ProactivityModeKey {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 148,
+        "match": "return PROACTIVITY_MODE_META[mode]?.key ?? 'proaktiv';"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 151,
+        "match": "export function parseProactivityMode(input: unknown, fallback: ProactivityMode = DEFAULT_PROACTIVITY_MODE): ProactivityMode {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 153,
+        "match": "if (typeof input === 'number' && PROACTIVITY_MODE_META[input as ProactivityMode]) {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 154,
+        "match": "return input as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 158,
+        "match": "const matched = PROACTIVITY_MODE_ORDER.find(mode => modeToKey(mode) === normalized);"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 161,
+        "match": "if (!Number.isNaN(asNumber) && PROACTIVITY_MODE_META[asNumber as ProactivityMode]) {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 162,
+        "match": "return asNumber as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 168,
+        "match": "export function isExecutionMode(mode: ProactivityMode) {"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 169,
+        "match": "return mode >= ProactivityMode.Kraken;"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 169,
+        "match": "return mode >= ProactivityMode.Kraken;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 1,
+        "match": "import { DEFAULT_DEGRADE_RAIL, ProactivityMode, modeToKey } from './modes';"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 3,
+        "match": "export interface ProactivityCap {"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 6,
+        "match": "mode: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 11,
+        "match": "requested: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 12,
+        "match": "caps?: ProactivityCap[];"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 14,
+        "match": "degradeRail?: ProactivityMode[];"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 18,
+        "match": "export interface ProactivityResolution {"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 19,
+        "match": "requested: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 20,
+        "match": "effective: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 22,
+        "match": "caps: ProactivityCap[];"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 23,
+        "match": "degradeRail: ProactivityMode[];"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 26,
+        "match": "function clampToRail(mode: ProactivityMode, rail: ProactivityMode[]): ProactivityMode {"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 36,
+        "match": "function degradeDown(current: ProactivityMode, limit: ProactivityMode, rail: ProactivityMode[]): ProactivityMode {"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 41,
+        "match": "return Math.max(limit, ProactivityMode.Usynlig) as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 41,
+        "match": "return Math.max(limit, ProactivityMode.Usynlig) as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 52,
+        "match": "export function resolveEffectiveMode(input: ResolveEffectiveModeInput): ProactivityResolution {"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 65,
+        "match": "effective = ProactivityMode.Usynlig;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 65,
+        "match": "effective = ProactivityMode.Usynlig;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 85,
+        "match": "export function degradeOnError(current: ProactivityMode, rail: ProactivityMode[] = DEFAULT_DEGRADE_RAIL): ProactivityMode {"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 88,
+        "match": "const fallback = Math.max(current - 1, ProactivityMode.Usynlig) as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/state.ts",
+        "line": 88,
+        "match": "const fallback = Math.max(current - 1, ProactivityMode.Usynlig) as ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 1,
+        "match": "import { modeToKey, ProactivityMode } from './modes';"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 2,
+        "match": "import type { ProactivityState } from './context';"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 4,
+        "match": "export interface ProactivityTelemetryEvent {"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 8,
+        "match": "requested: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 9,
+        "match": "effective: ProactivityMode;"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 15,
+        "match": "const events: ProactivityTelemetryEvent[] = [];"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 18,
+        "match": "export function logModusskift(state: ProactivityState, opts: { tenantId: string; userId?: string; source?: string }): void {"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 19,
+        "match": "const entry: ProactivityTelemetryEvent = {"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 35,
+        "match": "export function getRecentProactivityEvents(limit = 10): (ProactivityTelemetryEvent & { requestedKey: string; effectiveKey: string })[] {"
+      },
+      {
+        "file": "src/core/proactivity/telemetry.ts",
+        "line": 46,
+        "match": "export function resetProactivityTelemetry() {"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 1,
+        "match": "import { ProactivityMode } from '../proactivity/modes';"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 7,
+        "match": "flex: { plan: 'flex', maxMode: ProactivityMode.Ambisiøs },"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 7,
+        "match": "flex: { plan: 'flex', maxMode: ProactivityMode.Ambisiøs },"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 8,
+        "match": "secure: { plan: 'secure', maxMode: ProactivityMode.Proaktiv },"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 9,
+        "match": "enterprise: { plan: 'enterprise', maxMode: ProactivityMode.Tsunami },"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 9,
+        "match": "enterprise: { plan: 'enterprise', maxMode: ProactivityMode.Tsunami },"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 12,
+        "match": "export function getPlanMaxMode(plan: SubscriptionPlan): ProactivityMode {"
+      },
+      {
+        "file": "src/core/subscription/entitlements.ts",
+        "line": 13,
+        "match": "return PLAN_ENTITLEMENTS[plan]?.maxMode ?? ProactivityMode.Proaktiv;"
+      },
+      {
+        "file": "src/core/subscription/state.ts",
+        "line": 1,
+        "match": "import { ProactivityMode } from '../proactivity/modes';"
+      },
+      {
+        "file": "src/core/subscription/state.ts",
+        "line": 29,
+        "match": "maxMode: ProactivityMode;"
+      },
+      {
+        "file": "src/core/subscription/state.ts",
+        "line": 35,
+        "match": "const secureCap = settings.secureTenant ? Math.min(planCap, ProactivityMode.Proaktiv) as ProactivityMode : planCap;"
+      },
+      {
+        "file": "src/core/subscription/state.ts",
+        "line": 36,
+        "match": "const maxMode = settings.killSwitch ? ProactivityMode.Usynlig : secureCap;"
+      },
+      {
+        "file": "src/core/subscription/state.ts",
+        "line": 36,
+        "match": "const maxMode = settings.killSwitch ? ProactivityMode.Usynlig : secureCap;"
+      },
+      {
+        "file": "src/core/subscription/types.ts",
+        "line": 1,
+        "match": "import type { ProactivityMode } from '../proactivity/modes';"
+      },
+      {
+        "file": "src/core/subscription/types.ts",
+        "line": 10,
+        "match": "maxOverride?: ProactivityMode;"
+      },
+      {
+        "file": "src/core/subscription/types.ts",
+        "line": 15,
+        "match": "maxMode: ProactivityMode;"
+      },
+      {
+        "file": "src/ingest/jobboards/pipeline.ts",
+        "line": 6,
+        "match": "'report_generation_automation': ['automated reports','reporting automation'],"
+      },
+      {
+        "file": "src/server.ts",
+        "line": 60,
+        "match": "safeMount('/api', '../backend/routes/proactivity');"
+      },
+      {
+        "file": "tests/explainability/last.test.ts",
+        "line": 3,
+        "match": "import { resetProactivityTelemetry } from '../../src/core/proactivity/telemetry';"
+      },
+      {
+        "file": "tests/explainability/last.test.ts",
+        "line": 6,
+        "match": "beforeEach(() => resetProactivityTelemetry());"
+      },
+      {
+        "file": "tests/explainability/last.test.ts",
+        "line": 10,
+        "match": ".get('/api/proactivity/state')"
+      },
+      {
+        "file": "tests/explainability/last.test.ts",
+        "line": 14,
+        "match": ".set('x-proactivity', 'kraken');"
+      },
+      {
+        "file": "tests/explainability/last.test.ts",
+        "line": 14,
+        "match": ".set('x-proactivity', 'kraken');"
+      },
+      {
+        "file": "tests/metrics/metrics.test.ts",
+        "line": 5,
+        "match": "it('exposes proactivity metrics in Prometheus format', async () => {"
+      },
+      {
+        "file": "tests/metrics/metrics.test.ts",
+        "line": 8,
+        "match": "expect(res.text).toContain('proactivity_dummy');"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 3,
+        "match": "import { ProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 20,
+        "match": "{ tenantId: 'TEN', roleBinding: { userId: 'user', primaryRole: 'sales_rep' }, requestedMode: ProactivityMode.Tsunami },"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 20,
+        "match": "{ tenantId: 'TEN', roleBinding: { userId: 'user', primaryRole: 'sales_rep' }, requestedMode: ProactivityMode.Tsunami },"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 25,
+        "match": "expect(result.proactivity.effective).toBe(ProactivityMode.Proaktiv);"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 26,
+        "match": "expect(result.proactivity.basis).toEqual(expect.arrayContaining(['cap:role:crm:proaktiv']));"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 29,
+        "match": "expect.objectContaining({ autonomy_level: ProactivityMode.Proaktiv })"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 4,
+        "match": "import { resetProactivityTelemetry, getRecentProactivityEvents } from '../../src/core/proactivity/telemetry';"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 5,
+        "match": "import { ProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 7,
+        "match": "describe('GET /api/proactivity/state', () => {"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 10,
+        "match": "resetProactivityTelemetry();"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 16,
+        "match": ".get('/api/proactivity/state')"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 20,
+        "match": ".set('x-proactivity', 'tsunami');"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 20,
+        "match": ".set('x-proactivity', 'tsunami');"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 23,
+        "match": "expect(res.body.requestedKey).toBe('tsunami');"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 24,
+        "match": "expect(res.body.effectiveKey).toBe('ambisiøs');"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 27,
+        "match": "const events = getRecentProactivityEvents(1);"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 29,
+        "match": "expect(events[0].requestedKey).toBe('tsunami');"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 35,
+        "match": ".post('/api/proactivity/state')"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 39,
+        "match": ".send({ requestedMode: ProactivityMode.Kraken });"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 39,
+        "match": ".send({ requestedMode: ProactivityMode.Kraken });"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 42,
+        "match": "expect(res.body.effective).toBe(ProactivityMode.Kraken);"
+      },
+      {
+        "file": "tests/proactivity/api-state.test.ts",
+        "line": 42,
+        "match": "expect(res.body.effective).toBe(ProactivityMode.Kraken);"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 3,
+        "match": "import { ProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 27,
+        "match": "{ mode: ProactivityMode.Usynlig, invoked: 'observe' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 27,
+        "match": "{ mode: ProactivityMode.Usynlig, invoked: 'observe' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 28,
+        "match": "{ mode: ProactivityMode.Rolig, invoked: 'observe' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 28,
+        "match": "{ mode: ProactivityMode.Rolig, invoked: 'observe' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 29,
+        "match": "{ mode: ProactivityMode.Proaktiv, invoked: 'suggest' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 30,
+        "match": "{ mode: ProactivityMode.Ambisiøs, invoked: 'prepare' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 30,
+        "match": "{ mode: ProactivityMode.Ambisiøs, invoked: 'prepare' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 31,
+        "match": "{ mode: ProactivityMode.Kraken, invoked: 'execute' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 31,
+        "match": "{ mode: ProactivityMode.Kraken, invoked: 'execute' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 32,
+        "match": "{ mode: ProactivityMode.Tsunami, invoked: 'execute+overlay' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 32,
+        "match": "{ mode: ProactivityMode.Tsunami, invoked: 'execute+overlay' },"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 61,
+        "match": "expect(result.proactivity.effective).toBeLessThanOrEqual(mode);"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 63,
+        "match": "expect(logEvent?.proactivity?.basis?.some((entry: string) => entry.startsWith('requested:'))).toBe(true);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 1,
+        "match": "import { resolveEffectiveMode, degradeOnError } from '../../src/core/proactivity/state';"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 2,
+        "match": "import { ProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 4,
+        "match": "describe('proactivity state resolver', () => {"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 7,
+        "match": "requested: ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 7,
+        "match": "requested: ProactivityMode.Tsunami,"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 9,
+        "match": "{ id: 'subscription:flex', mode: ProactivityMode.Ambisiøs },"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 9,
+        "match": "{ id: 'subscription:flex', mode: ProactivityMode.Ambisiøs },"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 10,
+        "match": "{ id: 'role:feature', mode: ProactivityMode.Proaktiv },"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 13,
+        "match": "expect(res.effective).toBe(ProactivityMode.Proaktiv);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 15,
+        "match": "'requested:tsunami',"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 16,
+        "match": "'cap:subscription:flex:ambisiøs',"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 21,
+        "match": "it('honours kill switch by forcing usynlig', () => {"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 23,
+        "match": "requested: ProactivityMode.Kraken,"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 23,
+        "match": "requested: ProactivityMode.Kraken,"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 25,
+        "match": "caps: [{ id: 'subscription:enterprise', mode: ProactivityMode.Tsunami }],"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 25,
+        "match": "caps: [{ id: 'subscription:enterprise', mode: ProactivityMode.Tsunami }],"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 27,
+        "match": "expect(res.effective).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 27,
+        "match": "expect(res.effective).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 32,
+        "match": "expect(degradeOnError(ProactivityMode.Tsunami)).toBe(ProactivityMode.Kraken);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 32,
+        "match": "expect(degradeOnError(ProactivityMode.Tsunami)).toBe(ProactivityMode.Kraken);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 32,
+        "match": "expect(degradeOnError(ProactivityMode.Tsunami)).toBe(ProactivityMode.Kraken);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 33,
+        "match": "expect(degradeOnError(ProactivityMode.Kraken)).toBe(ProactivityMode.Ambisiøs);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 33,
+        "match": "expect(degradeOnError(ProactivityMode.Kraken)).toBe(ProactivityMode.Ambisiøs);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 33,
+        "match": "expect(degradeOnError(ProactivityMode.Kraken)).toBe(ProactivityMode.Ambisiøs);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 34,
+        "match": "expect(degradeOnError(ProactivityMode.Proaktiv)).toBe(ProactivityMode.Rolig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 34,
+        "match": "expect(degradeOnError(ProactivityMode.Proaktiv)).toBe(ProactivityMode.Rolig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 35,
+        "match": "expect(degradeOnError(ProactivityMode.Rolig)).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 35,
+        "match": "expect(degradeOnError(ProactivityMode.Rolig)).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 35,
+        "match": "expect(degradeOnError(ProactivityMode.Rolig)).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 36,
+        "match": "expect(degradeOnError(ProactivityMode.Usynlig)).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 36,
+        "match": "expect(degradeOnError(ProactivityMode.Usynlig)).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 40,
+        "match": "const rail = [ProactivityMode.Kraken, ProactivityMode.Proaktiv, ProactivityMode.Rolig] as const;"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 40,
+        "match": "const rail = [ProactivityMode.Kraken, ProactivityMode.Proaktiv, ProactivityMode.Rolig] as const;"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 40,
+        "match": "const rail = [ProactivityMode.Kraken, ProactivityMode.Proaktiv, ProactivityMode.Rolig] as const;"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 41,
+        "match": "const res = resolveEffectiveMode({ requested: ProactivityMode.Kraken, caps: [{ id: 'policy', mode: ProactivityMode.Proaktiv }], degradeRail: [...rail] });"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 41,
+        "match": "const res = resolveEffectiveMode({ requested: ProactivityMode.Kraken, caps: [{ id: 'policy', mode: ProactivityMode.Proaktiv }], degradeRail: [...rail] });"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 43,
+        "match": "expect(degradeOnError(ProactivityMode.Kraken, [...rail])).toBe(ProactivityMode.Proaktiv);"
+      },
+      {
+        "file": "tests/proactivity/state-resolver.test.ts",
+        "line": 43,
+        "match": "expect(degradeOnError(ProactivityMode.Kraken, [...rail])).toBe(ProactivityMode.Proaktiv);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 3,
+        "match": "import { ProactivityMode } from '../../src/core/proactivity/modes';"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 9,
+        "match": "expect(getPlanMaxMode('flex')).toBe(ProactivityMode.Ambisiøs);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 9,
+        "match": "expect(getPlanMaxMode('flex')).toBe(ProactivityMode.Ambisiøs);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 10,
+        "match": "expect(getPlanMaxMode('secure')).toBe(ProactivityMode.Proaktiv);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 11,
+        "match": "expect(getPlanMaxMode('enterprise')).toBe(ProactivityMode.Tsunami);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 11,
+        "match": "expect(getPlanMaxMode('enterprise')).toBe(ProactivityMode.Tsunami);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 17,
+        "match": "expect(cap.maxMode).toBe(ProactivityMode.Proaktiv);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 21,
+        "match": "expect(cap.maxMode).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 21,
+        "match": "expect(cap.maxMode).toBe(ProactivityMode.Usynlig);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 25,
+        "match": "setSubscriptionForTenant('TEN', { plan: 'enterprise', maxOverride: ProactivityMode.Kraken });"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 25,
+        "match": "setSubscriptionForTenant('TEN', { plan: 'enterprise', maxOverride: ProactivityMode.Kraken });"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 27,
+        "match": "expect(cap.maxMode).toBe(ProactivityMode.Kraken);"
+      },
+      {
+        "file": "tests/subscription/entitlements.test.ts",
+        "line": 27,
+        "match": "expect(cap.maxMode).toBe(ProactivityMode.Kraken);"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 116,
+        "match": "PROACTIVITY: {"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 118,
+        "match": "'proactivity',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 119,
+        "match": "'proactive',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 121,
+        "match": "'assistive',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 122,
+        "match": "'automated',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 123,
+        "match": "'tsunami',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 124,
+        "match": "'kraken',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 125,
+        "match": "'rolig',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 126,
+        "match": "'usynlig',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 251,
+        "match": "PROACTIVITY: ["
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 252,
+        "match": "/proactiv/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 253,
+        "match": "/usynlig/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 254,
+        "match": "/rolig/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 256,
+        "match": "/kraken/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 257,
+        "match": "/tsunami/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 259,
+        "match": "/suggestive/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 260,
+        "match": "/advisory/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 261,
+        "match": "/assistive/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 262,
+        "match": "/automated/i"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 313,
+        "match": "PROACTIVITY: [],"
+      },
+      {
+        "file": "tsconfig.proactivity.json",
+        "line": 8,
+        "match": "\"src/core/proactivity/modes.ts\","
+      },
+      {
+        "file": "tsconfig.proactivity.json",
+        "line": 9,
+        "match": "\"src/core/proactivity/state.ts\","
+      },
+      {
+        "file": "tsconfig.proactivity.json",
+        "line": 10,
+        "match": "\"src/core/proactivity/context.ts\","
+      },
+      {
+        "file": "tsconfig.proactivity.json",
+        "line": 11,
+        "match": "\"src/core/proactivity/telemetry.ts\","
+      },
+      {
+        "file": "tsconfig.proactivity.json",
+        "line": 12,
+        "match": "\"src/core/proactivity/guards.ts\","
+      },
+      {
+        "file": "tsconfig.proactivity.json",
+        "line": 18,
+        "match": "\"backend/routes/proactivity.ts\","
+      }
+    ],
+    "ROLES": [
+      {
+        "file": "backend/jest.config.cjs",
+        "line": 11,
+        "match": "// Resolve TS files when imports end with .js (e.g., './rbac/policies.js')"
+      },
+      {
+        "file": "backend/jest.config.js",
+        "line": 11,
+        "match": "// Resolve TS files when imports end with .js (e.g., './rbac/policies.js')"
+      },
+      {
+        "file": "backend/prisma/schema.prisma",
+        "line": 19,
+        "match": "roles     RoleBinding[]"
+      },
+      {
+        "file": "backend/prisma/schema.prisma",
+        "line": 31,
+        "match": "roleBinds RoleBinding[]"
+      },
+      {
+        "file": "backend/prisma/schema.prisma",
+        "line": 161,
+        "match": "model RoleBinding {"
+      },
+      {
+        "file": "backend/routes/dev.runner.ts",
+        "line": 2,
+        "match": "import { RoleRegistry } from '../../src/roles/registry';"
+      },
+      {
+        "file": "backend/routes/dev.runner.ts",
+        "line": 9,
+        "match": "const rr = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);"
+      },
+      {
+        "file": "backend/routes/features.ts",
+        "line": 3,
+        "match": "import { RoleRegistry } from '../../src/roles/registry';"
+      },
+      {
+        "file": "backend/routes/features.ts",
+        "line": 8,
+        "match": "const rr = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 2,
+        "match": "import { RoleRegistry } from '../../src/roles/registry';"
+      },
+      {
+        "file": "backend/routes/proactivity.ts",
+        "line": 9,
+        "match": "const roleRegistry = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);"
+      },
+      {
+        "file": "backend/src/app.ts",
+        "line": 3,
+        "match": "import { canAccess, EntityType, RecordMeta } from './rbac/policies.js';"
+      },
+      {
+        "file": "backend/src/app.ts",
+        "line": 4,
+        "match": "import { clearAudit, getAudit, pushAudit } from './rbac/audit.js';"
+      },
+      {
+        "file": "backend/src/audit/log.ts",
+        "line": 6,
+        "match": "const file = join(dir, 'rbac.log');"
+      },
+      {
+        "file": "backend/src/crm/dummy_mutations.ts",
+        "line": 2,
+        "match": "import { enforce } from '../rbac/middleware.js';"
+      },
+      {
+        "file": "backend/src/crm/routes.db.ts",
+        "line": 3,
+        "match": "import { requireRole } from '../middleware/rbac.js';"
+      },
+      {
+        "file": "backend/src/crm/routes.ts",
+        "line": 5,
+        "match": "import { enforce } from '../rbac/enforce.js';"
+      },
+      {
+        "file": "backend/src/rbac/middleware.ts",
+        "line": 23,
+        "match": "audit({ type: 'rbac.denied', tenant_id, actor_id: user_id, details: { action, resourceKind, resource, reason: decision.reason } });"
+      },
+      {
+        "file": "backend/src/rbac/policy.ts",
+        "line": 5,
+        "match": "export interface RoleBinding {"
+      },
+      {
+        "file": "backend/src/rbac/policy.ts",
+        "line": 26,
+        "match": "binding?: RoleBinding | null;"
+      },
+      {
+        "file": "backend/src/rbac/policy.ts",
+        "line": 30,
+        "match": "listBindings(tenant_id: string): Promise<RoleBinding[]>;"
+      },
+      {
+        "file": "backend/src/rbac/policy.ts",
+        "line": 31,
+        "match": "upsert(b: Omit<RoleBinding, 'id'|'created_at'> & { id?: string }): Promise<RoleBinding>;"
+      },
+      {
+        "file": "backend/src/rbac/policy.ts",
+        "line": 36,
+        "match": "private data = new Map<string, RoleBinding[]>();"
+      },
+      {
+        "file": "backend/src/rbac/policy.ts",
+        "line": 40,
+        "match": "const rb: RoleBinding = { id, created_at: Date.now(), effect: 'allow', ...b };"
+      },
+      {
+        "file": "backend/src/rbac/routes.ts",
+        "line": 19,
+        "match": "audit({ type: 'rbac.policy.change', tenant_id: tenant, actor_id: (req as any).actor_user_id || null, details: { op: 'upsert', rb } });"
+      },
+      {
+        "file": "backend/src/rbac/routes.ts",
+        "line": 28,
+        "match": "audit({ type: 'rbac.policy.change', tenant_id: tenant, actor_id: (req as any).actor_user_id || null, details: { op: 'delete', id: req.params.id } });"
+      },
+      {
+        "file": "backend/tests/rbac.binding.test.ts",
+        "line": 1,
+        "match": "import { upsertBinding, resolveRoles } from '../src/rbac/binding';"
+      },
+      {
+        "file": "backend/tests/rbac.enforce.test.ts",
+        "line": 4,
+        "match": "describe('RBAC enforcement', () => {"
+      },
+      {
+        "file": "backend/tests/rbac.routes.test.ts",
+        "line": 4,
+        "match": "describe('RBAC admin routes', () => {"
+      },
+      {
+        "file": "backend/tests/rbac.routes.test.ts",
+        "line": 7,
+        "match": "const list0 = await request(app).get('/api/v1/admin/rbac/bindings').set('x-tenant-id','t1');"
+      },
+      {
+        "file": "backend/tests/rbac.routes.test.ts",
+        "line": 12,
+        "match": "const up = await request(app).post('/api/v1/admin/rbac/bindings').set('x-tenant-id','t1').send({"
+      },
+      {
+        "file": "backend/tests/rbac.routes.test.ts",
+        "line": 25,
+        "match": "const del = await request(app).delete('/api/v1/admin/rbac/bindings/'+up.body.id).set('x-tenant-id','t1');"
+      },
+      {
+        "file": "backend/tests/rbac.test.ts",
+        "line": 1,
+        "match": "import { canRead, canWrite, type Subject } from '../src/rbac/policy';"
+      },
+      {
+        "file": "backend/tests/rbac_policy.test.ts",
+        "line": 3,
+        "match": "import { enforce } from '../src/rbac/enforce';"
+      },
+      {
+        "file": "backend/tests/rbac_policy.test.ts",
+        "line": 5,
+        "match": "describe('RBAC policy (CRM endpoints)', () => {"
+      },
+      {
+        "file": "backend/tests/rbac_record_level.test.ts",
+        "line": 20,
+        "match": "describe('RBAC record-level', () => {"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 6970,
+        "match": "\"ai_assists\": [\"Foreslå rollemodeller (RBAC)\", \"Varsle mislykket provisjonering\", \"Oppsummer integrasjonsfeil\", \"Utkast til endringsplan\", \"Generer målepanel for IAM\", \"Foreslå MFA-regler\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7763,
+        "match": "\"access_control\": \"Role-based access to master data\","
+      },
+      {
+        "file": "crm/lib/api/handler.ts",
+        "line": 4,
+        "match": "import { requireWriteRole } from '../rbac';"
+      },
+      {
+        "file": "crm/pages/api/onboarding/demo.ts",
+        "line": 3,
+        "match": "import { requireWriteRole } from '../../../lib/rbac';"
+      },
+      {
+        "file": "crm/pages/api/onboarding/demo.ts",
+        "line": 5,
+        "match": "import { requireWriteRole } from '../../../lib/rbac';"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 631,
+        "match": "// ===== Final Ready: OIDC & RBAC (skeleton integration) ====="
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 635,
+        "match": "const base = PORTAL_URL.replace('/portal','') + '/rbac';"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 639,
+        "match": "store.set('rbac', data);"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 644,
+        "match": "function hasRole(role) { try { const r = store.get('rbac'); return Array.isArray(r?.roles) && r.roles.includes(role); } catch { return false; }}"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 659,
+        "match": "// RBAC enforcement helper"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 663,
+        "match": "const pol = store.get('rbac') || {};"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 679,
+        "match": "// ===== RBAC gating IPC ====="
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 681,
+        "match": "ipcMain.handle('wb:rbac:can', async (_evt, payload) => { try { const { action, resource } = wb_rbac_can_Schema.parse(payload||{});"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 683,
+        "match": "const pol = store.get('rbac') || {};"
+      },
+      {
+        "file": "desktop/main.js",
+        "line": 684,
+        "match": "// Simple policy: action:resource strings in pol.allowed[] or role-based rules"
+      },
+      {
+        "file": "desktop/preload.js",
+        "line": 4,
+        "match": "contextBridge.exposeInMainWorld('wbDesktop', { pluginsVerify: (p)=> ipcRenderer.invoke('wb:plugins:verify', p), rbacCan:, metricsSnapshot: ()=> ipcRenderer.invoke('wb:metrics:snapshot'), (p)=> ipcRenderer.invoke('wb:rbac:can', p),"
+      },
+      {
+        "file": "desktop/tests/e2e/rbac-deny.spec.mjs",
+        "line": 2,
+        "match": "test('RBAC denies plugin enable without policy', async()=>{"
+      },
+      {
+        "file": "desktop/tests/unit/rbac.test.js",
+        "line": 1,
+        "match": "test('rbac can deny by default', ()=>{"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1461,
+        "match": "-                        <li>RBAC tilgangskontroll</li>"
+      },
+      {
+        "file": "enterprise/__tests__/e2e/data_quality_approve.spec.ts",
+        "line": 6,
+        "match": "// inject token for RBAC bypass in dev (if any)"
+      },
+      {
+        "file": "enterprise/__tests__/rbac.test.js",
+        "line": 2,
+        "match": "const { getRole } = require('../lib/auth/rbac.js');"
+      },
+      {
+        "file": "enterprise/__tests__/unit/rbac-metrics.test.js",
+        "line": 2,
+        "match": "test('rbac metric exists', ()=>{ expect(wbRbacDenied).toBeTruthy(); });"
+      },
+      {
+        "file": "enterprise/__tests__/unit/rbac.tenant.test.js",
+        "line": 1,
+        "match": "import { enforceTenant } from '../../lib/secure/rbac.js';"
+      },
+      {
+        "file": "enterprise/api/data-quality.js",
+        "line": 5,
+        "match": "// Assumes an Express-like app and existing middlewares for RBAC/Tenant and policy gates"
+      },
+      {
+        "file": "enterprise/api/data-quality.js",
+        "line": 7,
+        "match": "const { rbac, tenant, policy, audit, metrics, siem, connectors, aiService, cache } = deps;"
+      },
+      {
+        "file": "enterprise/api/data-quality.js",
+        "line": 13,
+        "match": "rbac.require(['dq:read']),"
+      },
+      {
+        "file": "enterprise/api/data-quality.js",
+        "line": 51,
+        "match": "rbac.require(['dq:read']),"
+      },
+      {
+        "file": "enterprise/api/integrations.js",
+        "line": 5,
+        "match": "const { rbac, tenant, metrics, siem } = deps;"
+      },
+      {
+        "file": "enterprise/api/integrations.js",
+        "line": 10,
+        "match": "rbac.require(['integrations:read']),"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 6970,
+        "match": "\"ai_assists\": [\"Foreslå rollemodeller (RBAC)\", \"Varsle mislykket provisjonering\", \"Oppsummer integrasjonsfeil\", \"Utkast til endringsplan\", \"Generer målepanel for IAM\", \"Foreslå MFA-regler\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7763,
+        "match": "\"access_control\": \"Role-based access to master data\","
+      },
+      {
+        "file": "enterprise/data/writebackPolicy.js",
+        "line": 16,
+        "match": "// RBAC check"
+      },
+      {
+        "file": "enterprise/data-quality/approve.js",
+        "line": 6,
+        "match": "import { requireRole } from '../../../lib/rbac.js';"
+      },
+      {
+        "file": "enterprise/data-quality/queue.js",
+        "line": 4,
+        "match": "import { requireRole } from '../../../lib/rbac.js';"
+      },
+      {
+        "file": "enterprise/infra/alerts/prometheus/wb.rules.yml",
+        "line": 80,
+        "match": "summary: \"RBAC denies\""
+      },
+      {
+        "file": "enterprise/infra/alerts/prometheus/wb.rules.yml",
+        "line": 81,
+        "match": "description: \"Uvanlig mange 403 pga. RBAC.\""
+      },
+      {
+        "file": "enterprise/infra/grafana/dashboards/wb-multitenant.json",
+        "line": 1,
+        "match": "{\"title\": \"WorkBuoy Multitenant\", \"panels\": [{\"type\": \"stat\", \"title\": \"AI req by tenant\", \"targets\": [{\"expr\": \"sum by (tenant) (wb_ai_req_by_tenant_total)\"}]}, {\"type\": \"graph\", \"title\": \"Connector sync (by tenant)\", \"targets\": [{\"expr\": "
+      },
+      {
+        "file": "enterprise/integration/retry.js",
+        "line": 3,
+        "match": "import { requireRole } from '../../../lib/rbac.js';"
+      },
+      {
+        "file": "enterprise/lib/auth/oidc.js",
+        "line": 8,
+        "match": "const { enforceRBAC } = require('../rbac');"
+      },
+      {
+        "file": "enterprise/lib/auth/oidc.js",
+        "line": 51,
+        "match": "// Enforce RBAC by required roles; tenant header is ignored in prod"
+      },
+      {
+        "file": "enterprise/lib/data/writebackPolicy.js",
+        "line": 16,
+        "match": "// RBAC check"
+      },
+      {
+        "file": "enterprise/lib/middleware/tenant.js",
+        "line": 76,
+        "match": "/** RBAC helper: checks user membership within tenant (sqlite variant kept for dev) */"
+      },
+      {
+        "file": "enterprise/lib/secure/rbac.js",
+        "line": 2,
+        "match": "* Enterprise RBAC wrapper — supports scoped permissions and enforcement."
+      },
+      {
+        "file": "enterprise/lib/secure/rbac.js",
+        "line": 22,
+        "match": "const err = new Error('Denied by RBAC');"
+      },
+      {
+        "file": "enterprise/lib/secure/rbac.js",
+        "line": 29,
+        "match": "/** Multi-tenant RBAC enforcement */"
+      },
+      {
+        "file": "enterprise/pages/api/admin/retention/run.js",
+        "line": 2,
+        "match": "import { getRole } from '../../../../lib/auth/rbac.js';"
+      },
+      {
+        "file": "enterprise/pages/api/admin/users.js",
+        "line": 3,
+        "match": "import { getRole } from '../../../lib/auth/rbac.js';"
+      },
+      {
+        "file": "enterprise/pages/api/audit/logs.js",
+        "line": 1,
+        "match": "import { requireRole } from '../../../lib/auth/rbac.js';"
+      },
+      {
+        "file": "enterprise/pages/api/audit/logs.js",
+        "line": 9,
+        "match": "const role = await (await import('../../../lib/auth/rbac.js')).then(m=>m.getRole(tenant_id, req.headers['x-user-id']||''));"
+      },
+      {
+        "file": "enterprise/pages/api/billing/checkout-session.js",
+        "line": 3,
+        "match": "// RBAC admin+ check"
+      },
+      {
+        "file": "enterprise/pages/api/billing/create-payment.js",
+        "line": 3,
+        "match": "// RBAC admin+ check"
+      },
+      {
+        "file": "enterprise/pages/api/billing/create-portal-session.js",
+        "line": 3,
+        "match": "// RBAC admin+ check"
+      },
+      {
+        "file": "enterprise/pages/api/billing/create-subscription.js",
+        "line": 3,
+        "match": "// RBAC admin+ check"
+      },
+      {
+        "file": "enterprise/pages/api/data-quality/approve.js",
+        "line": 6,
+        "match": "import { requireRole } from '../../../lib/rbac.js';"
+      },
+      {
+        "file": "enterprise/pages/api/data-quality/queue.js",
+        "line": 4,
+        "match": "import { requireRole } from '../../../lib/rbac.js';"
+      },
+      {
+        "file": "enterprise/pages/api/integration/retry.js",
+        "line": 3,
+        "match": "import { requireRole } from '../../../lib/rbac.js';"
+      },
+      {
+        "file": "enterprise/pages/api/portal/secrets.js",
+        "line": 3,
+        "match": "// RBAC admin+ check"
+      },
+      {
+        "file": "enterprise/pages/api/systems/resync.js",
+        "line": 2,
+        "match": "import { getRole } from '../../../lib/auth/rbac.js';"
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1277,
+        "match": "<li>RBAC tilgangskontroll</li>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1251,
+        "match": "<li>RBAC tilgangskontroll</li>"
+      },
+      {
+        "file": "enterprise/public/register.html",
+        "line": 52,
+        "match": "<ul><li>SOC2/GDPR/HIPAA</li><li>Advanced audit</li><li>RBAC</li></ul>"
+      },
+      {
+        "file": "enterprise/secure/rbac.js",
+        "line": 2,
+        "match": "* Enterprise RBAC wrapper — supports scoped permissions and enforcement."
+      },
+      {
+        "file": "enterprise/secure/rbac.js",
+        "line": 22,
+        "match": "const err = new Error('Denied by RBAC');"
+      },
+      {
+        "file": "enterprise/secure/rbac.js",
+        "line": 29,
+        "match": "/** Multi-tenant RBAC enforcement */"
+      },
+      {
+        "file": "ops/dashboards/workbuoy.json",
+        "line": 11,
+        "match": "\"title\": \"RBAC & Security\""
+      },
+      {
+        "file": "ops/dashboards/workbuoy.json",
+        "line": 15,
+        "match": "\"title\": \"RBAC denied (5m)\","
+      },
+      {
+        "file": "ops/dashboards/workbuoy.json",
+        "line": 45,
+        "match": "\"title\": \"RBAC denied rate\","
+      },
+      {
+        "file": "ops/dashboards/workbuoy_crm_desktop.json",
+        "line": 59,
+        "match": "\"title\": \"RBAC denied (5m)\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 6970,
+        "match": "\"ai_assists\": [\"Foreslå rollemodeller (RBAC)\", \"Varsle mislykket provisjonering\", \"Oppsummer integrasjonsfeil\", \"Utkast til endringsplan\", \"Generer målepanel for IAM\", \"Foreslå MFA-regler\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7763,
+        "match": "\"access_control\": \"Role-based access to master data\","
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 1,
+        "match": "import { RoleRegistry } from '../roles/registry';"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 2,
+        "match": "import { policyCheckRoleAware, RoleAwareContext } from './policyRoleAware';"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 15,
+        "match": "rr: RoleRegistry,"
+      },
+      {
+        "file": "src/core/capabilityRunnerRole.ts",
+        "line": 19,
+        "match": "ctx: RoleAwareContext,"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 1,
+        "match": "import { RoleRegistry } from '../roles/registry';"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 6,
+        "match": "export interface RoleAwareContext {"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 22,
+        "match": "ctx: RoleAwareContext,"
+      },
+      {
+        "file": "src/core/policyRoleAware.ts",
+        "line": 23,
+        "match": "rr: RoleRegistry,"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 1,
+        "match": "import { RoleRegistry } from '../../roles/registry';"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 10,
+        "match": "roleRegistry?: RoleRegistry;"
+      },
+      {
+        "file": "src/core/proactivity/context.ts",
+        "line": 31,
+        "match": "registry: RoleRegistry | undefined,"
+      },
+      {
+        "file": "src/core/security/rbac.ts",
+        "line": 5,
+        "match": "export function rbac(allowed: Role[]) {"
+      },
+      {
+        "file": "src/features/activation/featureActivation.ts",
+        "line": 1,
+        "match": "import { RoleRegistry } from '../../roles/registry';"
+      },
+      {
+        "file": "src/features/activation/featureActivation.ts",
+        "line": 11,
+        "match": "export function getActiveFeatures(rr: RoleRegistry, uc: UserContext){"
+      },
+      {
+        "file": "src/roles/loader.ts",
+        "line": 3,
+        "match": "import { RoleProfile, FeatureDef } from './types';"
+      },
+      {
+        "file": "src/roles/loader.ts",
+        "line": 6,
+        "match": "export function loadRolesFromRepo(): RoleProfile[] {"
+      },
+      {
+        "file": "src/roles/loader.ts",
+        "line": 17,
+        "match": "return raw as RoleProfile[];"
+      },
+      {
+        "file": "src/roles/registry.ts",
+        "line": 1,
+        "match": "import { RoleProfile, OrgRoleOverride, FeatureDef, UserRoleBinding } from './types';"
+      },
+      {
+        "file": "src/roles/registry.ts",
+        "line": 3,
+        "match": "export class RoleRegistry {"
+      },
+      {
+        "file": "src/roles/registry.ts",
+        "line": 5,
+        "match": "private roles: RoleProfile[],"
+      },
+      {
+        "file": "src/roles/registry.ts",
+        "line": 21,
+        "match": "const acc = new Map<string,RoleProfile>();"
+      },
+      {
+        "file": "src/roles/registry.ts",
+        "line": 32,
+        "match": "private composeFeatureCaps(tenantId: string, rs: RoleProfile[]) {"
+      },
+      {
+        "file": "src/roles/registry.ts",
+        "line": 45,
+        "match": "private composeScope(rs: RoleProfile[]) {"
+      },
+      {
+        "file": "src/roles/types.ts",
+        "line": 1,
+        "match": "export type RoleId ="
+      },
+      {
+        "file": "src/roles/types.ts",
+        "line": 16,
+        "match": "export interface RoleProfile {"
+      },
+      {
+        "file": "src/roles/types.ts",
+        "line": 17,
+        "match": "role_id: RoleId;"
+      },
+      {
+        "file": "src/roles/types.ts",
+        "line": 36,
+        "match": "inherits?: RoleId[];"
+      },
+      {
+        "file": "src/roles/types.ts",
+        "line": 43,
+        "match": "role_id: RoleId;"
+      },
+      {
+        "file": "src/roles/types.ts",
+        "line": 50,
+        "match": "primaryRole: RoleId;"
+      },
+      {
+        "file": "src/roles/types.ts",
+        "line": 51,
+        "match": "secondaryRoles?: RoleId[];"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 1,
+        "match": "import { RoleRegistry } from '../../src/roles/registry';"
+      },
+      {
+        "file": "tests/policy/rolecap.test.ts",
+        "line": 5,
+        "match": "const rr = new RoleRegistry("
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 1,
+        "match": "import { RoleRegistry } from '../../src/roles/registry';"
+      },
+      {
+        "file": "tests/proactivity/runner-paths.test.ts",
+        "line": 6,
+        "match": "const rr = new RoleRegistry("
+      },
+      {
+        "file": "tests/security.rbac.test.ts",
+        "line": 3,
+        "match": "import { rbac } from \"../src/core/security/rbac\";"
+      },
+      {
+        "file": "tests/security.rbac.test.ts",
+        "line": 5,
+        "match": "describe(\"rbac middleware\", () => {"
+      },
+      {
+        "file": "tests/security.rbac.test.ts",
+        "line": 8,
+        "match": "app.get(\"/admin\", rbac([\"admin\"]), (_req, res) => res.json({ ok: true }));"
+      },
+      {
+        "file": "tests/security.rbac.test.ts",
+        "line": 15,
+        "match": "app.get(\"/admin\", rbac([\"admin\"]), (_req, res) => res.json({ ok: true }));"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 71,
+        "match": "'rbac',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 72,
+        "match": "'abac',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 110,
+        "match": "'rbac',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 111,
+        "match": "'abac',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 267,
+        "match": "/role-based/i,"
+      },
+      {
+        "file": "workbuoy_pr_az/ai/buoy/explanations.ts",
+        "line": 5,
+        "match": "hints: result.status===200 ? 'OK' : 'Kontroller input/RBAC/rate-limit'"
+      }
+    ],
+    "SECURE_RAILS": [
+      {
+        "file": "META_ROUTE_README.md",
+        "line": 1,
+        "match": "# META Route Quickstart"
+      },
+      {
+        "file": "META_ROUTE_RUNBOOK.md",
+        "line": 1,
+        "match": "# META Route Runbook"
+      },
+      {
+        "file": "PATCHES/USE_CACHED_GUARD.md",
+        "line": 1,
+        "match": "# Use cached policy guard"
+      },
+      {
+        "file": "PATCHES/WIRE_WHY_SOURCES.md",
+        "line": 3,
+        "match": "In your Buoy agent or policy guard, after you build the explanation:"
+      },
+      {
+        "file": "README.md",
+        "line": 4,
+        "match": "autonomous development proposals and explicit evolution guardrails across the"
+      },
+      {
+        "file": "README.md",
+        "line": 4,
+        "match": "autonomous development proposals and explicit evolution guardrails across the"
+      },
+      {
+        "file": "README.md",
+        "line": 16,
+        "match": "- **Evolution gatekeeper** – `POST /genetics/implement-evolution` enforces"
+      },
+      {
+        "file": "README.md",
+        "line": 23,
+        "match": "Without the token the endpoint returns `403 approval_required`."
+      },
+      {
+        "file": "README.md",
+        "line": 25,
+        "match": "describes the manual merge steps; no git actions are triggered from HTTP."
+      },
+      {
+        "file": "README_MINI_FINAL.md",
+        "line": 7,
+        "match": "3) **Policy guard** som returnerer `explanations[].sources[]` ved 403."
+      },
+      {
+        "file": "README_MVP_REMAINING_20.md",
+        "line": 6,
+        "match": "- CRM policy enforcement test + patch guide"
+      },
+      {
+        "file": "README_MVP_REMAINING_20.md",
+        "line": 22,
+        "match": "1) **CRM policy guard**"
+      },
+      {
+        "file": "README_PR_T.md",
+        "line": 4,
+        "match": "- **Policy engine**: `src/rbac/policy.ts` – deny-overrides, roller, beslutning"
+      },
+      {
+        "file": "README_SUPERPROMPT.md",
+        "line": 11,
+        "match": "git commit -m \"feat(mvp): superdrop v1 — audit verify, event-bus tests, CRM policy guard, openapi lint, coverage, docs\""
+      },
+      {
+        "file": "README_SUPERPROMPT.md",
+        "line": 17,
+        "match": "1) **CRM policy guard**"
+      },
+      {
+        "file": "README_SUPERPROMPT.md",
+        "line": 41,
+        "match": "feat(mvp): superdrop v1 — audit verify, event-bus tests, CRM policy guard, openapi lint, coverage, docs"
+      },
+      {
+        "file": "RUNBOOK_prod_ready_musthave.md",
+        "line": 47,
+        "match": "- Governance: `.github/CODEOWNERS`, `SECURITY.md`, `CONTRIBUTING.md`"
+      },
+      {
+        "file": "backend/src/meta-evolution/genesis/need-analyzer.ts",
+        "line": 38,
+        "match": "area: 'governance',"
+      },
+      {
+        "file": "backend/src/meta-evolution/genesis/need-analyzer.ts",
+        "line": 41,
+        "match": "signals: ['audit trails stitched manually', 'policy enforcement inconsistent']"
+      },
+      {
+        "file": "backend/src/meta-evolution/genesis/solution-synthesizer.ts",
+        "line": 69,
+        "match": "'Ensure auditability and governance compliance.'"
+      },
+      {
+        "file": "backend/src/meta-evolution/genesis/solution-synthesizer.ts",
+        "line": 81,
+        "match": "\"it('ensures governance policies are respected', () => { /* generated test */ });\""
+      },
+      {
+        "file": "backend/tests/genesis.autonomy.test.ts",
+        "line": 42,
+        "match": "error: 'approval_required',"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 312,
+        "match": "\"core_tasks\": [\"Definere KPI-tre\", \"Styremøter for GTM\", \"Allokere verktøybudsjett\", \"Lede endringsprogrammer\", \"Rapportere helhetlig vekst\", \"Koordinere data governance\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 410,
+        "match": "\"summary\": \"Leder deal desk-team og governance.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 1792,
+        "match": "\"summary\": \"Styrer spendprogram og governance.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 2038,
+        "match": "\"core_tasks\": [\"Data governance\", \"KPI-rammeverk\", \"Endringsledelse\", \"Roadmap\", \"Rapportering til ledelse\", \"Koordinere team\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 2045,
+        "match": "\"ai_assists\": [\"Generer styredeck\", \"Oppsummer programstatus\", \"Foreslå KPI-endringer\", \"Lag datagovernance-plan\", \"Varsle risiko\", \"Oppsummer gevinst\", \"Foreslå opplæring\", \"Utkast til kommunikasjon\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 3618,
+        "match": "\"core_tasks\": [\"Krav og backlogg\", \"Release og test\", \"Brukerstøtte\", \"Rapportbygger\", \"Data governance\", \"Opplæring\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 4098,
+        "match": "\"core_tasks\": [\"Design av komp-planer\", \"Governance og godkjenning\", \"KPI og kostkontroll\", \"Leverandør- og verktøystyring\", \"Stakeholderdialog\", \"Revisjonsspor\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 4152,
+        "match": "\"alt_titles\": [\"Leder utgiftspolicy\", \"Expense Governance Manager\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 4310,
+        "match": "\"role_id\": \"finance-lead-finance-data-governance-lead\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 4311,
+        "match": "\"canonical_title\": \"Finance Data Governance Lead\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 4312,
+        "match": "\"alt_titles\": [\"Leder finansdatastyring\", \"Data Governance Lead Finance\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 4860,
+        "match": "\"core_tasks\": [\"Definere leveransemodell\", \"Stakeholder management\", \"Eskaleringshåndtering\", \"Kost/nytte-oppfølging\", \"Governance og kvalitetssikring\", \"Coache prosjektledere\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 4900,
+        "match": "\"core_tasks\": [\"Prioriteringsrammeverk\", \"Stage-gate og governance\", \"Kapitalallokering\", \"Roadmap-vedlikehold\", \"Rapportere porteføljestatus\", \"Håndtere risiko/avhengigheter\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 5220,
+        "match": "\"core_tasks\": [\"Policy og katalogstyring\", \"Onboarding leverandør\", \"P2P-KPI og forbedring\", \"Automatisering og integrasjoner\", \"Opplæring brukere\", \"Tverrfaglig governance\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 6903,
+        "match": "\"core_tasks\": [\"Policy og governance\", \"Teams/rom/gruppe-livssyklus\", \"Møte- og opptaksinnstillinger\", \"Ekstern deling\", \"Rapportering\", \"Incident/forespørsler\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 6907,
+        "match": "\"artifacts\": [\"Governance-dokument\", \"Rapportpakke\", \"Brukerveiledning\", \"Endringslogg\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7183,
+        "match": "\"core_tasks\": [\"Landing zone og nett\", \"Policy/guardrails\", \"Automatisere provisjonering\", \"Patch/backup\", \"Observability\", \"Kostoptimalisering\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7183,
+        "match": "\"core_tasks\": [\"Landing zone og nett\", \"Policy/guardrails\", \"Automatisere provisjonering\", \"Patch/backup\", \"Observability\", \"Kostoptimalisering\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7756,
+        "match": "\"artifacts\": [\"Master data creation procedures\", \"Data quality reports\", \"Validation checklists\", \"Master data governance documents\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7770,
+        "match": "\"alt_titles\": [\"Master Data Expert\", \"SAP Master Data Consultant\", \"Data Governance Specialist\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7774,
+        "match": "\"summary\": \"Advanced master data management with focus on process improvement, data governance, and cross-module integration.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7775,
+        "match": "\"mission\": \"Design and implement robust master data governance frameworks while ensuring seamless integration across SAP landscape.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7777,
+        "match": "\"Design master data governance processes and workflows\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7778,
+        "match": "\"Configure SAP MDG (Master Data Governance) solutions\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7785,
+        "match": "\"kpis\": [\"Data governance compliance\", \"Master data migration success rate\", \"User training completion\", \"Process automation level\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7786,
+        "match": "\"artifacts\": [\"Master data strategy documents\", \"Governance frameworks\", \"Migration procedures\", \"Training materials\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7792,
+        "match": "\"governance_framework\": \"Implement enterprise data governance standards\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 7972,
+        "match": "\"forecast_governance\": \"Follow established forecasting methodology and review processes\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8062,
+        "match": "\"architecture_governance\": \"Enforce architectural standards and review processes\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8092,
+        "match": "\"model_governance\": \"Follow ML lifecycle management and versioning standards\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8198,
+        "match": "\"Establish API governance and versioning strategies\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8230,
+        "match": "\"Design data governance and quality frameworks\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8236,
+        "match": "\"artifacts\": [\"Data models\", \"ETL specifications\", \"Data governance policies\", \"Architecture blueprints\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8242,
+        "match": "\"data_governance\": \"Implement comprehensive data governance and lineage tracking\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8321,
+        "match": "\"Establish cloud governance and security frameworks\""
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8326,
+        "match": "\"artifacts\": [\"Cloud architecture diagrams\", \"Migration plans\", \"Cost optimization reports\", \"Governance frameworks\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8334,
+        "match": "\"governance\": \"Maintain cloud governance and operational excellence\""
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8406,
+        "match": "\"core_tasks\": [\"Power calculations\", \"Guardrail metric setup\", \"Results analysis\", \"Experiment documentation\", \"Educate teams\", \"Monitor novelty effects\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8406,
+        "match": "\"core_tasks\": [\"Power calculations\", \"Guardrail metric setup\", \"Results analysis\", \"Experiment documentation\", \"Educate teams\", \"Monitor novelty effects\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8413,
+        "match": "\"ai_assists\": [\"Calculate sample sizes\", \"Draft hypotheses\", \"Detect peeking risks\", \"Summarize lift with CIs\", \"Recommend follow-up tests\", \"Auto-tag learnings\", \"Suggest guardrails\", \"Flag novelty bias\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8413,
+        "match": "\"ai_assists\": [\"Calculate sample sizes\", \"Draft hypotheses\", \"Detect peeking risks\", \"Summarize lift with CIs\", \"Recommend follow-up tests\", \"Auto-tag learnings\", \"Suggest guardrails\", \"Flag novelty bias\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8566,
+        "match": "\"core_tasks\": [\"Build HR dashboards\", \"Attrition modeling\", \"Diversity reporting\", \"Comp analysis\", \"Survey analytics\", \"Data governance with HR\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8626,
+        "match": "\"core_tasks\": [\"Run triage/IRB-like review\", \"Maintain registry and guardrails\", \"Publish weekly wins\", \"Coordinate platform upgrades\", \"Coach teams\", \"Enforce standards\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8626,
+        "match": "\"core_tasks\": [\"Run triage/IRB-like review\", \"Maintain registry and guardrails\", \"Publish weekly wins\", \"Coordinate platform upgrades\", \"Coach teams\", \"Enforce standards\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8778,
+        "match": "\"role_id\": \"data-mid-data-governance-analyst\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 8779,
+        "match": "\"canonical_title\": \"Data Governance Analyst\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9144,
+        "match": "\"summary\": \"Owns the experimentation program and governance across product and growth.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9146,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9146,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9150,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9150,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9153,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9153,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9225,
+        "match": "\"mission\": \"Ship robust ML models to production with observability and governance.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9238,
+        "match": "\"role_id\": \"data-manager-data-governance-manager\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9239,
+        "match": "\"canonical_title\": \"Data Governance Manager\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9244,
+        "match": "\"summary\": \"Leads data governance program across quality, ownership and policy.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9246,
+        "match": "\"core_tasks\": [\"Define ownership/RACI\", \"Run data council\", \"Publish policies/standards\", \"Oversee catalog & lineage\", \"Drive quality remediation\", \"Report governance KPIs\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9271,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Engineering\", \"Data Governance\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9351,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Data Governance\", \"Domain leads\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9446,
+        "match": "\"core_tasks\": [\"Own HR service catalog\", \"Optimize processes\", \"Manage vendors\", \"Run payroll interface governance\", \"Drive ticket SLAs\", \"Report HR ops KPIs\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9604,
+        "match": "\"summary\": \"Owns the experimentation program and governance across product and growth.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9606,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9606,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9610,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9610,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9613,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9613,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9685,
+        "match": "\"mission\": \"Ship robust ML models to production with observability and governance.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9698,
+        "match": "\"role_id\": \"data-manager-data-governance-manager\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9699,
+        "match": "\"canonical_title\": \"Data Governance Manager\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9704,
+        "match": "\"summary\": \"Leads data governance program across quality, ownership and policy.\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9706,
+        "match": "\"core_tasks\": [\"Define ownership/RACI\", \"Run data council\", \"Publish policies/standards\", \"Oversee catalog & lineage\", \"Drive quality remediation\", \"Report governance KPIs\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9731,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Engineering\", \"Data Governance\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9811,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Data Governance\", \"Domain leads\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 9906,
+        "match": "\"core_tasks\": [\"Own HR service catalog\", \"Optimize processes\", \"Manage vendors\", \"Run payroll interface governance\", \"Drive ticket SLAs\", \"Report HR ops KPIs\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 10160,
+        "match": "\"alt_titles\": [\"Governance, Risk & Compliance Manager\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 10793,
+        "match": "\"ai_assists\": [\"Draft legal assessment\", \"Clause mapping\", \"Policy check\", \"Response templates\", \"Training slides\", \"Summary for leaders\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 12591,
+        "match": "\"artifacts\": [\"Guardrails\", \"Referansearkitektur\", \"Rapporter\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 12591,
+        "match": "\"artifacts\": [\"Guardrails\", \"Referansearkitektur\", \"Rapporter\"],"
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 13319,
+        "match": "\"role_id\": \"data-mid-data-governance-analyst\","
+      },
+      {
+        "file": "core/roles/roles.json",
+        "line": 13320,
+        "match": "\"canonical_title\": \"Data Governance Analyst\","
+      },
+      {
+        "file": "docs/BUOY_CHAT_SEARCH.md",
+        "line": 28,
+        "match": "- Policy guard (0–2) gates write-intents; WhyDrawer shows `explanations[]` with `policyBasis`, `sources`, `impact`."
+      },
+      {
+        "file": "docs/CLEANUP.md",
+        "line": 6,
+        "match": "- Ensure write endpoints use the same policy guard (v2)"
+      },
+      {
+        "file": "docs/MVP_BC_CHECKLIST.md",
+        "line": 2,
+        "match": "- [ ] CRM API (GET/POST/DELETE) in-memory with policy guard"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 11,
+        "match": "| 5     | `kraken`  | Execute under policy guardrails                   | Call `impl.execute()`                          | Stream execution log |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 11,
+        "match": "| 5     | `kraken`  | Execute under policy guardrails                   | Call `impl.execute()`                          | Stream execution log |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 11,
+        "match": "| 5     | `kraken`  | Execute under policy guardrails                   | Call `impl.execute()`                          | Stream execution log |"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 32,
+        "match": "`policyCheckRoleAware` now evaluates policy with the *effective* proactivity mode. Role feature caps still apply: the registry resolves feature autonomy caps, and the cap is injected into the resolution pipeline. Policy guardrails can provi"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 32,
+        "match": "`policyCheckRoleAware` now evaluates policy with the *effective* proactivity mode. Role feature caps still apply: the registry resolves feature autonomy caps, and the cap is injected into the resolution pipeline. Policy guardrails can provi"
+      },
+      {
+        "file": "docs/proactivity.md",
+        "line": 32,
+        "match": "`policyCheckRoleAware` now evaluates policy with the *effective* proactivity mode. Role feature caps still apply: the registry resolves feature autonomy caps, and the cap is injected into the resolution pipeline. Policy guardrails can provi"
+      },
+      {
+        "file": "enterprise/PR_SUMMARY.md",
+        "line": 86,
+        "match": "- SBOM/cosign placeholders; governance (CODEOWNERS/CONTRIBUTING/Renovate)"
+      },
+      {
+        "file": "enterprise/WORKBUOY_MARKETING_UPDATE.diff",
+        "line": 1459,
+        "match": "-                    <p>Enterprise-grade sikkerhet, compliance og governance for trygg AI i organisasjonen.</p>"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 312,
+        "match": "\"core_tasks\": [\"Definere KPI-tre\", \"Styremøter for GTM\", \"Allokere verktøybudsjett\", \"Lede endringsprogrammer\", \"Rapportere helhetlig vekst\", \"Koordinere data governance\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 410,
+        "match": "\"summary\": \"Leder deal desk-team og governance.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 1792,
+        "match": "\"summary\": \"Styrer spendprogram og governance.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 2038,
+        "match": "\"core_tasks\": [\"Data governance\", \"KPI-rammeverk\", \"Endringsledelse\", \"Roadmap\", \"Rapportering til ledelse\", \"Koordinere team\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 2045,
+        "match": "\"ai_assists\": [\"Generer styredeck\", \"Oppsummer programstatus\", \"Foreslå KPI-endringer\", \"Lag datagovernance-plan\", \"Varsle risiko\", \"Oppsummer gevinst\", \"Foreslå opplæring\", \"Utkast til kommunikasjon\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 3618,
+        "match": "\"core_tasks\": [\"Krav og backlogg\", \"Release og test\", \"Brukerstøtte\", \"Rapportbygger\", \"Data governance\", \"Opplæring\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 4098,
+        "match": "\"core_tasks\": [\"Design av komp-planer\", \"Governance og godkjenning\", \"KPI og kostkontroll\", \"Leverandør- og verktøystyring\", \"Stakeholderdialog\", \"Revisjonsspor\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 4152,
+        "match": "\"alt_titles\": [\"Leder utgiftspolicy\", \"Expense Governance Manager\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 4310,
+        "match": "\"role_id\": \"finance-lead-finance-data-governance-lead\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 4311,
+        "match": "\"canonical_title\": \"Finance Data Governance Lead\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 4312,
+        "match": "\"alt_titles\": [\"Leder finansdatastyring\", \"Data Governance Lead Finance\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 4860,
+        "match": "\"core_tasks\": [\"Definere leveransemodell\", \"Stakeholder management\", \"Eskaleringshåndtering\", \"Kost/nytte-oppfølging\", \"Governance og kvalitetssikring\", \"Coache prosjektledere\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 4900,
+        "match": "\"core_tasks\": [\"Prioriteringsrammeverk\", \"Stage-gate og governance\", \"Kapitalallokering\", \"Roadmap-vedlikehold\", \"Rapportere porteføljestatus\", \"Håndtere risiko/avhengigheter\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 5220,
+        "match": "\"core_tasks\": [\"Policy og katalogstyring\", \"Onboarding leverandør\", \"P2P-KPI og forbedring\", \"Automatisering og integrasjoner\", \"Opplæring brukere\", \"Tverrfaglig governance\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 6903,
+        "match": "\"core_tasks\": [\"Policy og governance\", \"Teams/rom/gruppe-livssyklus\", \"Møte- og opptaksinnstillinger\", \"Ekstern deling\", \"Rapportering\", \"Incident/forespørsler\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 6907,
+        "match": "\"artifacts\": [\"Governance-dokument\", \"Rapportpakke\", \"Brukerveiledning\", \"Endringslogg\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7183,
+        "match": "\"core_tasks\": [\"Landing zone og nett\", \"Policy/guardrails\", \"Automatisere provisjonering\", \"Patch/backup\", \"Observability\", \"Kostoptimalisering\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7183,
+        "match": "\"core_tasks\": [\"Landing zone og nett\", \"Policy/guardrails\", \"Automatisere provisjonering\", \"Patch/backup\", \"Observability\", \"Kostoptimalisering\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7756,
+        "match": "\"artifacts\": [\"Master data creation procedures\", \"Data quality reports\", \"Validation checklists\", \"Master data governance documents\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7770,
+        "match": "\"alt_titles\": [\"Master Data Expert\", \"SAP Master Data Consultant\", \"Data Governance Specialist\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7774,
+        "match": "\"summary\": \"Advanced master data management with focus on process improvement, data governance, and cross-module integration.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7775,
+        "match": "\"mission\": \"Design and implement robust master data governance frameworks while ensuring seamless integration across SAP landscape.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7777,
+        "match": "\"Design master data governance processes and workflows\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7778,
+        "match": "\"Configure SAP MDG (Master Data Governance) solutions\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7785,
+        "match": "\"kpis\": [\"Data governance compliance\", \"Master data migration success rate\", \"User training completion\", \"Process automation level\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7786,
+        "match": "\"artifacts\": [\"Master data strategy documents\", \"Governance frameworks\", \"Migration procedures\", \"Training materials\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7792,
+        "match": "\"governance_framework\": \"Implement enterprise data governance standards\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 7972,
+        "match": "\"forecast_governance\": \"Follow established forecasting methodology and review processes\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8062,
+        "match": "\"architecture_governance\": \"Enforce architectural standards and review processes\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8092,
+        "match": "\"model_governance\": \"Follow ML lifecycle management and versioning standards\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8198,
+        "match": "\"Establish API governance and versioning strategies\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8230,
+        "match": "\"Design data governance and quality frameworks\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8236,
+        "match": "\"artifacts\": [\"Data models\", \"ETL specifications\", \"Data governance policies\", \"Architecture blueprints\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8242,
+        "match": "\"data_governance\": \"Implement comprehensive data governance and lineage tracking\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8321,
+        "match": "\"Establish cloud governance and security frameworks\""
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8326,
+        "match": "\"artifacts\": [\"Cloud architecture diagrams\", \"Migration plans\", \"Cost optimization reports\", \"Governance frameworks\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8334,
+        "match": "\"governance\": \"Maintain cloud governance and operational excellence\""
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8406,
+        "match": "\"core_tasks\": [\"Power calculations\", \"Guardrail metric setup\", \"Results analysis\", \"Experiment documentation\", \"Educate teams\", \"Monitor novelty effects\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8406,
+        "match": "\"core_tasks\": [\"Power calculations\", \"Guardrail metric setup\", \"Results analysis\", \"Experiment documentation\", \"Educate teams\", \"Monitor novelty effects\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8413,
+        "match": "\"ai_assists\": [\"Calculate sample sizes\", \"Draft hypotheses\", \"Detect peeking risks\", \"Summarize lift with CIs\", \"Recommend follow-up tests\", \"Auto-tag learnings\", \"Suggest guardrails\", \"Flag novelty bias\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8413,
+        "match": "\"ai_assists\": [\"Calculate sample sizes\", \"Draft hypotheses\", \"Detect peeking risks\", \"Summarize lift with CIs\", \"Recommend follow-up tests\", \"Auto-tag learnings\", \"Suggest guardrails\", \"Flag novelty bias\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8566,
+        "match": "\"core_tasks\": [\"Build HR dashboards\", \"Attrition modeling\", \"Diversity reporting\", \"Comp analysis\", \"Survey analytics\", \"Data governance with HR\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8626,
+        "match": "\"core_tasks\": [\"Run triage/IRB-like review\", \"Maintain registry and guardrails\", \"Publish weekly wins\", \"Coordinate platform upgrades\", \"Coach teams\", \"Enforce standards\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8626,
+        "match": "\"core_tasks\": [\"Run triage/IRB-like review\", \"Maintain registry and guardrails\", \"Publish weekly wins\", \"Coordinate platform upgrades\", \"Coach teams\", \"Enforce standards\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8778,
+        "match": "\"role_id\": \"data-mid-data-governance-analyst\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 8779,
+        "match": "\"canonical_title\": \"Data Governance Analyst\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9144,
+        "match": "\"summary\": \"Owns the experimentation program and governance across product and growth.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9146,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9146,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9150,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9150,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9153,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9153,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9225,
+        "match": "\"mission\": \"Ship robust ML models to production with observability and governance.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9238,
+        "match": "\"role_id\": \"data-manager-data-governance-manager\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9239,
+        "match": "\"canonical_title\": \"Data Governance Manager\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9244,
+        "match": "\"summary\": \"Leads data governance program across quality, ownership and policy.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9246,
+        "match": "\"core_tasks\": [\"Define ownership/RACI\", \"Run data council\", \"Publish policies/standards\", \"Oversee catalog & lineage\", \"Drive quality remediation\", \"Report governance KPIs\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9271,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Engineering\", \"Data Governance\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9351,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Data Governance\", \"Domain leads\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9446,
+        "match": "\"core_tasks\": [\"Own HR service catalog\", \"Optimize processes\", \"Manage vendors\", \"Run payroll interface governance\", \"Drive ticket SLAs\", \"Report HR ops KPIs\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9604,
+        "match": "\"summary\": \"Owns the experimentation program and governance across product and growth.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9606,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9606,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9610,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9610,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9613,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9613,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9685,
+        "match": "\"mission\": \"Ship robust ML models to production with observability and governance.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9698,
+        "match": "\"role_id\": \"data-manager-data-governance-manager\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9699,
+        "match": "\"canonical_title\": \"Data Governance Manager\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9704,
+        "match": "\"summary\": \"Leads data governance program across quality, ownership and policy.\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9706,
+        "match": "\"core_tasks\": [\"Define ownership/RACI\", \"Run data council\", \"Publish policies/standards\", \"Oversee catalog & lineage\", \"Drive quality remediation\", \"Report governance KPIs\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9731,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Engineering\", \"Data Governance\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9811,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Data Governance\", \"Domain leads\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 9906,
+        "match": "\"core_tasks\": [\"Own HR service catalog\", \"Optimize processes\", \"Manage vendors\", \"Run payroll interface governance\", \"Drive ticket SLAs\", \"Report HR ops KPIs\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 10160,
+        "match": "\"alt_titles\": [\"Governance, Risk & Compliance Manager\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 10793,
+        "match": "\"ai_assists\": [\"Draft legal assessment\", \"Clause mapping\", \"Policy check\", \"Response templates\", \"Training slides\", \"Summary for leaders\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 12591,
+        "match": "\"artifacts\": [\"Guardrails\", \"Referansearkitektur\", \"Rapporter\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 12591,
+        "match": "\"artifacts\": [\"Guardrails\", \"Referansearkitektur\", \"Rapporter\"],"
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 13319,
+        "match": "\"role_id\": \"data-mid-data-governance-analyst\","
+      },
+      {
+        "file": "enterprise/data/roles/roles.json",
+        "line": 13320,
+        "match": "\"canonical_title\": \"Data Governance Analyst\","
+      },
+      {
+        "file": "enterprise/docs/roadmap/WorkBuoy ChatGPT Development Roadmap v2 final.md",
+        "line": 62,
+        "match": "- **Enterprise Integration**: SSO, directory services, enterprise policy enforcement"
+      },
+      {
+        "file": "enterprise/lib/wb2wb/policy.js",
+        "line": 1,
+        "match": "// Secure wb2wb policy engine"
+      },
+      {
+        "file": "enterprise/public/config/flex.config.json",
+        "line": 23,
+        "match": "\"guardrails\": ["
+      },
+      {
+        "file": "enterprise/public/config/flex.config.json",
+        "line": 23,
+        "match": "\"guardrails\": ["
+      },
+      {
+        "file": "enterprise/public/config/flex.config.json",
+        "line": 35,
+        "match": "\"guardrails\": ["
+      },
+      {
+        "file": "enterprise/public/config/flex.config.json",
+        "line": 35,
+        "match": "\"guardrails\": ["
+      },
+      {
+        "file": "enterprise/public/marketing.html",
+        "line": 1275,
+        "match": "<p>Enterprise-grade sikkerhet, compliance og governance for trygg AI i organisasjonen.</p>"
+      },
+      {
+        "file": "enterprise/public/marketing.html.bak",
+        "line": 1249,
+        "match": "<p>Enterprise-grade sikkerhet, compliance og governance for trygg AI i organisasjonen.</p>"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 312,
+        "match": "\"core_tasks\": [\"Definere KPI-tre\", \"Styremøter for GTM\", \"Allokere verktøybudsjett\", \"Lede endringsprogrammer\", \"Rapportere helhetlig vekst\", \"Koordinere data governance\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 410,
+        "match": "\"summary\": \"Leder deal desk-team og governance.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 1792,
+        "match": "\"summary\": \"Styrer spendprogram og governance.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 2038,
+        "match": "\"core_tasks\": [\"Data governance\", \"KPI-rammeverk\", \"Endringsledelse\", \"Roadmap\", \"Rapportering til ledelse\", \"Koordinere team\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 2045,
+        "match": "\"ai_assists\": [\"Generer styredeck\", \"Oppsummer programstatus\", \"Foreslå KPI-endringer\", \"Lag datagovernance-plan\", \"Varsle risiko\", \"Oppsummer gevinst\", \"Foreslå opplæring\", \"Utkast til kommunikasjon\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 3618,
+        "match": "\"core_tasks\": [\"Krav og backlogg\", \"Release og test\", \"Brukerstøtte\", \"Rapportbygger\", \"Data governance\", \"Opplæring\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 4098,
+        "match": "\"core_tasks\": [\"Design av komp-planer\", \"Governance og godkjenning\", \"KPI og kostkontroll\", \"Leverandør- og verktøystyring\", \"Stakeholderdialog\", \"Revisjonsspor\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 4152,
+        "match": "\"alt_titles\": [\"Leder utgiftspolicy\", \"Expense Governance Manager\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 4310,
+        "match": "\"role_id\": \"finance-lead-finance-data-governance-lead\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 4311,
+        "match": "\"canonical_title\": \"Finance Data Governance Lead\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 4312,
+        "match": "\"alt_titles\": [\"Leder finansdatastyring\", \"Data Governance Lead Finance\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 4860,
+        "match": "\"core_tasks\": [\"Definere leveransemodell\", \"Stakeholder management\", \"Eskaleringshåndtering\", \"Kost/nytte-oppfølging\", \"Governance og kvalitetssikring\", \"Coache prosjektledere\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 4900,
+        "match": "\"core_tasks\": [\"Prioriteringsrammeverk\", \"Stage-gate og governance\", \"Kapitalallokering\", \"Roadmap-vedlikehold\", \"Rapportere porteføljestatus\", \"Håndtere risiko/avhengigheter\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 5220,
+        "match": "\"core_tasks\": [\"Policy og katalogstyring\", \"Onboarding leverandør\", \"P2P-KPI og forbedring\", \"Automatisering og integrasjoner\", \"Opplæring brukere\", \"Tverrfaglig governance\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 6903,
+        "match": "\"core_tasks\": [\"Policy og governance\", \"Teams/rom/gruppe-livssyklus\", \"Møte- og opptaksinnstillinger\", \"Ekstern deling\", \"Rapportering\", \"Incident/forespørsler\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 6907,
+        "match": "\"artifacts\": [\"Governance-dokument\", \"Rapportpakke\", \"Brukerveiledning\", \"Endringslogg\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7183,
+        "match": "\"core_tasks\": [\"Landing zone og nett\", \"Policy/guardrails\", \"Automatisere provisjonering\", \"Patch/backup\", \"Observability\", \"Kostoptimalisering\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7183,
+        "match": "\"core_tasks\": [\"Landing zone og nett\", \"Policy/guardrails\", \"Automatisere provisjonering\", \"Patch/backup\", \"Observability\", \"Kostoptimalisering\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7756,
+        "match": "\"artifacts\": [\"Master data creation procedures\", \"Data quality reports\", \"Validation checklists\", \"Master data governance documents\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7770,
+        "match": "\"alt_titles\": [\"Master Data Expert\", \"SAP Master Data Consultant\", \"Data Governance Specialist\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7774,
+        "match": "\"summary\": \"Advanced master data management with focus on process improvement, data governance, and cross-module integration.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7775,
+        "match": "\"mission\": \"Design and implement robust master data governance frameworks while ensuring seamless integration across SAP landscape.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7777,
+        "match": "\"Design master data governance processes and workflows\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7778,
+        "match": "\"Configure SAP MDG (Master Data Governance) solutions\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7785,
+        "match": "\"kpis\": [\"Data governance compliance\", \"Master data migration success rate\", \"User training completion\", \"Process automation level\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7786,
+        "match": "\"artifacts\": [\"Master data strategy documents\", \"Governance frameworks\", \"Migration procedures\", \"Training materials\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7792,
+        "match": "\"governance_framework\": \"Implement enterprise data governance standards\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 7972,
+        "match": "\"forecast_governance\": \"Follow established forecasting methodology and review processes\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8062,
+        "match": "\"architecture_governance\": \"Enforce architectural standards and review processes\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8092,
+        "match": "\"model_governance\": \"Follow ML lifecycle management and versioning standards\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8198,
+        "match": "\"Establish API governance and versioning strategies\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8230,
+        "match": "\"Design data governance and quality frameworks\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8236,
+        "match": "\"artifacts\": [\"Data models\", \"ETL specifications\", \"Data governance policies\", \"Architecture blueprints\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8242,
+        "match": "\"data_governance\": \"Implement comprehensive data governance and lineage tracking\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8321,
+        "match": "\"Establish cloud governance and security frameworks\""
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8326,
+        "match": "\"artifacts\": [\"Cloud architecture diagrams\", \"Migration plans\", \"Cost optimization reports\", \"Governance frameworks\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8334,
+        "match": "\"governance\": \"Maintain cloud governance and operational excellence\""
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8406,
+        "match": "\"core_tasks\": [\"Power calculations\", \"Guardrail metric setup\", \"Results analysis\", \"Experiment documentation\", \"Educate teams\", \"Monitor novelty effects\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8406,
+        "match": "\"core_tasks\": [\"Power calculations\", \"Guardrail metric setup\", \"Results analysis\", \"Experiment documentation\", \"Educate teams\", \"Monitor novelty effects\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8413,
+        "match": "\"ai_assists\": [\"Calculate sample sizes\", \"Draft hypotheses\", \"Detect peeking risks\", \"Summarize lift with CIs\", \"Recommend follow-up tests\", \"Auto-tag learnings\", \"Suggest guardrails\", \"Flag novelty bias\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8413,
+        "match": "\"ai_assists\": [\"Calculate sample sizes\", \"Draft hypotheses\", \"Detect peeking risks\", \"Summarize lift with CIs\", \"Recommend follow-up tests\", \"Auto-tag learnings\", \"Suggest guardrails\", \"Flag novelty bias\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8566,
+        "match": "\"core_tasks\": [\"Build HR dashboards\", \"Attrition modeling\", \"Diversity reporting\", \"Comp analysis\", \"Survey analytics\", \"Data governance with HR\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8626,
+        "match": "\"core_tasks\": [\"Run triage/IRB-like review\", \"Maintain registry and guardrails\", \"Publish weekly wins\", \"Coordinate platform upgrades\", \"Coach teams\", \"Enforce standards\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8626,
+        "match": "\"core_tasks\": [\"Run triage/IRB-like review\", \"Maintain registry and guardrails\", \"Publish weekly wins\", \"Coordinate platform upgrades\", \"Coach teams\", \"Enforce standards\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8778,
+        "match": "\"role_id\": \"data-mid-data-governance-analyst\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 8779,
+        "match": "\"canonical_title\": \"Data Governance Analyst\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9144,
+        "match": "\"summary\": \"Owns the experimentation program and governance across product and growth.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9146,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9146,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9150,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9150,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9153,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9153,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9225,
+        "match": "\"mission\": \"Ship robust ML models to production with observability and governance.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9238,
+        "match": "\"role_id\": \"data-manager-data-governance-manager\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9239,
+        "match": "\"canonical_title\": \"Data Governance Manager\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9244,
+        "match": "\"summary\": \"Leads data governance program across quality, ownership and policy.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9246,
+        "match": "\"core_tasks\": [\"Define ownership/RACI\", \"Run data council\", \"Publish policies/standards\", \"Oversee catalog & lineage\", \"Drive quality remediation\", \"Report governance KPIs\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9271,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Engineering\", \"Data Governance\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9351,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Data Governance\", \"Domain leads\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9446,
+        "match": "\"core_tasks\": [\"Own HR service catalog\", \"Optimize processes\", \"Manage vendors\", \"Run payroll interface governance\", \"Drive ticket SLAs\", \"Report HR ops KPIs\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9604,
+        "match": "\"summary\": \"Owns the experimentation program and governance across product and growth.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9606,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9606,
+        "match": "\"core_tasks\": [\"Define guardrails\", \"Run design reviews\", \"Coach teams on stats\", \"Maintain experiment backlog\", \"Publish experiment portfolio\", \"Drive causal inference best practice\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9610,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9610,
+        "match": "\"artifacts\": [\"Experiment playbook\", \"Backlog\", \"Quarterly learnings report\", \"Standards & guardrails\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9613,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9613,
+        "match": "\"ai_assists\": [\"Check sample power\", \"Detect SRM early\", \"Draft hypotheses and KPIs\", \"Auto-generate readouts\", \"Suggest CUPED/variance reduction\", \"Propose guardrail metrics\", \"Summarize portfolio risk\", \"Flag conflicting tests\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9685,
+        "match": "\"mission\": \"Ship robust ML models to production with observability and governance.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9698,
+        "match": "\"role_id\": \"data-manager-data-governance-manager\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9699,
+        "match": "\"canonical_title\": \"Data Governance Manager\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9704,
+        "match": "\"summary\": \"Leads data governance program across quality, ownership and policy.\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9706,
+        "match": "\"core_tasks\": [\"Define ownership/RACI\", \"Run data council\", \"Publish policies/standards\", \"Oversee catalog & lineage\", \"Drive quality remediation\", \"Report governance KPIs\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9731,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Engineering\", \"Data Governance\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9811,
+        "match": "\"stakeholders_internal\": [\"Analytics\", \"Data Governance\", \"Domain leads\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 9906,
+        "match": "\"core_tasks\": [\"Own HR service catalog\", \"Optimize processes\", \"Manage vendors\", \"Run payroll interface governance\", \"Drive ticket SLAs\", \"Report HR ops KPIs\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 10160,
+        "match": "\"alt_titles\": [\"Governance, Risk & Compliance Manager\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 10793,
+        "match": "\"ai_assists\": [\"Draft legal assessment\", \"Clause mapping\", \"Policy check\", \"Response templates\", \"Training slides\", \"Summary for leaders\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 12591,
+        "match": "\"artifacts\": [\"Guardrails\", \"Referansearkitektur\", \"Rapporter\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 12591,
+        "match": "\"artifacts\": [\"Guardrails\", \"Referansearkitektur\", \"Rapporter\"],"
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 13319,
+        "match": "\"role_id\": \"data-mid-data-governance-analyst\","
+      },
+      {
+        "file": "roles/roles.json",
+        "line": 13320,
+        "match": "\"canonical_title\": \"Data Governance Analyst\","
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 99,
+        "match": "description: 'Execute automations directly under policy guardrails.',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 99,
+        "match": "description: 'Execute automations directly under policy guardrails.',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 99,
+        "match": "description: 'Execute automations directly under policy guardrails.',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 103,
+        "match": "banner: 'Executing with guardrails',"
+      },
+      {
+        "file": "src/core/proactivity/modes.ts",
+        "line": 103,
+        "match": "banner: 'Executing with guardrails',"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 18,
+        "match": "summary: 'Systems aligned with guardrails. No unattended autonomy detected.',"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 18,
+        "match": "summary: 'Systems aligned with guardrails. No unattended autonomy detected.',"
+      },
+      {
+        "file": "src/routes/genesis.autonomy.ts",
+        "line": 99,
+        "match": "error: 'approval_required',"
+      },
+      {
+        "file": "tests/crm.policy.test.ts",
+        "line": 4,
+        "match": "describe(\"CRM policy enforcement\", () => {"
+      },
+      {
+        "file": "tests/meta/policy.test.ts",
+        "line": 35,
+        "match": "it('returns snapshot data from policy engine and metrics store', async () => {"
+      },
+      {
+        "file": "tests/policy/audit.guard.test.ts",
+        "line": 4,
+        "match": "describe('policy guard on /api/audit', () => {"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 69,
+        "match": "'governance',"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 277,
+        "match": "/guardrail/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 277,
+        "match": "/guardrail/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 279,
+        "match": "/governance/i,"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 579,
+        "match": "violations.missing_approval_gate.push({ file: null, reason: 'No approval gate references detected (.evolution/APPROVED, approval_required, or evolution gatekeeper).' });"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 579,
+        "match": "violations.missing_approval_gate.push({ file: null, reason: 'No approval gate references detected (.evolution/APPROVED, approval_required, or evolution gatekeeper).' });"
+      },
+      {
+        "file": "tools/analyze-workbuoy.mjs",
+        "line": 579,
+        "match": "violations.missing_approval_gate.push({ file: null, reason: 'No approval gate references detected (.evolution/APPROVED, approval_required, or evolution gatekeeper).' });"
+      }
+    ],
+    "BUOY_ASSISTANT_SINGULAR": {
+      "singular_mentions": [
+        {
+          "file": "README_BUOY_2.4.4.md",
+          "line": 1,
+          "match": "# Buoy AI OS v2.4.4 — Placement + MVP Endpoint"
+        },
+        {
+          "file": "azure-pipelines.yml",
+          "line": 56,
+          "match": "displayName: Buoy AI smoke"
+        },
+        {
+          "file": "desktop/README.md",
+          "line": 87,
+          "match": "## Phase D (Buoy AI & CRM)"
+        },
+        {
+          "file": "desktop/metrics.js",
+          "line": 17,
+          "match": "const aiRequests = new client.Counter({ name: 'wb_desktop_ai_requests_total', help: 'Buoy AI requests', registers: [register] });"
+        },
+        {
+          "file": "desktop/metrics.js",
+          "line": 18,
+          "match": "const aiWorkflows = new client.Counter({ name: 'wb_desktop_ai_workflows_total', help: 'Buoy AI workflow requests', registers: [register] });"
+        },
+        {
+          "file": "docs/PR_CHECKLIST_BUOY.md",
+          "line": 1,
+          "match": "# PR Checklist — Buoy AI OS v2.4.4 (Placement + Endpoint)"
+        },
+        {
+          "file": "docs/auto/release_playbook.md",
+          "line": 14,
+          "match": "- Buoy AI smoke test: ⛔"
+        },
+        {
+          "file": "src/buoy/agent.ts",
+          "line": 2,
+          "match": "* Buoy AI OS — agent orchestrator (v2.4.4)"
+        },
+        {
+          "file": "workbuoy_pr_ay/ai/policy/tool_allowlist.yaml",
+          "line": 1,
+          "match": "# Allowlist of methods+paths Buoy AI is allowed to call via the action layer."
+        },
+        {
+          "file": "workbuoy_pr_ay/docs/AI_OPENAPI_TOOLS.md",
+          "line": 1,
+          "match": "# Buoy AI – OpenAPI action layer"
+        },
+        {
+          "file": "workbuoy_pr_az/docs/AI_BUOY_INTEGRATION.md",
+          "line": 1,
+          "match": "# Buoy AI – integrasjon"
+        }
+      ],
+      "plural_hits": []
+    }
+  },
+  "violations": {
+    "http_write_ops": [
+      {
+        "file": "enterprise/pages/api/meta/apply.js",
+        "line": 18,
+        "snippet": "fs.writeFileSync(out, JSON.stringify({ id, patch, applied_at: new Date().toISOString() }, null, 2));"
+      },
+      {
+        "file": "enterprise/pages/api/wb2wb/policy.update.js",
+        "line": 20,
+        "snippet": "fs.writeFileSync(storePath, JSON.stringify(data,null,2));"
+      }
+    ],
+    "missing_approval_gate": []
+  }
+}


### PR DESCRIPTION
## Summary
- add a Node-based repository scanner (`tools/analyze-workbuoy.mjs`) to classify platform pillars and capture guardrail signals
- produce the generated `workbuoy-analysis.json` snapshot for the current HEAD
- author `WORKBUOY_AUDIT.md` summarizing pillar coverage, meta rails, and outstanding violations

## Testing
- node tools/analyze-workbuoy.mjs > workbuoy-analysis.json
- jq '.summary' workbuoy-analysis.json

------
https://chatgpt.com/codex/tasks/task_e_68ce62512984832a870819648c259b9b