### PR TITLE
DB persistence for roles & usage + caps integration (proactivity-aware, gap fill)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -8,8 +8,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: workbuoy
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
     env:
       CI: "true"
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/workbuoy
     steps:
       - uses: actions/checkout@v4
 
@@ -26,6 +38,14 @@ jobs:
           npm config set audit false
           npm config get registry
 
+      - name: Install root dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-fund --no-audit
+          fi
+
       - name: Install dependencies
         working-directory: backend
         run: |
@@ -35,6 +55,11 @@ jobs:
             npm install --no-fund --no-audit
           fi
 
-      - name: Run smoke tests (temporary)
-        working-directory: backend
-        run: npx jest --ci --config jest.ci.config.cjs
+      - name: Apply Prisma migrations
+        run: npx prisma migrate deploy
+
+      - name: Run tests (FF_PERSISTENCE=false)
+        run: FF_PERSISTENCE=false npm test
+
+      - name: Run tests (FF_PERSISTENCE=true)
+        run: FF_PERSISTENCE=true npm test

--- a/backend/jest.meta.config.cjs
+++ b/backend/jest.meta.config.cjs
@@ -7,6 +7,11 @@ module.exports = {
     '<rootDir>/tests/eventBus.stats.shape.test.ts',
     '<rootDir>/tests/mvp.crm-baseline.test.ts',
     '<rootDir>/../tests/meta/**/*.test.ts',
-    '<rootDir>/../tests/policy/**/*.test.ts'
+    '<rootDir>/../tests/policy/**/*.test.ts',
+    '<rootDir>/../tests/roles/db.registry.test.ts',
+    '<rootDir>/../tests/usage/db.usage.test.ts',
+    '<rootDir>/../tests/features/active.api.test.ts',
+    '<rootDir>/../tests/admin/roles.api.test.ts',
+    '<rootDir>/../tests/proactivity/context.integration.test.ts'
   ],
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "express": "^4.19.2",
     "express-rate-limit": "^6.10.0",
     "prom-client": "^15.1.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "@prisma/client": "^5.14.0"
   },
   "devDependencies": {
     "typescript": "^5.4.5",

--- a/backend/routes/admin.roles.ts
+++ b/backend/routes/admin.roles.ts
@@ -1,0 +1,95 @@
+import { Router } from 'express';
+import { rbac } from '../../src/core/security/rbac';
+import { envBool } from '../../src/core/env';
+import { loadFeaturesFromRepo, loadRolesFromRepo } from '../../src/roles/loader';
+import { getRoleRegistry, importRolesAndFeatures, listOverridesForTenant, setOverride } from '../../src/roles/service';
+import type { OrgRoleOverride, UserRoleBinding } from '../../src/roles/types';
+
+const router = Router();
+const requireAdmin = rbac(['admin']);
+
+function tenantFrom(req: any): string {
+  return String(req.header('x-tenant') || req.header('x-tenant-id') || req.body?.tenantId || 'demo');
+}
+
+function ensurePersistence(res: any): boolean {
+  if (!envBool('FF_PERSISTENCE', false)) {
+    res.status(412).json({ error: 'persistence_disabled', message: 'FF_PERSISTENCE must be true for admin role operations' });
+    return false;
+  }
+  return true;
+}
+
+router.post('/admin/roles/import', requireAdmin, async (_req, res) => {
+  if (!ensurePersistence(res)) return;
+  try {
+    const roles = loadRolesFromRepo();
+    const features = loadFeaturesFromRepo();
+    const summary = await importRolesAndFeatures(roles, features);
+    res.json({ ok: true, imported: summary });
+  } catch (err: any) {
+    res.status(500).json({ error: 'roles_import_failed', message: err?.message || String(err) });
+  }
+});
+
+async function summarizeRole(tenantId: string, roleId: string) {
+  const registry = await getRoleRegistry({ refresh: true });
+  const binding: UserRoleBinding = { userId: '__admin__', primaryRole: roleId };
+  const ctx = registry.getUserContext(tenantId, binding);
+  if (!ctx.roles.length) {
+    return null;
+  }
+  return {
+    rolesResolved: ctx.roles.map(r => ({ role_id: r.role_id, title: r.canonical_title })),
+    featureCaps: ctx.featureCaps,
+    features: ctx.features,
+  };
+}
+
+router.put('/admin/roles/:roleId/overrides', requireAdmin, async (req, res) => {
+  if (!ensurePersistence(res)) return;
+  const tenantId = tenantFrom(req);
+  const roleId = String(req.params.roleId);
+  const { featureCaps, disabledFeatures } = req.body || {};
+  try {
+    const normalizedCaps = featureCaps
+      ? Object.fromEntries(
+          Object.entries(featureCaps)
+            .map(([fid, cap]: [string, any]) => [fid, Number(cap)])
+            .filter(([, cap]) => !Number.isNaN(cap))
+        )
+      : undefined;
+    const override = await setOverride(tenantId, roleId, {
+      tenantId,
+      role_id: roleId as OrgRoleOverride['role_id'],
+      featureCaps: normalizedCaps,
+      disabledFeatures: Array.isArray(disabledFeatures) ? disabledFeatures.map((v: any) => String(v)) : undefined,
+    });
+    const summary = await summarizeRole(tenantId, roleId);
+    if (!summary) {
+      return res.status(404).json({ error: 'role_not_found', message: `role ${roleId} not registered` });
+    }
+    res.json({ tenantId, roleId, override, effective: summary });
+  } catch (err: any) {
+    res.status(500).json({ error: 'override_failed', message: err?.message || String(err) });
+  }
+});
+
+router.get('/admin/roles/:roleId', requireAdmin, async (req, res) => {
+  if (!ensurePersistence(res)) return;
+  const tenantId = tenantFrom(req);
+  const roleId = String(req.params.roleId);
+  try {
+    const summary = await summarizeRole(tenantId, roleId);
+    if (!summary) {
+      return res.status(404).json({ error: 'role_not_found', message: `role ${roleId} not registered` });
+    }
+    const overrides = await listOverridesForTenant(tenantId);
+    const override = overrides.find(o => o.role_id === roleId) ?? null;
+    res.json({ tenantId, roleId, override, effective: summary });
+  } catch (err: any) {
+    res.status(500).json({ error: 'role_inspect_failed', message: err?.message || String(err) });
+  }
+});
+
+export default router;

--- a/backend/routes/admin.subscription.ts
+++ b/backend/routes/admin.subscription.ts
@@ -2,8 +2,10 @@ import { Router } from 'express';
 import { getSubscriptionForTenant, getSubscriptionCap, setSubscriptionForTenant } from '../../src/core/subscription/state';
 import { isSubscriptionPlan } from '../../src/core/subscription/entitlements';
 import { parseProactivityMode } from '../../src/core/proactivity/modes';
+import { rbac } from '../../src/core/security/rbac';
 
 const router: any = Router();
+const requireAdmin = rbac(['admin']);
 
 function tenantFrom(req: any) {
   return String(req.header('x-tenant') || req.header('x-tenant-id') || req.query?.tenant || 'demo');
@@ -22,12 +24,12 @@ function serialize(tenantId: string) {
   };
 }
 
-router.get('/admin/subscription', (req: any, res: any) => {
+router.get('/admin/subscription', requireAdmin, (req: any, res: any) => {
   const tenantId = tenantFrom(req);
   res.json(serialize(tenantId));
 });
 
-router.put('/admin/subscription', (req: any, res: any) => {
+router.put('/admin/subscription', requireAdmin, (req: any, res: any) => {
   const tenantId = tenantFrom(req);
   const { plan, killSwitch, secureTenant, maxOverride } = req.body || {};
   const overrideValue = maxOverride === null ? undefined : maxOverride;

--- a/backend/routes/dev.runner.ts
+++ b/backend/routes/dev.runner.ts
@@ -1,12 +1,11 @@
 import { Router } from 'express';
-import { RoleRegistry } from '../../src/roles/registry';
-import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
 import { runCapabilityWithRole } from '../../src/core/capabilityRunnerRole';
 import { testCaps } from '../../src/capabilities/testCaps';
 import { parseProactivityMode } from '../../src/core/proactivity/modes';
+import { getRoleRegistry, resolveUserBinding } from '../../src/roles/service';
+import type { UserRoleBinding } from '../../src/roles/types';
 
 const router: any = Router();
-const rr = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
 
 async function policyAllowAlways() { return { allowed: true, basis: ['dev:allow'] }; }
 async function logIntent(event: any) { console.log('[intent]', JSON.stringify(event)); }
@@ -25,14 +24,18 @@ router.post('/dev/run', async (req: any, res: any) => {
   const role = String(req.header('x-role') ?? 'sales_rep');
   const requestedHeader = req.header('x-proactivity');
 
+  const registry = await getRoleRegistry();
+  const fallback: UserRoleBinding = { userId, primaryRole: role };
+  const binding = (await resolveUserBinding(tenantId, userId, fallback)) ?? fallback;
+
   const result = await runCapabilityWithRole(
-    rr,
+    registry,
     capability,
     featureId,
     payload,
     {
       tenantId,
-      roleBinding: { userId, primaryRole: role },
+      roleBinding: binding,
       requestedMode: parseProactivityMode(requestedHeader ?? req.body?.mode),
     },
     impl,

--- a/backend/routes/features.ts
+++ b/backend/routes/features.ts
@@ -1,19 +1,41 @@
 import { Router } from 'express';
-import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
-import { RoleRegistry } from '../../src/roles/registry';
+import type { UserRoleBinding } from '../../src/roles/types';
+import { getRoleRegistry, resolveUserBinding } from '../../src/roles/service';
 import { getActiveFeatures } from '../../src/features/activation/featureActivation';
-import { aggregateFeatureUseCount } from '../../src/telemetry/usageSignals';
+import { aggregateFeatureUseCount as aggregateInMemory } from '../../src/telemetry/usageSignals';
+import { aggregateFeatureUseCount as aggregateFromDb } from '../../src/telemetry/usageSignals.db';
+import { envBool } from '../../src/core/env';
 
 const r = Router();
-const rr = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
+const usePersistence = envBool('FF_PERSISTENCE', false);
 
-r.get('/api/features/active', (req, res) => {
+r.get('/api/features/active', async (req, res) => {
   const tenantId = String(req.header('x-tenant') ?? 'DEV');
   const userId = String(req.header('x-user') ?? 'dev-user');
   const role = String(req.header('x-role') ?? 'sales_rep');
-  const usage = aggregateFeatureUseCount(userId);
-  const list = getActiveFeatures(rr, { tenantId, userId, roleBinding: { userId, primaryRole: role }, workPatterns: { featureUseCount: usage } });
-  res.json(list);
+  try {
+    const registry = await getRoleRegistry();
+    const fallback: UserRoleBinding = { userId, primaryRole: role };
+    const binding = (await resolveUserBinding(tenantId, userId, fallback)) ?? fallback;
+    const usage = usePersistence
+      ? await aggregateFromDb(userId, tenantId)
+      : aggregateInMemory(userId, tenantId);
+    const orgContext = {
+      industry: req.header('x-industry') ?? undefined,
+      region: req.header('x-region') ?? undefined,
+      size: (req.header('x-tenant-size') as 'smb'|'mid'|'ent' | undefined) ?? undefined,
+    };
+    const list = getActiveFeatures(registry, {
+      tenantId,
+      userId,
+      roleBinding: binding,
+      workPatterns: { featureUseCount: usage },
+      orgContext,
+    });
+    res.json(list);
+  } catch (err: any) {
+    res.status(500).json({ error: 'feature_activation_failed', message: err?.message || String(err) });
+  }
 });
 
 export default r;

--- a/backend/routes/proactivity.ts
+++ b/backend/routes/proactivity.ts
@@ -1,12 +1,11 @@
 import { Router } from 'express';
-import { RoleRegistry } from '../../src/roles/registry';
-import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
+import type { UserRoleBinding } from '../../src/roles/types';
+import { getRoleRegistry, resolveUserBinding } from '../../src/roles/service';
 import { buildProactivityContext } from '../../src/core/proactivity/context';
 import { parseProactivityMode } from '../../src/core/proactivity/modes';
 import { logModusskift } from '../../src/core/proactivity/telemetry';
 
 const router: any = Router();
-const roleRegistry = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
 
 function resolveHeaders(req: any) {
   const tenantId = String(req.header('x-tenant') || req.header('x-tenant-id') || 'demo');
@@ -16,14 +15,17 @@ function resolveHeaders(req: any) {
   return { tenantId, userId, role, requestedHeader };
 }
 
-function computeState(req: any, overrideMode?: any) {
+async function computeState(req: any, overrideMode?: any) {
   const { tenantId, userId, role, requestedHeader } = resolveHeaders(req);
   const requested = overrideMode ?? req.body?.requested ?? req.body?.mode ?? requestedHeader;
   const featureId = req.body?.featureId || req.query?.featureId || undefined;
+  const registry = await getRoleRegistry();
+  const fallbackBinding: UserRoleBinding = { userId, primaryRole: role };
+  const binding = (await resolveUserBinding(tenantId, userId, fallbackBinding)) ?? fallbackBinding;
   const state = buildProactivityContext({
     tenantId,
-    roleRegistry,
-    roleBinding: { userId, primaryRole: role },
+    roleRegistry: registry,
+    roleBinding: binding,
     requestedMode: parseProactivityMode(requested),
     featureId,
   });
@@ -49,14 +51,22 @@ function toResponse(state: ReturnType<typeof buildProactivityContext>) {
   };
 }
 
-router.get('/proactivity/state', (req: any, res: any) => {
-  const { state } = computeState(req);
-  res.json(toResponse(state));
+router.get('/proactivity/state', async (req: any, res: any) => {
+  try {
+    const { state } = await computeState(req);
+    res.json(toResponse(state));
+  } catch (err: any) {
+    res.status(500).json({ error: 'proactivity_state_error', message: err?.message || String(err) });
+  }
 });
 
-router.post('/proactivity/state', (req: any, res: any) => {
-  const { state } = computeState(req, req.body?.requestedMode ?? req.body?.requested ?? req.body?.mode);
-  res.json(toResponse(state));
+router.post('/proactivity/state', async (req: any, res: any) => {
+  try {
+    const { state } = await computeState(req, req.body?.requestedMode ?? req.body?.requested ?? req.body?.mode);
+    res.json(toResponse(state));
+  } catch (err: any) {
+    res.status(500).json({ error: 'proactivity_state_error', message: err?.message || String(err) });
+  }
 });
 
 export default router;

--- a/backend/routes/usage.ts
+++ b/backend/routes/usage.ts
@@ -1,16 +1,37 @@
 import { Router } from 'express';
-import { recordFeatureUsage, aggregateFeatureUseCount } from '../../src/telemetry/usageSignals';
+import { recordFeatureUsage as recordInMemory, aggregateFeatureUseCount as aggregateInMemory } from '../../src/telemetry/usageSignals';
+import { recordFeatureUsage as recordDbUsage, aggregateFeatureUseCount as aggregateFromDb } from '../../src/telemetry/usageSignals.db';
+import { envBool } from '../../src/core/env';
 const r = Router();
+const usePersistence = envBool('FF_PERSISTENCE', false);
 
-r.post('/api/usage/feature', (req,res)=>{
-  const { userId, featureId, action } = req.body||{};
-  if (!userId || !featureId || !action) return res.status(400).json({ error: 'Missing userId/featureId/action' });
-  recordFeatureUsage({ userId, featureId, action, ts: new Date().toISOString() });
-  res.json({ ok: true });
+r.post('/api/usage/feature', async (req,res)=>{
+  try {
+    const tenantId = String(req.header('x-tenant') ?? req.body?.tenantId ?? 'DEV');
+    const { userId, featureId, action } = req.body||{};
+    if (!userId || !featureId || !action) return res.status(400).json({ error: 'Missing userId/featureId/action' });
+    if (usePersistence) {
+      await recordDbUsage({ userId, tenantId, featureId, action });
+    } else {
+      recordInMemory({ userId, tenantId, featureId, action, ts: new Date().toISOString() });
+    }
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: 'usage_record_failed', message: err?.message || String(err) });
+  }
 });
 
-r.get('/api/usage/aggregate/:userId', (req,res)=>{
-  res.json(aggregateFeatureUseCount(String(req.params.userId)));
+r.get('/api/usage/aggregate/:userId', async (req,res)=>{
+  try {
+    const tenantId = String(req.header('x-tenant') ?? req.query?.tenantId ?? 'DEV');
+    const userId = String(req.params.userId);
+    const usage = usePersistence
+      ? await aggregateFromDb(userId, tenantId)
+      : aggregateInMemory(userId, tenantId);
+    res.json(usage);
+  } catch (err: any) {
+    res.status(500).json({ error: 'usage_aggregate_failed', message: err?.message || String(err) });
+  }
 });
 
 export default r;

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,5 +6,8 @@
 - Buoy: `openapi/buoy.yaml`
 - Manual: `openapi/manual.yaml`
 - Proactivity: `openapi/proactivity.yaml`
+- Roles & Overrides: see `/api/admin/roles/*` in `openapi/proactivity.yaml`
+- Feature usage telemetry: `/api/usage/*`
+- Feature activation: `/api/features/active`
 
 CI runs Spectral (non-blocking) over all specs.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,48 @@
+# Roles & Feature Caps
+
+Workbuoy persists role definitions, feature metadata, tenant overrides and user bindings in Postgres when `FF_PERSISTENCE=true`. The registry still supports the in-repo JSON seed for offline development.
+
+## Data Model
+
+| Table | Purpose |
+|-------|---------|
+| `Role` | Canonical role definitions (`role_id`, inherits, feature caps, scope hints, JSON profile). |
+| `Feature` | Feature catalog with descriptions, default autonomy caps and capability ids. |
+| `OrgRoleOverride` | Tenant-specific overrides for role caps and disabled features. Composite key `(tenant_id, role_id)`. |
+| `UserRole` | User→role bindings (`primaryRole`, optional `secondaryRoles`). |
+
+`featureCaps` are stored as JSON maps of `featureId → autonomyCap (1..6)`. Overrides clamp values between 0 and 6; `disabledFeatures` force a cap of zero.
+
+## Seeding & Import
+
+1. Ensure Postgres is running and `DATABASE_URL` is exported.
+2. Seed from the repository JSON: `npx ts-node scripts/seed-roles-from-json.ts`
+   - The script loads `roles/roles.json` and `src/roles/seed/features.ts`, upserts into Postgres, and refreshes the registry cache.
+3. Admins can re-import via API: `POST /api/admin/roles/import` with `x-role-id: admin`.
+
+When `FF_PERSISTENCE=false`, the registry falls back to in-memory data (`loadRolesFromRepo` + `defaultFeatures`).
+
+## Tenant Overrides
+
+`PUT /api/admin/roles/:roleId/overrides`
+
+```bash
+curl -X PUT \
+  -H 'x-role-id: admin' \
+  -H 'x-tenant: ACME' \
+  -H 'Content-Type: application/json' \
+  -d '{"featureCaps": {"cashflow_forecast": 4}, "disabledFeatures": ["contract_compliance"]}' \
+  http://localhost:3000/api/admin/roles/sales-manager-account-executive/overrides
+```
+
+The registry merges role caps with overrides at read time. `RoleRegistry.getUserContext()` exposes the resolved `featureCaps` and active features for a binding.
+
+## Inspecting Effective Caps
+
+`GET /api/admin/roles/:roleId` returns:
+
+- `override` — current tenant override (if any)
+- `effective.featureCaps` — resolved caps after inheritance + overrides
+- `effective.features` — activatable features with autonomy caps and ranking basis
+
+Use this endpoint when debugging proactivity downgrades.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,36 @@
+# Usage Signals
+
+Feature usage telemetry is persisted in Postgres when `FF_PERSISTENCE=true` and falls back to an in-memory buffer for local smoke testing.
+
+## Event Shape
+
+```json
+{
+  "userId": "u-123",
+  "tenantId": "ACME",
+  "featureId": "cashflow_forecast",
+  "action": "open" | "complete" | "dismiss",
+  "ts": "2024-06-01T12:34:56.000Z"
+}
+```
+
+`POST /api/usage/feature` records events. When persistence is enabled the handler writes to Prisma's `FeatureUsage` table (enum `FeatureUsageAction`).
+
+## Aggregation
+
+`GET /api/usage/aggregate/:userId`
+
+- Optional `x-tenant` header filters counts per tenant.
+- Response is a `{ featureId: count }` map.
+
+The Active Features API consumes this aggregation to boost frequently used features:
+
+```
+score = autonomyCap + log(usage + 1) * 1.2 + industryBoost
+```
+
+## Admin & Debugging
+
+- Clear usage during tests with `DELETE FROM "FeatureUsage";`
+- The DB-backed implementation lives in `src/telemetry/usageSignals.db.ts`.
+- In-memory fallback remains in `src/telemetry/usageSignals.ts` for `FF_PERSISTENCE=false` runs.

--- a/openapi/proactivity.yaml
+++ b/openapi/proactivity.yaml
@@ -107,6 +107,149 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SubscriptionState'
+  /api/features/active:
+    get:
+      summary: List active features ranked for the current user
+      parameters:
+        - in: header
+          name: x-tenant
+          required: true
+          schema: { type: string }
+        - in: header
+          name: x-user
+          required: true
+          schema: { type: string }
+        - in: header
+          name: x-role
+          required: true
+          schema: { type: string }
+        - in: header
+          name: x-industry
+          schema: { type: string }
+      responses:
+        '200':
+          description: Ranked feature list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActiveFeature'
+  /api/usage/feature:
+    post:
+      summary: Record a feature usage event
+      parameters:
+        - in: header
+          name: x-tenant
+          required: false
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsageEvent'
+      responses:
+        '200':
+          description: Event recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+  /api/usage/aggregate/{userId}:
+    get:
+      summary: Aggregate usage counts for a user
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema: { type: string }
+        - in: header
+          name: x-tenant
+          schema: { type: string }
+      responses:
+        '200':
+          description: Aggregated counts
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: { type: integer }
+  /api/admin/roles/import:
+    post:
+      summary: Import roles.json into Postgres
+      parameters:
+        - in: header
+          name: x-role-id
+          required: true
+          schema: { type: string, enum: [admin] }
+      responses:
+        '200':
+          description: Import summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  imported:
+                    type: object
+                    properties:
+                      roles: { type: integer }
+                      features: { type: integer }
+  /api/admin/roles/{roleId}:
+    get:
+      summary: Inspect role caps for a tenant
+      parameters:
+        - in: path
+          name: roleId
+          required: true
+          schema: { type: string }
+        - in: header
+          name: x-role-id
+          required: true
+          schema: { type: string, enum: [admin] }
+        - in: header
+          name: x-tenant
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Effective caps
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleInspection'
+    put:
+      summary: Set tenant-specific role overrides
+      parameters:
+        - in: path
+          name: roleId
+          required: true
+          schema: { type: string }
+        - in: header
+          name: x-role-id
+          required: true
+          schema: { type: string, enum: [admin] }
+        - in: header
+          name: x-tenant
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoleOverrideRequest'
+      responses:
+        '200':
+          description: Updated override
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleInspection'
   /api/explain/last:
     get:
       summary: Fetch recent proactivity events for explainability UI
@@ -181,3 +324,60 @@ components:
           type: array
           items: { type: string }
         source: { type: string, nullable: true }
+    ActiveFeature:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        autonomyCap: { type: integer, minimum: 0, maximum: 6 }
+        score: { type: number }
+        rankBasis:
+          type: object
+          properties:
+            autonomyCap: { type: integer }
+            usage: { type: integer }
+            usageWeight: { type: number }
+            industryBoost: { type: number }
+    UsageEvent:
+      type: object
+      required: [userId, featureId, action]
+      properties:
+        userId: { type: string }
+        tenantId: { type: string }
+        featureId: { type: string }
+        action: { type: string, enum: [open, complete, dismiss] }
+        ts: { type: string, format: date-time }
+    RoleOverrideRequest:
+      type: object
+      properties:
+        featureCaps:
+          type: object
+          additionalProperties: { type: integer, minimum: 0, maximum: 6 }
+        disabledFeatures:
+          type: array
+          items: { type: string }
+    RoleInspection:
+      type: object
+      properties:
+        tenantId: { type: string }
+        roleId: { type: string }
+        override:
+          $ref: '#/components/schemas/RoleOverrideRequest'
+        effective:
+          type: object
+          properties:
+            rolesResolved:
+              type: array
+              items:
+                type: object
+                properties:
+                  role_id: { type: string }
+                  title: { type: string }
+            featureCaps:
+              type: object
+              additionalProperties: { type: integer }
+            features:
+              type: array
+              items:
+                $ref: '#/components/schemas/ActiveFeature'

--- a/package.json
+++ b/package.json
@@ -5,5 +5,12 @@
     "build": "tsc --noEmit -p tsconfig.proactivity.json",
     "test": "npm run test --prefix backend",
     "typecheck": "tsc --noEmit -p tsconfig.meta.json"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.14.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.14.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/prisma/migrations/20240601000000_roles_feature_usage/migration.sql
+++ b/prisma/migrations/20240601000000_roles_feature_usage/migration.sql
@@ -1,0 +1,69 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'FeatureUsageAction') THEN
+    CREATE TYPE "FeatureUsageAction" AS ENUM ('open', 'complete', 'dismiss');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "Role" (
+  "role_id" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "inherits" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "featureCaps" JSONB,
+  "scopeHints" JSONB,
+  "profile" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Role_pkey" PRIMARY KEY ("role_id")
+);
+
+CREATE TABLE IF NOT EXISTS "Feature" (
+  "id" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "description" TEXT,
+  "defaultAutonomyCap" INTEGER NOT NULL DEFAULT 3,
+  "capabilities" TEXT[] NOT NULL,
+  "metadata" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Feature_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "OrgRoleOverride" (
+  "tenant_id" TEXT NOT NULL,
+  "role_id" TEXT NOT NULL,
+  "featureCaps" JSONB,
+  "disabledFeatures" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "OrgRoleOverride_pkey" PRIMARY KEY ("tenant_id", "role_id")
+);
+
+CREATE INDEX IF NOT EXISTS "OrgRoleOverride_role_id_idx" ON "OrgRoleOverride" ("role_id");
+
+CREATE TABLE IF NOT EXISTS "UserRole" (
+  "user_id" TEXT NOT NULL,
+  "tenant_id" TEXT NOT NULL,
+  "primaryRole" TEXT NOT NULL,
+  "secondaryRoles" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "UserRole_pkey" PRIMARY KEY ("user_id")
+);
+
+CREATE TABLE IF NOT EXISTS "FeatureUsage" (
+  "id" TEXT NOT NULL DEFAULT (gen_random_uuid())::text,
+  "userId" TEXT NOT NULL,
+  "tenantId" TEXT NOT NULL,
+  "featureId" TEXT NOT NULL,
+  "action" "FeatureUsageAction" NOT NULL,
+  "ts" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "metadata" JSONB,
+  CONSTRAINT "FeatureUsage_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "FeatureUsage_userId_idx" ON "FeatureUsage" ("userId");
+CREATE INDEX IF NOT EXISTS "FeatureUsage_featureId_idx" ON "FeatureUsage" ("featureId");
+CREATE INDEX IF NOT EXISTS "FeatureUsage_tenantId_idx" ON "FeatureUsage" ("tenantId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,3 +43,66 @@ model AuditChain {
   createdAt DateTime @default(now())
   headHash  String?
 }
+
+enum FeatureUsageAction {
+  open
+  complete
+  dismiss
+}
+
+model Role {
+  role_id     String   @id
+  title       String
+  inherits    String[] @default([])
+  featureCaps Json?
+  scopeHints  Json?
+  profile     Json?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model Feature {
+  id                  String   @id
+  title               String
+  description         String?
+  defaultAutonomyCap  Int      @default(3)
+  capabilities        String[]
+  metadata            Json?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+}
+
+model OrgRoleOverride {
+  tenant_id        String
+  role_id          String
+  featureCaps      Json?
+  disabledFeatures String[] @default([])
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@id([tenant_id, role_id])
+  @@index([role_id])
+}
+
+model UserRole {
+  user_id        String  @id
+  tenant_id      String
+  primaryRole    String
+  secondaryRoles String[] @default([])
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+}
+
+model FeatureUsage {
+  id        String             @id @default(uuid())
+  userId    String
+  tenantId  String
+  featureId String
+  action    FeatureUsageAction
+  ts        DateTime           @default(now())
+  metadata  Json?
+
+  @@index([userId])
+  @@index([featureId])
+  @@index([tenantId])
+}

--- a/scripts/seed-roles-from-json.ts
+++ b/scripts/seed-roles-from-json.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env ts-node
+import path from 'node:path';
+import { loadRolesFromRepo, loadFeaturesFromRepo } from '../src/roles/loader';
+import { importRolesAndFeatures } from '../src/roles/service';
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL must be set to run the seed');
+  }
+  process.env.FF_PERSISTENCE = process.env.FF_PERSISTENCE ?? 'true';
+
+  const roles = loadRolesFromRepo();
+  const features = loadFeaturesFromRepo();
+  if (!roles.length) {
+    throw new Error(`roles.json not found in ${path.resolve(process.cwd(), 'roles/roles.json')}`);
+  }
+
+  const summary = await importRolesAndFeatures(roles, features);
+  console.log(JSON.stringify({ ok: true, imported: summary }));
+}
+
+main().catch(err => {
+  console.error('[seed-roles-from-json] failed:', err);
+  process.exit(1);
+});

--- a/src/core/capabilityRunnerRole.ts
+++ b/src/core/capabilityRunnerRole.ts
@@ -34,6 +34,7 @@ export async function runCapabilityWithRole<T>(
       basis: proactivity.basis,
     },
     mode: modeToKey(mode),
+    effectiveMode: proactivity.effectiveKey,
   };
 
   let outcome: T | undefined;

--- a/src/core/proactivity/state.ts
+++ b/src/core/proactivity/state.ts
@@ -63,7 +63,7 @@ export function resolveEffectiveMode(input: ResolveEffectiveModeInput): Proactiv
 
   if (input.killSwitch) {
     effective = ProactivityMode.Usynlig;
-    basis.add('cap:killswitch');
+    basis.add('kill');
   }
 
   for (const cap of caps) {

--- a/src/roles/db/FeatureRepo.ts
+++ b/src/roles/db/FeatureRepo.ts
@@ -1,0 +1,72 @@
+import type { Feature as FeatureRow, Prisma } from '@prisma/client';
+import { prisma } from '../../core/db/prisma';
+import type { FeatureDef } from '../types';
+
+function toJson(value: unknown): Prisma.InputJsonValue | undefined {
+  if (value === undefined) return undefined;
+  return value as Prisma.InputJsonValue;
+}
+
+function mapRowToFeature(row: FeatureRow): FeatureDef {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description ?? undefined,
+    defaultAutonomyCap: (row.defaultAutonomyCap as FeatureDef['defaultAutonomyCap']) ?? undefined,
+    capabilities: row.capabilities,
+  };
+}
+
+export class FeatureRepo {
+  async list(): Promise<FeatureDef[]> {
+    const rows = await prisma.feature.findMany({ orderBy: { id: 'asc' } });
+    return rows.map(mapRowToFeature);
+  }
+
+  async upsert(feature: FeatureDef): Promise<FeatureDef> {
+    const row = await prisma.feature.upsert({
+      where: { id: feature.id },
+      create: {
+        id: feature.id,
+        title: feature.title,
+        description: feature.description,
+        defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
+        capabilities: feature.capabilities,
+        metadata: toJson({ ...feature }),
+      },
+      update: {
+        title: feature.title,
+        description: feature.description,
+        defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
+        capabilities: feature.capabilities,
+        metadata: toJson({ ...feature }),
+      },
+    });
+    return mapRowToFeature(row);
+  }
+
+  async upsertMany(features: FeatureDef[]): Promise<number> {
+    if (!features.length) return 0;
+    await prisma.$transaction(features.map(feature =>
+      prisma.feature.upsert({
+        where: { id: feature.id },
+        create: {
+          id: feature.id,
+          title: feature.title,
+          description: feature.description,
+          defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
+          capabilities: feature.capabilities,
+          metadata: toJson({ ...feature }),
+        },
+        update: {
+          title: feature.title,
+          description: feature.description,
+          defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
+          capabilities: feature.capabilities,
+          metadata: toJson({ ...feature }),
+        },
+      })
+    ));
+    return features.length;
+  }
+}

--- a/src/roles/db/OverrideRepo.ts
+++ b/src/roles/db/OverrideRepo.ts
@@ -1,0 +1,51 @@
+import type { OrgRoleOverride as OverrideRow, Prisma } from '@prisma/client';
+import { prisma } from '../../core/db/prisma';
+import type { OrgRoleOverride } from '../types';
+
+function toJson(value: unknown): Prisma.InputJsonValue | undefined {
+  if (value === undefined) return undefined;
+  return value as Prisma.InputJsonValue;
+}
+
+function mapRow(row: OverrideRow): OrgRoleOverride {
+  return {
+    tenantId: row.tenant_id,
+    role_id: row.role_id as OrgRoleOverride['role_id'],
+    featureCaps: row.featureCaps as OrgRoleOverride['featureCaps'],
+    disabledFeatures: row.disabledFeatures ?? [],
+  };
+}
+
+export class OverrideRepo {
+  async list(): Promise<OrgRoleOverride[]> {
+    const rows = await prisma.orgRoleOverride.findMany();
+    return rows.map(mapRow);
+  }
+
+  async listForTenant(tenantId: string): Promise<OrgRoleOverride[]> {
+    const rows = await prisma.orgRoleOverride.findMany({ where: { tenant_id: tenantId } });
+    return rows.map(mapRow);
+  }
+
+  async get(tenantId: string, roleId: string): Promise<OrgRoleOverride | null> {
+    const row = await prisma.orgRoleOverride.findUnique({ where: { tenant_id_role_id: { tenant_id: tenantId, role_id: roleId } } });
+    return row ? mapRow(row) : null;
+  }
+
+  async set(tenantId: string, roleId: string, override: Partial<OrgRoleOverride>): Promise<OrgRoleOverride> {
+    const row = await prisma.orgRoleOverride.upsert({
+      where: { tenant_id_role_id: { tenant_id: tenantId, role_id: roleId } },
+      create: {
+        tenant_id: tenantId,
+        role_id: roleId,
+        featureCaps: toJson(override.featureCaps),
+        disabledFeatures: override.disabledFeatures ?? [],
+      },
+      update: {
+        featureCaps: toJson(override.featureCaps),
+        disabledFeatures: override.disabledFeatures ?? [],
+      },
+    });
+    return mapRow(row);
+  }
+}

--- a/src/roles/db/RoleRepo.ts
+++ b/src/roles/db/RoleRepo.ts
@@ -1,0 +1,82 @@
+import type { Prisma, Role as RoleRow } from '@prisma/client';
+import { prisma } from '../../core/db/prisma';
+import type { RoleProfile } from '../types';
+
+function toJson(value: unknown): Prisma.InputJsonValue | undefined {
+  if (value === undefined) return undefined;
+  return value as Prisma.InputJsonValue;
+}
+
+function mapRowToProfile(row: RoleRow): RoleProfile {
+  const profile = (row.profile as RoleProfile | null) ?? {} as RoleProfile;
+  const featureCaps = (row.featureCaps as Record<string, number> | null) ?? profile.featureCaps;
+  const scopeHints = (row.scopeHints as Record<string, any> | null) ?? profile.scopeHints;
+  return {
+    ...profile,
+    role_id: row.role_id,
+    canonical_title: profile.canonical_title ?? row.title,
+    inherits: profile.inherits ?? row.inherits ?? [],
+    featureCaps: featureCaps as RoleProfile['featureCaps'],
+    scopeHints: scopeHints as RoleProfile['scopeHints'],
+  };
+}
+
+export class RoleRepo {
+  async list(): Promise<RoleProfile[]> {
+    const rows = await prisma.role.findMany({ orderBy: { role_id: 'asc' } });
+    return rows.map(mapRowToProfile);
+  }
+
+  async get(roleId: string): Promise<RoleProfile | null> {
+    const row = await prisma.role.findUnique({ where: { role_id: roleId } });
+    return row ? mapRowToProfile(row) : null;
+  }
+
+  async upsert(role: RoleProfile): Promise<RoleProfile> {
+    const data: Prisma.RoleUpsertArgs['create'] = {
+      role_id: role.role_id,
+      title: role.canonical_title ?? role.role_id,
+      inherits: role.inherits ?? [],
+      featureCaps: toJson(role.featureCaps),
+      scopeHints: toJson(role.scopeHints),
+      profile: toJson(role),
+    };
+    const updated = await prisma.role.upsert({
+      where: { role_id: role.role_id },
+      create: data,
+      update: {
+        title: role.canonical_title ?? role.role_id,
+        inherits: role.inherits ?? [],
+        featureCaps: toJson(role.featureCaps),
+        scopeHints: toJson(role.scopeHints),
+        profile: toJson(role),
+      },
+    });
+    return mapRowToProfile(updated);
+  }
+
+  async upsertMany(roles: RoleProfile[]): Promise<number> {
+    if (!roles.length) return 0;
+    await prisma.$transaction(roles.map(role =>
+      prisma.role.upsert({
+        where: { role_id: role.role_id },
+        create: {
+          role_id: role.role_id,
+          title: role.canonical_title ?? role.role_id,
+          inherits: role.inherits ?? [],
+          featureCaps: toJson(role.featureCaps),
+          scopeHints: toJson(role.scopeHints),
+          profile: toJson(role),
+        },
+        update: {
+          title: role.canonical_title ?? role.role_id,
+          inherits: role.inherits ?? [],
+          featureCaps: toJson(role.featureCaps),
+          scopeHints: toJson(role.scopeHints),
+          profile: toJson(role),
+        },
+      })
+    ));
+    return roles.length;
+  }
+}

--- a/src/roles/db/UserRoleRepo.ts
+++ b/src/roles/db/UserRoleRepo.ts
@@ -1,0 +1,43 @@
+import type { UserRole as UserRoleRow } from '@prisma/client';
+import { prisma } from '../../core/db/prisma';
+import type { UserRoleBinding } from '../types';
+
+function mapRow(row: UserRoleRow): UserRoleBinding {
+  return {
+    userId: row.user_id,
+    primaryRole: row.primaryRole as UserRoleBinding['primaryRole'],
+    secondaryRoles: row.secondaryRoles ?? [],
+  };
+}
+
+export class UserRoleRepo {
+  async get(userId: string, tenantId: string): Promise<UserRoleBinding | null> {
+    const row = await prisma.userRole.findUnique({ where: { user_id: userId } });
+    if (!row) return null;
+    if (row.tenant_id !== tenantId) return null;
+    return mapRow(row);
+  }
+
+  async listForTenant(tenantId: string): Promise<UserRoleBinding[]> {
+    const rows = await prisma.userRole.findMany({ where: { tenant_id: tenantId } });
+    return rows.map(mapRow);
+  }
+
+  async set(tenantId: string, binding: UserRoleBinding): Promise<UserRoleBinding> {
+    const row = await prisma.userRole.upsert({
+      where: { user_id: binding.userId },
+      create: {
+        user_id: binding.userId,
+        tenant_id: tenantId,
+        primaryRole: binding.primaryRole,
+        secondaryRoles: binding.secondaryRoles ?? [],
+      },
+      update: {
+        tenant_id: tenantId,
+        primaryRole: binding.primaryRole,
+        secondaryRoles: binding.secondaryRoles ?? [],
+      },
+    });
+    return mapRow(row);
+  }
+}

--- a/src/roles/registry.ts
+++ b/src/roles/registry.ts
@@ -7,6 +7,10 @@ export class RoleRegistry {
     private overrides: OrgRoleOverride[] = []
   ) {}
 
+  withOverrides(overrides: OrgRoleOverride[]): RoleRegistry {
+    return new RoleRegistry(this.roles, this.features, overrides);
+  }
+
   getUserContext(tenantId: string, binding: UserRoleBinding) {
     const resolved = this.resolveRoles(binding);
     const effCaps = this.composeFeatureCaps(tenantId, resolved);
@@ -14,6 +18,11 @@ export class RoleRegistry {
       .filter(f => effCaps[f.id] !== 0)
       .map(f => ({ ...f, autonomyCap: effCaps[f.id] ?? f.defaultAutonomyCap ?? 3 }));
     return { roles: resolved, features: activeFeatures, featureCaps: effCaps, scope: this.composeScope(resolved) };
+  }
+
+  getFeatureCap(tenantId: string, binding: UserRoleBinding, featureId: string): number {
+    const caps = this.composeFeatureCaps(tenantId, this.resolveRoles(binding));
+    return caps[featureId] ?? this.features.find(f => f.id === featureId)?.defaultAutonomyCap ?? 0;
   }
 
   private resolveRoles(binding: UserRoleBinding) {
@@ -31,12 +40,17 @@ export class RoleRegistry {
 
   private composeFeatureCaps(tenantId: string, rs: RoleProfile[]) {
     const caps: Record<string, number> = {};
+    const clamp = (value: unknown) => {
+      const num = Number(value ?? 0);
+      if (Number.isNaN(num)) return 0;
+      return Math.max(0, Math.min(6, num));
+    };
     rs.forEach(r => Object.entries(r.featureCaps||{}).forEach(([fid, cap]) => {
-      caps[fid] = Math.max(caps[fid]||0, Number(cap));
+      caps[fid] = Math.max(caps[fid] ?? 0, clamp(cap));
     }));
     const orgs = this.overrides.filter(o => o.tenantId===tenantId && rs.some(r=>r.role_id===o.role_id));
     for (const org of orgs) {
-      Object.entries(org.featureCaps||{}).forEach(([fid, cap]) => { caps[fid] = Number(cap); });
+      Object.entries(org.featureCaps||{}).forEach(([fid, cap]) => { caps[fid] = clamp(cap); });
       (org.disabledFeatures||[]).forEach(fid => { caps[fid] = 0; });
     }
     return caps;

--- a/src/roles/service.ts
+++ b/src/roles/service.ts
@@ -1,0 +1,96 @@
+import { envBool } from '../core/env';
+import { loadFeaturesFromRepo, loadRolesFromRepo } from './loader';
+import { RoleRegistry } from './registry';
+import type { FeatureDef, OrgRoleOverride, RoleProfile, UserRoleBinding } from './types';
+import { RoleRepo } from './db/RoleRepo';
+import { FeatureRepo } from './db/FeatureRepo';
+import { OverrideRepo } from './db/OverrideRepo';
+import { UserRoleRepo } from './db/UserRoleRepo';
+
+const roleRepo = new RoleRepo();
+const featureRepo = new FeatureRepo();
+const overrideRepo = new OverrideRepo();
+const userRoleRepo = new UserRoleRepo();
+
+const CACHE_TTL_MS = 15_000;
+let cached: { registry: RoleRegistry; loadedAt: number } | null = null;
+
+function usePersistence(): boolean {
+  return envBool('FF_PERSISTENCE', false);
+}
+
+async function loadFromDb(): Promise<{ roles: RoleProfile[]; features: FeatureDef[]; overrides: OrgRoleOverride[] }> {
+  const [roles, features, overrides] = await Promise.all([
+    roleRepo.list(),
+    featureRepo.list(),
+    overrideRepo.list(),
+  ]);
+  const hydratedFeatures = features.length ? features : loadFeaturesFromRepo();
+  return { roles, features: hydratedFeatures, overrides };
+}
+
+async function loadStatic(): Promise<{ roles: RoleProfile[]; features: FeatureDef[]; overrides: OrgRoleOverride[] }> {
+  return {
+    roles: loadRolesFromRepo(),
+    features: loadFeaturesFromRepo(),
+    overrides: [],
+  };
+}
+
+async function buildRegistry(): Promise<RoleRegistry> {
+  const source = usePersistence() ? await loadFromDb() : await loadStatic();
+  return new RoleRegistry(source.roles, source.features, source.overrides);
+}
+
+export async function getRoleRegistry(opts: { refresh?: boolean } = {}): Promise<RoleRegistry> {
+  if (!cached || opts.refresh || Date.now() - cached.loadedAt > CACHE_TTL_MS) {
+    const registry = await buildRegistry();
+    cached = { registry, loadedAt: Date.now() };
+  }
+  return cached.registry;
+}
+
+export async function refreshRoleRegistry(): Promise<RoleRegistry> {
+  cached = null;
+  return getRoleRegistry({ refresh: true });
+}
+
+export async function resolveUserBinding(tenantId: string, userId: string, fallback: UserRoleBinding | undefined): Promise<UserRoleBinding | undefined> {
+  if (!usePersistence()) return fallback;
+  if (!userId) return fallback;
+  const binding = await userRoleRepo.get(userId, tenantId);
+  return binding ?? fallback;
+}
+
+export async function listRoles(): Promise<RoleProfile[]> {
+  if (usePersistence()) return roleRepo.list();
+  return loadRolesFromRepo();
+}
+
+export async function listFeatures(): Promise<FeatureDef[]> {
+  if (usePersistence()) return featureRepo.list();
+  return loadFeaturesFromRepo();
+}
+
+export async function listOverridesForTenant(tenantId: string): Promise<OrgRoleOverride[]> {
+  if (!usePersistence()) return [];
+  return overrideRepo.listForTenant(tenantId);
+}
+
+export async function setOverride(tenantId: string, roleId: string, override: Partial<OrgRoleOverride>): Promise<OrgRoleOverride> {
+  const row = await overrideRepo.set(tenantId, roleId, override);
+  await refreshRoleRegistry();
+  return row;
+}
+
+export async function upsertRoleBinding(tenantId: string, binding: UserRoleBinding): Promise<UserRoleBinding> {
+  const saved = await userRoleRepo.set(tenantId, binding);
+  return saved;
+}
+
+export async function importRolesAndFeatures(roles: RoleProfile[], features: FeatureDef[]): Promise<{ roles: number; features: number }> {
+  const roleCount = await roleRepo.upsertMany(roles);
+  const featureCount = await featureRepo.upsertMany(features);
+  await refreshRoleRegistry();
+  return { roles: roleCount, features: featureCount };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,8 +57,11 @@ safeMount('/api/insights', './src/routes/insights', 'insightsRouter');
 safeMount('/api/finance', './src/routes/finance.reminder', 'financeReminderRouter');
 safeMount('/api', './src/routes/manual.complete', 'manualCompleteRouter');
 safeMount('/', './src/routes/genesis.autonomy', 'metaGenesisRouter');
+safeMount('/api', '../backend/routes/usage');
+safeMount('/api', '../backend/routes/features');
 safeMount('/api', '../backend/routes/proactivity');
 safeMount('/api', '../backend/routes/admin.subscription');
+safeMount('/api', '../backend/routes/admin.roles');
 safeMount('/api', '../backend/routes/explainability');
 
 app.use('/api', knowledgeRouter);

--- a/src/telemetry/usageSignals.db.ts
+++ b/src/telemetry/usageSignals.db.ts
@@ -1,0 +1,41 @@
+import { FeatureUsageAction } from '@prisma/client';
+import { prisma } from '../core/db/prisma';
+
+export interface FeatureUsageEvent {
+  userId: string;
+  tenantId: string;
+  featureId: string;
+  action: FeatureUsageAction | 'open' | 'complete' | 'dismiss';
+  ts?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordFeatureUsage(evt: FeatureUsageEvent): Promise<void> {
+  await prisma.featureUsage.create({
+    data: {
+      userId: evt.userId,
+      tenantId: evt.tenantId,
+      featureId: evt.featureId,
+      action: evt.action as FeatureUsageAction,
+      ts: evt.ts ?? new Date(),
+      metadata: evt.metadata,
+    },
+  });
+}
+
+export async function aggregateFeatureUseCount(userId: string, tenantId?: string): Promise<Record<string, number>> {
+  const rows = await prisma.featureUsage.groupBy({
+    by: ['featureId'],
+    where: {
+      userId,
+      ...(tenantId ? { tenantId } : {}),
+    },
+    _count: {
+      _all: true,
+    },
+  });
+  return rows.reduce<Record<string, number>>((acc, row) => {
+    acc[row.featureId] = row._count._all;
+    return acc;
+  }, {});
+}

--- a/src/telemetry/usageSignals.ts
+++ b/src/telemetry/usageSignals.ts
@@ -1,7 +1,8 @@
-export interface FeatureUsage { userId: string; featureId: string; ts: string; action: 'open'|'complete'|'dismiss'; }
+export interface FeatureUsage { userId: string; tenantId?: string; featureId: string; ts: string; action: 'open'|'complete'|'dismiss'; }
 const store: FeatureUsage[] = [];
 export function recordFeatureUsage(evt: FeatureUsage) { store.push(evt); }
-export function aggregateFeatureUseCount(userId: string) {
-  return store.filter(e=>e.userId===userId)
+export function aggregateFeatureUseCount(userId: string, tenantId?: string) {
+  return store
+    .filter(e => e.userId === userId && (!tenantId || e.tenantId === tenantId))
     .reduce((acc,e)=>{ acc[e.featureId]=(acc[e.featureId]||0)+1; return acc; }, {} as Record<string,number>);
 }

--- a/tests/admin/roles.api.test.ts
+++ b/tests/admin/roles.api.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import type { Application } from 'express';
+import { prisma } from '../../src/core/db/prisma';
+
+const describeIfPersistence = process.env.FF_PERSISTENCE === 'true' ? describe : describe.skip;
+
+const tenantId = 'TENANT_ADMIN_API';
+const roleId = 'sales-manager-account-executive';
+
+let app: Application;
+
+describeIfPersistence('Admin roles API', () => {
+  beforeAll(async () => {
+    process.env.FF_PERSISTENCE = 'true';
+    await prisma.$connect();
+    await prisma.featureUsage.deleteMany();
+    await prisma.orgRoleOverride.deleteMany();
+    await prisma.userRole.deleteMany();
+    await prisma.role.deleteMany();
+    await prisma.feature.deleteMany();
+    app = (await import('../../src/server')).default;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test('imports roles and manages overrides', async () => {
+    const importRes = await request(app)
+      .post('/api/admin/roles/import')
+      .set('x-role-id', 'admin')
+      .send();
+    expect(importRes.status).toBe(200);
+    expect(importRes.body.imported.roles).toBeGreaterThan(0);
+
+    const initialInspect = await request(app)
+      .get(`/api/admin/roles/${roleId}`)
+      .set('x-role-id', 'admin')
+      .set('x-tenant', tenantId);
+    expect(initialInspect.status).toBe(200);
+    expect(initialInspect.body.effective.featureCaps).toBeDefined();
+
+    const overrideRes = await request(app)
+      .put(`/api/admin/roles/${roleId}/overrides`)
+      .set('x-role-id', 'admin')
+      .set('x-tenant', tenantId)
+      .send({ featureCaps: { cashflow_forecast: 4 }, disabledFeatures: ['contract_compliance'] });
+    expect(overrideRes.status).toBe(200);
+    expect(overrideRes.body.override.featureCaps.cashflow_forecast).toBe(4);
+
+    const finalInspect = await request(app)
+      .get(`/api/admin/roles/${roleId}`)
+      .set('x-role-id', 'admin')
+      .set('x-tenant', tenantId);
+    expect(finalInspect.status).toBe(200);
+    expect(finalInspect.body.override?.featureCaps.cashflow_forecast).toBe(4);
+    expect(finalInspect.body.effective.featureCaps.cashflow_forecast).toBe(4);
+  });
+});

--- a/tests/features/active.api.test.ts
+++ b/tests/features/active.api.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import type { Application } from 'express';
+import { prisma } from '../../src/core/db/prisma';
+import { importRolesAndFeatures, setOverride } from '../../src/roles/service';
+import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
+import { recordFeatureUsage } from '../../src/telemetry/usageSignals.db';
+
+const describeIfPersistence = process.env.FF_PERSISTENCE === 'true' ? describe : describe.skip;
+
+const tenantId = 'TENANT_ACTIVE_FEATURES';
+const roleId = 'sales-manager-account-executive';
+const userId = 'user-active';
+
+let app: Application;
+
+describeIfPersistence('GET /api/features/active', () => {
+  beforeAll(async () => {
+    process.env.FF_PERSISTENCE = 'true';
+    await prisma.$connect();
+    await prisma.featureUsage.deleteMany();
+    await prisma.orgRoleOverride.deleteMany();
+    await prisma.userRole.deleteMany();
+    await prisma.role.deleteMany();
+    await prisma.feature.deleteMany();
+    await importRolesAndFeatures(loadRolesFromRepo(), loadFeaturesFromRepo());
+    await setOverride(tenantId, roleId, { featureCaps: { cashflow_forecast: 5, lead_qualification: 3 } });
+    await recordFeatureUsage({ userId, tenantId, featureId: 'lead_qualification', action: 'open' });
+    await recordFeatureUsage({ userId, tenantId, featureId: 'lead_qualification', action: 'open' });
+    await recordFeatureUsage({ userId, tenantId, featureId: 'cashflow_forecast', action: 'complete' });
+    app = (await import('../../src/server')).default;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test('ranks features using autonomy caps, usage and org context', async () => {
+    const res = await request(app)
+      .get('/api/features/active')
+      .set('x-tenant', tenantId)
+      .set('x-user', userId)
+      .set('x-role', roleId)
+      .set('x-industry', 'finance');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0].id).toBe('cashflow_forecast');
+    const lead = res.body.find((f: any) => f.id === 'lead_qualification');
+    expect(lead).toBeDefined();
+    expect(res.body[0].score).toBeGreaterThan(lead.score);
+    expect(lead.rankBasis.usage).toBe(2);
+  });
+});

--- a/tests/proactivity/context.integration.test.ts
+++ b/tests/proactivity/context.integration.test.ts
@@ -1,0 +1,54 @@
+import { prisma } from '../../src/core/db/prisma';
+import { importRolesAndFeatures, setOverride, getRoleRegistry } from '../../src/roles/service';
+import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
+import { buildProactivityContext } from '../../src/core/proactivity/context';
+import { ProactivityMode } from '../../src/core/proactivity/modes';
+import { setSubscriptionForTenant, resetSubscriptionState } from '../../src/core/subscription/state';
+
+const describeIfPersistence = process.env.FF_PERSISTENCE === 'true' ? describe : describe.skip;
+
+const tenantId = 'TENANT_PROACTIVITY';
+const roleId = 'sales-manager-account-executive';
+
+describeIfPersistence('Proactivity context integration', () => {
+  beforeAll(async () => {
+    process.env.FF_PERSISTENCE = 'true';
+    await prisma.$connect();
+    await prisma.featureUsage.deleteMany();
+    await prisma.orgRoleOverride.deleteMany();
+    await prisma.userRole.deleteMany();
+    await prisma.role.deleteMany();
+    await prisma.feature.deleteMany();
+    await importRolesAndFeatures(loadRolesFromRepo(), loadFeaturesFromRepo());
+    await setOverride(tenantId, roleId, { featureCaps: { cashflow_forecast: 5 } });
+  });
+
+  afterAll(async () => {
+    resetSubscriptionState();
+    await prisma.$disconnect();
+  });
+
+  test('effective mode respects role, subscription and policy caps', async () => {
+    setSubscriptionForTenant(tenantId, { plan: 'secure', secureTenant: true, killSwitch: false });
+    const registry = await getRoleRegistry({ refresh: true });
+    const binding = { userId: 'proactivity-user', primaryRole: roleId };
+    const state = buildProactivityContext({
+      tenantId,
+      roleRegistry: registry,
+      roleBinding: binding,
+      featureId: 'cashflow_forecast',
+      requestedMode: ProactivityMode.Tsunami,
+      policyCap: ProactivityMode.Rolig,
+    });
+
+    expect(state.effective).toBe(ProactivityMode.Rolig);
+    expect(state.basis).toEqual(expect.arrayContaining([
+      'tenantPlan:secure',
+      'tenant<=3',
+      'roleCap:cashflow_forecast=5',
+      'degraded:rolig',
+      'cap:policy:rolig',
+    ]));
+    expect(state.basis).not.toContain('kill');
+  });
+});

--- a/tests/roles/db.registry.test.ts
+++ b/tests/roles/db.registry.test.ts
@@ -1,0 +1,38 @@
+import { prisma } from '../../src/core/db/prisma';
+import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
+import { getRoleRegistry, importRolesAndFeatures, setOverride } from '../../src/roles/service';
+
+const describeIfPersistence = process.env.FF_PERSISTENCE === 'true' ? describe : describe.skip;
+
+const tenantId = 'TENANT_REGISTRY_TEST';
+const roleId = 'sales-manager-account-executive';
+
+async function resetDb() {
+  await prisma.featureUsage.deleteMany();
+  await prisma.orgRoleOverride.deleteMany();
+  await prisma.userRole.deleteMany();
+  await prisma.role.deleteMany();
+  await prisma.feature.deleteMany();
+}
+
+describeIfPersistence('RoleRegistry with Postgres persistence', () => {
+  beforeAll(async () => {
+    await prisma.$connect();
+    await resetDb();
+    await importRolesAndFeatures(loadRolesFromRepo(), loadFeaturesFromRepo());
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test('override updates effective feature caps', async () => {
+    await setOverride(tenantId, roleId, { featureCaps: { lead_qualification: 2 } });
+    const registry = await getRoleRegistry({ refresh: true });
+    const binding = { userId: 'user-1', primaryRole: roleId };
+    const ctx = registry.getUserContext(tenantId, binding);
+    expect(ctx.roles.some(r => r.role_id === roleId)).toBe(true);
+    expect(ctx.featureCaps.lead_qualification).toBe(2);
+    expect(registry.getFeatureCap(tenantId, binding, 'lead_qualification')).toBe(2);
+  });
+});

--- a/tests/usage/db.usage.test.ts
+++ b/tests/usage/db.usage.test.ts
@@ -1,0 +1,28 @@
+import { prisma } from '../../src/core/db/prisma';
+import { recordFeatureUsage, aggregateFeatureUseCount } from '../../src/telemetry/usageSignals.db';
+
+const describeIfPersistence = process.env.FF_PERSISTENCE === 'true' ? describe : describe.skip;
+
+describeIfPersistence('Feature usage persistence', () => {
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  beforeEach(async () => {
+    await prisma.featureUsage.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  test('records and aggregates per tenant/user', async () => {
+    await recordFeatureUsage({ userId: 'u1', tenantId: 'T1', featureId: 'cashflow_forecast', action: 'open' });
+    await recordFeatureUsage({ userId: 'u1', tenantId: 'T1', featureId: 'cashflow_forecast', action: 'complete' });
+    await recordFeatureUsage({ userId: 'u1', tenantId: 'T2', featureId: 'cashflow_forecast', action: 'dismiss' });
+    const tenantCounts = await aggregateFeatureUseCount('u1', 'T1');
+    expect(tenantCounts.cashflow_forecast).toBe(2);
+    const allCounts = await aggregateFeatureUseCount('u1');
+    expect(allCounts.cashflow_forecast).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Mount the DB-backed usage and feature activation routers on the main Express app and scope admin RBAC to `/api/admin/*` endpoints only so the rest of the API keeps working without an admin header.
- Gate every Prisma-backed Jest suite behind `FF_PERSISTENCE===true` and switch Prisma JSON writes to `InputJsonValue` so `tsc --noEmit` passes when the generated client is available.

## Testing
- ✅ `npm run build`
- ✅ `FF_PERSISTENCE=false npm test`
- ❌ `FF_PERSISTENCE=true npm test` *(fails: PrismaClientInitializationError — Postgres not running in this environment)*
- ❌ `npx prisma migrate dev --name init` *(fails: P1001 — cannot reach Postgres at localhost:5432)*

### Already present (kept)
- Prisma schema/migration for roles, features, overrides, user bindings, and feature usage; DB repositories and role registry wiring.
- DB-backed usage telemetry & feature activation, proactivity caps resolution, admin APIs, OpenAPI + docs, CI workflow with Postgres matrix.

### Added / Updated in this pass
- Scoped RBAC in `backend/routes/admin.roles.ts` and `backend/routes/admin.subscription.ts`; mounted usage/features routers in `src/server.ts`.
- Updated Prisma JSON helpers in `src/roles/db/{RoleRepo,FeatureRepo,OverrideRepo}.ts` and guarded DB integration tests under `tests/**`.
- Added `ts-node` to `package.json` to support the seed script in environments without global installs.

### TODO / Follow-ups
- Bring up a Postgres instance (locally or via CI service) and rerun `npx prisma migrate dev` plus `FF_PERSISTENCE=true npm test` to exercise the DB-backed flow end-to-end.


------
https://chatgpt.com/codex/tasks/task_e_68ceb8899b94832a9295865f63a359a1