### PR TITLE
Mount backend feature and usage routers with /api prefix

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,8 @@ safeMount('/', './src/routes/genesis.autonomy', 'metaGenesisRouter');
 safeMount('/api', '../backend/routes/proactivity');
 safeMount('/api', '../backend/routes/admin.subscription');
 safeMount('/api', '../backend/routes/explainability');
+safeMount('/api', '../backend/routes/features');
+safeMount('/api', '../backend/routes/usage');
 
 app.use('/api', knowledgeRouter);
 app.use('/api/audit', auditRouter());


### PR DESCRIPTION
## Summary
- mount the backend features and usage routers using safeMount so they inherit the global /api prefix

## Testing
- FF_PERSISTENCE=true npx jest --config jest.config.cjs --runTestsByPath ../tests/features/active.api.test.ts ../tests/usage/usage.api.test.ts --runInBand --verbose

------
https://chatgpt.com/codex/tasks/task_e_68ceddb7ad94832a9869e3bc5a213118