### PR TITLE
Handle repeated connect keydown

### DIFF
--- a/frontend/src/components/FlipCard/FlipCard.test.tsx
+++ b/frontend/src/components/FlipCard/FlipCard.test.tsx
@@ -60,5 +60,9 @@ describe("FlipCard", () => {
     const connectButton = await screen.findByRole("button", { name: /connect contact:ada/i });
     fireEvent.click(connectButton);
     await waitFor(() => expect(onConnect).toHaveBeenCalledWith(expect.objectContaining({ type: "contact", id: "contact-1" })));
+    fireEvent.keyDown(connectButton, { key: "Enter", repeat: true });
+    expect(onConnect).toHaveBeenCalledTimes(1);
+    const card = screen.getByRole("group", { name: /flip card/i });
+    expect(card.getAttribute("data-side")).toBe("front");
   });
 });

--- a/frontend/src/components/FlipCard/FlipCard.tsx
+++ b/frontend/src/components/FlipCard/FlipCard.tsx
@@ -171,6 +171,17 @@ export function FlipCard({
     setConnectOpen(true);
   }, [commitConnection, onConnect, selectedEntity]);
 
+  const handleConnectKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.repeat) return;
+      handleConnect();
+    },
+    [handleConnect],
+  );
+
   const handleManualSubmit = useCallback((event: React.FormEvent) => {
     event.preventDefault();
     const trimmed = manualId.trim();
@@ -225,6 +236,7 @@ export function FlipCard({
               type="button"
               className="chip flip-card-toolbar__connect"
               onClick={handleConnect}
+              onKeyDown={handleConnectKeyDown}
               aria-haspopup="dialog"
               aria-label={`Connect ${connectLabel}`}
             >


### PR DESCRIPTION
## Summary
- prevent auto-repeated keyboard events on the FlipCard connect button from triggering connections or flipping the card
- add a regression test that simulates a repeated keydown and ensures the card stays on the front side

## Testing
- npm install *(fails: 403 Forbidden fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb160f8a4832a8edfb6ad9f0e8a4e