### PR TITLE
Update backend route paths for API mounts

### DIFF
--- a/backend/routes/features.ts
+++ b/backend/routes/features.ts
@@ -7,7 +7,7 @@ import { aggregateFeatureUseCount } from '../../src/telemetry/usageSignals';
 const r = Router();
 const rr = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
 
-r.get('/api/features/active', (req, res) => {
+r.get('/features/active', (req, res) => {
   const tenantId = String(req.header('x-tenant') ?? 'DEV');
   const userId = String(req.header('x-user') ?? 'dev-user');
   const role = String(req.header('x-role') ?? 'sales_rep');

--- a/backend/routes/usage.ts
+++ b/backend/routes/usage.ts
@@ -2,14 +2,14 @@ import { Router } from 'express';
 import { recordFeatureUsage, aggregateFeatureUseCount } from '../../src/telemetry/usageSignals';
 const r = Router();
 
-r.post('/api/usage/feature', (req,res)=>{
+r.post('/usage/feature', (req,res)=>{
   const { userId, featureId, action } = req.body||{};
   if (!userId || !featureId || !action) return res.status(400).json({ error: 'Missing userId/featureId/action' });
   recordFeatureUsage({ userId, featureId, action, ts: new Date().toISOString() });
   res.json({ ok: true });
 });
 
-r.get('/api/usage/aggregate/:userId', (req,res)=>{
+r.get('/usage/aggregate/:userId', (req,res)=>{
   res.json(aggregateFeatureUseCount(String(req.params.userId)));
 });
 


### PR DESCRIPTION
## Summary
- register the features router at /features/active so that the global /api mount prefixes it
- adjust usage feature and aggregate handlers to mount under /usage paths without duplicate prefixes

## Testing
- FF_PERSISTENCE=true npm test -- --runTestsByPath tests/features/active.api.test.ts tests/usage/db.usage.test.ts *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ced69837f8832a9f0f50fadf0d5761