### PR TITLE
Proposals & approval, connector idempotency/retry/DLQ, full 1–6 guards, and UI signals

### DIFF
--- a/backend/routes/connectors.health.ts
+++ b/backend/routes/connectors.health.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { getConnectorCircuitState, listConnectorCircuits } from '../../src/connectors/internal/circuitRegistry';
+
+const router = Router();
+
+router.get('/connectors/:name/health', (req, res) => {
+  const name = String(req.params.name || '');
+  const state = getConnectorCircuitState(name);
+  if (!state) {
+    return res.status(404).json({ connector: name, state: 'unknown' });
+  }
+  res.json({ connector: name, state });
+});
+
+router.get('/connectors/health', (_req, res) => {
+  const connectors = listConnectorCircuits();
+  res.json({ connectors });
+});
+
+export default router;

--- a/backend/routes/dev.runner.ts
+++ b/backend/routes/dev.runner.ts
@@ -24,6 +24,8 @@ router.post('/dev/run', async (req: any, res: any) => {
   const userId = String(req.header('x-user') ?? 'dev-user');
   const role = String(req.header('x-role') ?? 'sales_rep');
   const requestedHeader = req.header('x-proactivity');
+  const compatHeader = req.header('x-proactivity-compat');
+  const idempotencyHeader = req.header('idempotency-key') || req.header('Idempotency-Key');
 
   const result = await runCapabilityWithRole(
     rr,
@@ -34,6 +36,8 @@ router.post('/dev/run', async (req: any, res: any) => {
       tenantId,
       roleBinding: { userId, primaryRole: role },
       requestedMode: parseProactivityMode(requestedHeader ?? req.body?.mode),
+      compatMode: compatHeader,
+      idempotencyKey: typeof idempotencyHeader === 'string' ? idempotencyHeader : undefined,
     },
     impl,
     policyAllowAlways,

--- a/backend/routes/proactivity.ts
+++ b/backend/routes/proactivity.ts
@@ -1,38 +1,13 @@
 import { Router } from 'express';
 import { RoleRegistry } from '../../src/roles/registry';
 import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
-import { buildProactivityContext } from '../../src/core/proactivity/context';
-import { parseProactivityMode } from '../../src/core/proactivity/modes';
-import { logModusskift } from '../../src/core/proactivity/telemetry';
+import type { ProactivityState } from '../../src/core/proactivity/context';
+import { resolveProactivityForRequest } from './utils/proactivityContext';
 
 const router: any = Router();
 const roleRegistry = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
 
-function resolveHeaders(req: any) {
-  const tenantId = String(req.header('x-tenant') || req.header('x-tenant-id') || 'demo');
-  const userId = String(req.header('x-user') || req.header('x-user-id') || 'demo-user');
-  const role = String(req.header('x-role') || req.header('x-user-role') || 'sales_rep');
-  const requestedHeader = req.header('x-proactivity');
-  return { tenantId, userId, role, requestedHeader };
-}
-
-function computeState(req: any, overrideMode?: any) {
-  const { tenantId, userId, role, requestedHeader } = resolveHeaders(req);
-  const requested = overrideMode ?? req.body?.requested ?? req.body?.mode ?? requestedHeader;
-  const featureId = req.body?.featureId || req.query?.featureId || undefined;
-  const state = buildProactivityContext({
-    tenantId,
-    roleRegistry,
-    roleBinding: { userId, primaryRole: role },
-    requestedMode: parseProactivityMode(requested),
-    featureId,
-  });
-  req.proactivity = state;
-  logModusskift(state, { tenantId, userId, source: 'api/proactivity' });
-  return { tenantId, userId, state };
-}
-
-function toResponse(state: ReturnType<typeof buildProactivityContext>) {
+function toResponse(state: ProactivityState) {
   return {
     tenantId: state.tenantId,
     requested: state.requested,
@@ -43,6 +18,7 @@ function toResponse(state: ReturnType<typeof buildProactivityContext>) {
     caps: state.caps,
     degradeRail: state.degradeRail,
     uiHints: state.uiHints,
+    chip: state.chip,
     subscription: state.subscription,
     featureId: state.featureId,
     timestamp: state.timestamp,
@@ -50,12 +26,13 @@ function toResponse(state: ReturnType<typeof buildProactivityContext>) {
 }
 
 router.get('/proactivity/state', (req: any, res: any) => {
-  const { state } = computeState(req);
+  const { state } = resolveProactivityForRequest(roleRegistry, req);
   res.json(toResponse(state));
 });
 
 router.post('/proactivity/state', (req: any, res: any) => {
-  const { state } = computeState(req, req.body?.requestedMode ?? req.body?.requested ?? req.body?.mode);
+  const override = req.body?.requestedMode ?? req.body?.requested ?? req.body?.mode;
+  const { state } = resolveProactivityForRequest(roleRegistry, req, { requestedOverride: override });
   res.json(toResponse(state));
 });
 

--- a/backend/routes/proposals.ts
+++ b/backend/routes/proposals.ts
@@ -1,0 +1,156 @@
+import { Router } from 'express';
+import { RoleRegistry } from '../../src/roles/registry';
+import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
+import { requiresProMode } from '../../src/core/proactivity/guards';
+import { ProactivityMode } from '../../src/core/proactivity/modes';
+import { resolveProactivityForRequest } from './utils/proactivityContext';
+import {
+  listProposals,
+  createProposal as recordProposal,
+  sanitizeProposal,
+  getProposal,
+  markProposalApproved,
+  markProposalExecuted,
+  markProposalFailed,
+  markProposalRejected,
+  generateProposalIdempotencyKey,
+} from '../../src/core/proposals/service';
+import { getCapabilityImpl } from '../../src/capabilities/registry';
+import { runCapabilityWithRole } from '../../src/core/capabilityRunnerRole';
+import { policyCheck } from '../../src/core/policy';
+import { logIntent } from '../../src/core/intentLog';
+
+const router = Router();
+const roleRegistry = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
+
+function headerIdempotencyKey(req: any): string | undefined {
+  const header = req.header('idempotency-key') || req.header('Idempotency-Key');
+  if (typeof header === 'string') {
+    const trimmed = header.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+router.use((req, _res, next) => {
+  const context = resolveProactivityForRequest(roleRegistry, req as any, { logEvent: false });
+  (req as any).proactivityContext = context;
+  next();
+});
+
+router.get('/proposals', async (req, res) => {
+  const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+  const allowedStatuses = new Set(['proposed', 'approved', 'rejected', 'executed', 'failed']);
+  if (status && !allowedStatuses.has(status)) {
+    return res.status(400).json({ error: 'invalid_status' });
+  }
+  const filter = status ? { status: status as any } : undefined;
+  const proposals = await listProposals(filter);
+  res.json({ proposals: proposals.map(sanitizeProposal) });
+});
+
+router.post('/proposals', requiresProMode(ProactivityMode.Ambisiøs), async (req, res) => {
+  const ctx = (req as any).proactivityContext;
+  const { capabilityId, payload, preview, featureId } = req.body || {};
+  if (!capabilityId) {
+    return res.status(400).json({ error: 'capability_required' });
+  }
+  const headerKey = headerIdempotencyKey(req);
+  const idempotencyKey = headerKey ?? generateProposalIdempotencyKey();
+  const proposal = await recordProposal({
+    tenantId: ctx.tenantId,
+    userId: ctx.userId,
+    featureId: featureId ?? ctx.state.featureId,
+    capabilityId,
+    payload: payload ?? {},
+    preview,
+    idempotencyKey,
+    basis: ctx.state.basis,
+    requestedMode: ctx.state.requested,
+    effectiveMode: ctx.state.effective,
+  });
+  res.status(201).json({ proposal: sanitizeProposal(proposal) });
+});
+
+router.post('/proposals/:id/approve', requiresProMode(ProactivityMode.Kraken), async (req, res) => {
+  const ctx = (req as any).proactivityContext;
+  const proposalId = req.params.id;
+  const proposal = await getProposal(proposalId);
+  if (!proposal) return res.status(404).json({ error: 'proposal_not_found' });
+
+  if (proposal.status === 'rejected') {
+    return res.status(409).json({ error: 'proposal_rejected', proposal: sanitizeProposal(proposal) });
+  }
+  if (proposal.status === 'executed') {
+    return res.json({ proposal: sanitizeProposal(proposal) });
+  }
+
+  const capability = getCapabilityImpl(proposal.capabilityId);
+  if (!capability) {
+    return res.status(404).json({ error: 'capability_not_registered' });
+  }
+
+  const headerKey = headerIdempotencyKey(req);
+  let idempotencyKey = headerKey ?? proposal.idempotencyKey ?? undefined;
+  if (!idempotencyKey) {
+    idempotencyKey = generateProposalIdempotencyKey();
+  }
+  if (proposal.status === 'failed' && !headerKey) {
+    idempotencyKey = generateProposalIdempotencyKey();
+  } else if (headerKey) {
+    idempotencyKey = headerKey;
+  }
+
+  await markProposalApproved(proposalId, ctx.userId, idempotencyKey);
+
+  try {
+    const result = await runCapabilityWithRole(
+      roleRegistry,
+      proposal.capabilityId,
+      proposal.featureId,
+      proposal.payload,
+      {
+        tenantId: ctx.tenantId,
+        roleBinding: { userId: ctx.userId, primaryRole: ctx.role },
+        requestedMode: ctx.state.requested,
+        compatMode: req.header('x-proactivity-compat'),
+        idempotencyKey,
+        connectorName: proposal.capabilityId.split('.')[0],
+      },
+      capability,
+      policyCheck,
+      logIntent,
+    );
+
+    await markProposalExecuted(proposalId, result.outcome);
+    const updated = await getProposal(proposalId);
+    res.json({
+      proposal: updated ? sanitizeProposal(updated) : undefined,
+      outcome: result.outcome,
+      idempotencyKey: result.idempotencyKey ?? idempotencyKey,
+      basis: result.proactivity.basis,
+    });
+  } catch (err: any) {
+    const message = err?.message ?? String(err);
+    await markProposalFailed(proposalId, message);
+    const failed = await getProposal(proposalId);
+    res.status(500).json({ error: 'proposal_execute_failed', message, proposal: failed ? sanitizeProposal(failed) : undefined });
+  }
+});
+
+router.post('/proposals/:id/reject', requiresProMode(ProactivityMode.Ambisiøs), async (req, res) => {
+  const ctx = (req as any).proactivityContext;
+  const proposalId = req.params.id;
+  const proposal = await getProposal(proposalId);
+  if (!proposal) return res.status(404).json({ error: 'proposal_not_found' });
+  if (proposal.status === 'executed') {
+    return res.status(409).json({ error: 'proposal_already_executed', proposal: sanitizeProposal(proposal) });
+  }
+  const reason = typeof req.body?.reason === 'string' ? req.body.reason : undefined;
+  const updated = await markProposalRejected(proposalId, ctx.userId, reason);
+  res.json({ proposal: sanitizeProposal(updated) });
+});
+
+export default router;

--- a/backend/routes/utils/proactivityContext.ts
+++ b/backend/routes/utils/proactivityContext.ts
@@ -1,0 +1,37 @@
+import type { Request } from 'express';
+import { RoleRegistry } from '../../../src/roles/registry';
+import { buildProactivityContext } from '../../../src/core/proactivity/context';
+import { parseProactivityMode } from '../../../src/core/proactivity/modes';
+import { logModusskift } from '../../../src/core/proactivity/telemetry';
+
+interface ProactivityResolutionOptions {
+  requestedOverride?: any;
+  logEvent?: boolean;
+  logSource?: string;
+}
+
+export function resolveProactivityForRequest(rr: RoleRegistry, req: Request, opts: ProactivityResolutionOptions = {}) {
+  const tenantId = String(req.header('x-tenant') || req.header('x-tenant-id') || 'demo');
+  const userId = String(req.header('x-user') || req.header('x-user-id') || 'demo-user');
+  const role = String(req.header('x-role') || req.header('x-user-role') || 'sales_rep');
+  const requestedHeader = req.header('x-proactivity');
+  const compatHeader = req.header('x-proactivity-compat');
+  const bodyRequested = opts.requestedOverride ?? (req.body as any)?.requestedMode ?? (req.body as any)?.requested ?? (req.body as any)?.mode;
+  const featureId = (req.body as any)?.featureId || (req.query as any)?.featureId || undefined;
+
+  const state = buildProactivityContext({
+    tenantId,
+    roleRegistry: rr,
+    roleBinding: { userId, primaryRole: role },
+    featureId,
+    requestedMode: parseProactivityMode(bodyRequested ?? requestedHeader),
+    compatMode: compatHeader,
+  });
+
+  (req as any).proactivity = state;
+  if (opts.logEvent !== false) {
+    logModusskift(state, { tenantId, userId, source: opts.logSource ?? 'api/proactivity' });
+  }
+
+  return { tenantId, userId, role, featureId, state };
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,3 +8,16 @@
 - Proactivity: `openapi/proactivity.yaml`
 
 CI runs Spectral (non-blocking) over all specs.
+
+## Examples
+
+```bash
+# Resolve proactivity state with compat mapping
+curl -H "x-tenant: TENANT" -H "x-user: user" -H "x-role: sales_rep" \
+     -H "x-proactivity-compat: 2" https://api.workbuoy.local/api/proactivity/state
+
+# Approve a proposal (requires Kraken mode)
+curl -X POST -H "x-tenant: TENANT" -H "x-user: approver" -H "x-role: manager" \
+     -H "x-proactivity: kraken" -H "Idempotency-Key: proposal-123" \
+     https://api.workbuoy.local/api/proposals/PROPOSAL_ID/approve
+```

--- a/openapi/proactivity.yaml
+++ b/openapi/proactivity.yaml
@@ -23,6 +23,11 @@ paths:
           schema:
             type: string
             description: Desired mode (numeric 1-6 or keyword)
+        - in: header
+          name: x-proactivity-compat
+          schema:
+            type: string
+            description: Legacy mode (0-3) mapped to 1-6
       responses:
         '200':
           description: Current proactivity posture
@@ -42,6 +47,11 @@ paths:
         - in: header
           name: x-role
           schema: { type: string }
+        - in: header
+          name: x-proactivity-compat
+          schema:
+            type: string
+            description: Legacy mode (0-3) mapped to 1-6
       requestBody:
         required: false
         content:
@@ -122,6 +132,126 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/TelemetryEvent'
+  /api/proposals:
+    get:
+      summary: List proposals for the tenant
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [proposed, approved, rejected, executed, failed]
+          description: Filter by proposal status
+      responses:
+        '200':
+          description: List of proposals
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProposalListResponse'
+    post:
+      summary: Manually create a proposal (usually generated via runner)
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          schema: { type: string }
+          description: Optional idempotency key for the proposal record
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProposalCreateRequest'
+      responses:
+        '201':
+          description: Proposal created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProposalCreateResponse'
+        '400':
+          description: Missing capability id
+  /api/proposals/{id}/approve:
+    post:
+      summary: Approve a proposal and execute the underlying capability
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+        - in: header
+          name: Idempotency-Key
+          schema: { type: string }
+          description: Override idempotency key for connector execution
+      responses:
+        '200':
+          description: Proposal executed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProposalApproveResponse'
+        '404':
+          description: Proposal or capability not found
+        '409':
+          description: Proposal already rejected or executed
+        '500':
+          description: Execution failed
+  /api/proposals/{id}/reject:
+    post:
+      summary: Reject a proposal without executing it
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProposalRejectRequest'
+      responses:
+        '200':
+          description: Proposal rejected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProposalRejectResponse'
+        '404':
+          description: Proposal not found
+        '409':
+          description: Proposal already executed
+  /api/connectors/{name}/health:
+    get:
+      summary: Retrieve circuit breaker state for a connector
+      parameters:
+        - in: path
+          name: name
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Circuit breaker state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorHealth'
+        '404':
+          description: Connector unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorHealth'
+  /api/connectors/health:
+    get:
+      summary: List health for all known connector breakers
+      responses:
+        '200':
+          description: Aggregate circuit breaker states
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorHealthList'
 components:
   schemas:
     ProactivityState:
@@ -143,21 +273,125 @@ components:
               id: { type: string }
               label: { type: string }
               mode: { type: integer, minimum: 1, maximum: 6 }
+              enforced: { type: boolean, nullable: true }
+              basis:
+                type: array
+                items: { type: string }
+                nullable: true
+              degradeTag: { type: string, nullable: true }
         degradeRail:
           type: array
           items: { type: integer, minimum: 1, maximum: 6 }
         uiHints:
           type: object
           properties:
+            surface:
+              type: string
+              enum: [none, passive, cards, draft, backstage, dom-overlay]
             overlay: { type: boolean }
             callToAction: { type: string }
             banner: { type: string }
             healthChecks: { type: boolean }
-            reviewType: { type: string }
+            reviewType:
+              type: string
+              enum: [none, passive, suggestion, approval, execution]
+        chip:
+          type: object
+          properties:
+            key: { type: string }
+            label: { type: string }
+            icon: { type: string }
         subscription:
           $ref: '#/components/schemas/SubscriptionState'
         featureId: { type: string, nullable: true }
         timestamp: { type: string, format: date-time }
+    Proposal:
+      type: object
+      properties:
+        id: { type: string }
+        tenantId: { type: string }
+        userId: { type: string }
+        featureId: { type: string, nullable: true }
+        capabilityId: { type: string }
+        status: { type: string, enum: [proposed, approved, rejected, executed, failed] }
+        preview:
+          type: object
+          nullable: true
+          additionalProperties: true
+        basis:
+          type: array
+          items: { type: string }
+        idempotencyKey: { type: string, nullable: true }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        approvedBy: { type: string, nullable: true }
+        rejectedBy: { type: string, nullable: true }
+        requestedMode: { type: integer, nullable: true }
+        effectiveMode: { type: integer, nullable: true }
+        executionResult:
+          type: object
+          nullable: true
+          additionalProperties: true
+        failureReason: { type: string, nullable: true }
+    ProposalCreateRequest:
+      type: object
+      required: [capabilityId]
+      properties:
+        capabilityId: { type: string }
+        featureId: { type: string }
+        payload:
+          type: object
+          additionalProperties: true
+        preview:
+          type: object
+          nullable: true
+          additionalProperties: true
+    ProposalCreateResponse:
+      type: object
+      properties:
+        proposal:
+          $ref: '#/components/schemas/Proposal'
+    ProposalListResponse:
+      type: object
+      properties:
+        proposals:
+          type: array
+          items:
+            $ref: '#/components/schemas/Proposal'
+    ProposalApproveResponse:
+      type: object
+      properties:
+        proposal:
+          $ref: '#/components/schemas/Proposal'
+        outcome:
+          type: object
+          nullable: true
+          additionalProperties: true
+        idempotencyKey: { type: string }
+        basis:
+          type: array
+          items: { type: string }
+    ProposalRejectRequest:
+      type: object
+      properties:
+        reason: { type: string }
+    ProposalRejectResponse:
+      type: object
+      properties:
+        proposal:
+          $ref: '#/components/schemas/Proposal'
+    ConnectorHealth:
+      type: object
+      properties:
+        connector: { type: string }
+        state: { type: string, enum: [open, half-open, closed, unknown] }
+    ConnectorHealthList:
+      type: object
+      properties:
+        connectors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectorHealth'
     SubscriptionState:
       type: object
       properties:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,3 +43,56 @@ model AuditChain {
   createdAt DateTime @default(now())
   headHash  String?
 }
+
+enum ProposalStatus {
+  proposed
+  approved
+  rejected
+  executed
+  failed
+}
+
+enum ConnectorCallStatus {
+  pending
+  success
+  failed
+}
+
+model Proposal {
+  id             String          @id @default(uuid())
+  tenantId       String          @map("tenant_id")
+  userId         String          @map("user_id")
+  featureId      String?         @map("feature_id")
+  capabilityId   String          @map("capability_id")
+  payload        Json
+  preview        Json?
+  status         ProposalStatus  @default(proposed)
+  idempotencyKey String?         @map("idempotency_key")
+  basis          Json?
+  requestedMode  Int?            @map("requested_mode")
+  effectiveMode  Int?            @map("effective_mode")
+  executionResult Json?          @map("execution_result")
+  failureReason  String?         @map("failure_reason")
+  approvedBy     String?         @map("approved_by")
+  rejectedBy     String?         @map("rejected_by")
+  createdAt      DateTime        @default(now()) @map("created_at")
+  updatedAt      DateTime        @updatedAt      @map("updated_at")
+
+  @@map("proposals")
+}
+
+model ConnectorCall {
+  key          String              @id
+  connector    String
+  capabilityId String              @map("capability_id")
+  action       String?
+  requestHash  String              @map("request_hash")
+  status       ConnectorCallStatus @default(pending)
+  response     Json?
+  retries      Int                 @default(0)
+  lastError    String?             @map("last_error")
+  createdAt    DateTime            @default(now()) @map("created_at")
+  updatedAt    DateTime            @updatedAt      @map("updated_at")
+
+  @@map("connector_calls")
+}

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -1,0 +1,25 @@
+import type { CapabilityImpl } from '../core/capabilityRunnerRole';
+import { testCaps } from './testCaps';
+
+const registry = new Map<string, CapabilityImpl<any>>();
+
+export function registerCapability(id: string, impl: CapabilityImpl<any>): void {
+  registry.set(id, impl);
+}
+
+export function registerCapabilities(map: Record<string, CapabilityImpl<any>>): void {
+  for (const [id, impl] of Object.entries(map)) {
+    registerCapability(id, impl);
+  }
+}
+
+export function getCapabilityImpl<T = any>(id: string): CapabilityImpl<T> | undefined {
+  return registry.get(id) as CapabilityImpl<T> | undefined;
+}
+
+export function listRegisteredCapabilities(): string[] {
+  return Array.from(registry.keys());
+}
+
+// Default registrations for test/demo capabilities
+registerCapabilities(testCaps as Record<string, CapabilityImpl<any>>);

--- a/src/connectors/execution.ts
+++ b/src/connectors/execution.ts
@@ -1,0 +1,140 @@
+import crypto from 'node:crypto';
+import bus from '../core/eventBusV2';
+import { CircuitBreaker } from '../core/circuit';
+import { getConnectorCallRepository } from './internal/callsRepository';
+import { getConnectorCircuit } from './internal/circuitRegistry';
+
+export interface ConnectorExecutionOptions {
+  connector: string;
+  capabilityId: string;
+  action?: string;
+  payload: any;
+  idempotencyKey: string;
+  maxRetries?: number;
+  retryBaseMs?: number;
+  breaker?: CircuitBreaker;
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_MS = 250;
+
+function hashPayload(payload: any): string {
+  const json = JSON.stringify(payload ?? null);
+  return crypto.createHash('sha256').update(json).digest('hex');
+}
+
+function serializeError(err: any): string {
+  if (!err) return 'unknown_error';
+  if (typeof err === 'string') return err;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function extractStatus(err: any): number | undefined {
+  const candidates = [err?.statusCode, err?.status, err?.response?.status, err?.response?.statusCode];
+  for (const candidate of candidates) {
+    const numeric = Number(candidate);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return undefined;
+}
+
+function parseRetryAfter(err: any): number | undefined {
+  const header = err?.response?.headers?.['retry-after'] ?? err?.response?.headers?.RetryAfter ?? err?.retryAfter;
+  if (!header) return undefined;
+  if (typeof header === 'number' && Number.isFinite(header)) return header * 1000;
+  if (typeof header === 'string') {
+    const numeric = Number(header);
+    if (Number.isFinite(numeric)) return numeric * 1000;
+    const date = Date.parse(header);
+    if (!Number.isNaN(date)) {
+      const diff = date - Date.now();
+      return diff > 0 ? diff : undefined;
+    }
+  }
+  return undefined;
+}
+
+function shouldRetry(err: any, attempt: number, maxRetries: number): boolean {
+  if (attempt >= maxRetries) return false;
+  const status = extractStatus(err);
+  if (!status) return true;
+  if (status >= 500) return true;
+  if (status === 408 || status === 429) return true;
+  return status < 400;
+}
+
+async function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function computeDelay(attempt: number, baseMs: number, err: any): number {
+  const exponential = baseMs * Math.pow(2, attempt - 1);
+  const jitter = Math.floor(Math.random() * baseMs);
+  const retryAfter = parseRetryAfter(err);
+  const candidate = exponential + jitter;
+  if (typeof retryAfter === 'number') {
+    return Math.max(candidate, retryAfter);
+  }
+  return candidate;
+}
+
+export async function executeConnectorAction<T>(
+  opts: ConnectorExecutionOptions,
+  call: () => Promise<T>,
+): Promise<{ response: T; idempotencyKey: string }> {
+  if (!opts.idempotencyKey) throw new Error('connector_idempotency_key_required');
+  const repo = getConnectorCallRepository();
+  const key = opts.idempotencyKey;
+  const requestHash = hashPayload(opts.payload);
+  const existing = await repo.find(key);
+  if (existing) {
+    if (existing.status === 'success') {
+      return { response: existing.response, idempotencyKey: key };
+    }
+    if (existing.status === 'pending') {
+      throw Object.assign(new Error('connector_execution_inflight'), { code: 'inflight', connector: opts.connector });
+    }
+    throw Object.assign(new Error('connector_execution_failed'), { code: 'failed', connector: opts.connector, lastError: existing.lastError });
+  }
+
+  await repo.create({
+    key,
+    connector: opts.connector,
+    capabilityId: opts.capabilityId,
+    action: opts.action,
+    requestHash,
+  });
+
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseMs = opts.retryBaseMs ?? DEFAULT_BASE_MS;
+  const breaker = opts.breaker ?? getConnectorCircuit(opts.connector);
+  let attempt = 0;
+
+  while (true) {
+    try {
+      const response = await breaker.call(`${opts.connector}:${opts.action ?? 'execute'}`, call);
+      await repo.markSuccess(key, response, attempt);
+      return { response, idempotencyKey: key };
+    } catch (err: any) {
+      attempt += 1;
+      const retry = shouldRetry(err, attempt, maxRetries);
+      if (!retry) {
+        const message = serializeError(err);
+        await repo.markFailed(key, message, attempt);
+        await bus.emit('eventbus.dlq', {
+          connector: opts.connector,
+          capabilityId: opts.capabilityId,
+          idempotencyKey: key,
+          error: message,
+        });
+        throw Object.assign(new Error('connector_execution_failed'), { code: 'failed', connector: opts.connector, cause: err });
+      }
+      await repo.incrementRetries(key, attempt);
+      const delay = computeDelay(attempt, baseMs, err);
+      await (opts.sleepFn ?? sleep)(delay);
+    }
+  }
+}

--- a/src/connectors/internal/callsRepository.ts
+++ b/src/connectors/internal/callsRepository.ts
@@ -1,0 +1,123 @@
+export type ConnectorCallStatus = 'pending' | 'success' | 'failed';
+
+export interface ConnectorCallRecord {
+  key: string;
+  connector: string;
+  capabilityId: string;
+  action?: string;
+  requestHash: string;
+  status: ConnectorCallStatus;
+  response?: any;
+  retries: number;
+  lastError?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConnectorCallCreateInput {
+  key: string;
+  connector: string;
+  capabilityId: string;
+  action?: string;
+  requestHash: string;
+}
+
+export interface ConnectorCallRepository {
+  find(key: string): Promise<ConnectorCallRecord | undefined>;
+  create(input: ConnectorCallCreateInput): Promise<ConnectorCallRecord>;
+  markSuccess(key: string, response: any, retries: number): Promise<ConnectorCallRecord>;
+  markFailed(key: string, error: string, retries: number): Promise<ConnectorCallRecord>;
+  incrementRetries(key: string, retries: number): Promise<ConnectorCallRecord>;
+  reset(): void;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+class InMemoryConnectorCallRepository implements ConnectorCallRepository {
+  private readonly items = new Map<string, ConnectorCallRecord>();
+
+  async find(key: string): Promise<ConnectorCallRecord | undefined> {
+    const record = this.items.get(key);
+    return record ? clone(record) : undefined;
+  }
+
+  async create(input: ConnectorCallCreateInput): Promise<ConnectorCallRecord> {
+    const now = new Date().toISOString();
+    const record: ConnectorCallRecord = {
+      key: input.key,
+      connector: input.connector,
+      capabilityId: input.capabilityId,
+      action: input.action,
+      requestHash: input.requestHash,
+      status: 'pending',
+      retries: 0,
+      createdAt: now,
+      updatedAt: now,
+      response: undefined,
+      lastError: null,
+    };
+    this.items.set(record.key, record);
+    return clone(record);
+  }
+
+  async markSuccess(key: string, response: any, retries: number): Promise<ConnectorCallRecord> {
+    const existing = this.items.get(key);
+    if (!existing) throw new Error('connector_call_not_found');
+    const record: ConnectorCallRecord = {
+      ...existing,
+      status: 'success',
+      response,
+      retries,
+      lastError: null,
+      updatedAt: new Date().toISOString(),
+    };
+    this.items.set(key, record);
+    return clone(record);
+  }
+
+  async markFailed(key: string, error: string, retries: number): Promise<ConnectorCallRecord> {
+    const existing = this.items.get(key);
+    if (!existing) throw new Error('connector_call_not_found');
+    const record: ConnectorCallRecord = {
+      ...existing,
+      status: 'failed',
+      lastError: error,
+      retries,
+      updatedAt: new Date().toISOString(),
+    };
+    this.items.set(key, record);
+    return clone(record);
+  }
+
+  async incrementRetries(key: string, retries: number): Promise<ConnectorCallRecord> {
+    const existing = this.items.get(key);
+    if (!existing) throw new Error('connector_call_not_found');
+    const record: ConnectorCallRecord = {
+      ...existing,
+      retries,
+      updatedAt: new Date().toISOString(),
+    };
+    this.items.set(key, record);
+    return clone(record);
+  }
+
+  reset(): void {
+    this.items.clear();
+  }
+}
+
+let repository: ConnectorCallRepository = new InMemoryConnectorCallRepository();
+
+export function getConnectorCallRepository(): ConnectorCallRepository {
+  return repository;
+}
+
+export function setConnectorCallRepository(next: ConnectorCallRepository) {
+  repository = next;
+}
+
+export function resetConnectorCallRepository() {
+  repository.reset();
+}

--- a/src/connectors/internal/circuitRegistry.ts
+++ b/src/connectors/internal/circuitRegistry.ts
@@ -1,0 +1,29 @@
+import { CircuitBreaker, CircuitOptions, CircuitState } from '../../core/circuit';
+
+const breakers = new Map<string, CircuitBreaker>();
+
+const DEFAULT_OPTIONS: CircuitOptions = {
+  failureThreshold: 4,
+  halfOpenAfterMs: 10_000,
+  failureWindowMs: 60_000,
+};
+
+export function getConnectorCircuit(connector: string, opts?: CircuitOptions): CircuitBreaker {
+  const existing = breakers.get(connector);
+  if (existing) return existing;
+  const breaker = new CircuitBreaker({ ...DEFAULT_OPTIONS, ...(opts ?? {}) });
+  breakers.set(connector, breaker);
+  return breaker;
+}
+
+export function getConnectorCircuitState(connector: string): CircuitState | undefined {
+  return breakers.get(connector)?.getState();
+}
+
+export function listConnectorCircuits(): Array<{ connector: string; state: CircuitState }> {
+  return Array.from(breakers.entries()).map(([connector, breaker]) => ({ connector, state: breaker.getState() }));
+}
+
+export function resetConnectorCircuits() {
+  breakers.clear();
+}

--- a/src/core/capabilityRunnerRole.ts
+++ b/src/core/capabilityRunnerRole.ts
@@ -1,8 +1,11 @@
+import crypto from 'node:crypto';
 import { RoleRegistry } from '../roles/registry';
+import { executeConnectorAction } from '../connectors/execution';
 import { policyCheckRoleAware, RoleAwareContext } from './policyRoleAware';
+import { createProposal, sanitizeProposal } from './proposals/service';
 import { modeToKey, ProactivityMode } from './proactivity/modes';
 
-interface CapabilityImpl<T> {
+export interface CapabilityImpl<T> {
   observe?: () => Promise<void>;
   suggest?: () => Promise<T>;
   prepare?: () => Promise<T>;
@@ -37,9 +40,12 @@ export async function runCapabilityWithRole<T>(
   };
 
   let outcome: T | undefined;
+  const logExtra: Record<string, any> = {};
+  let proposalResult: any;
+  let executionKey = ctx.idempotencyKey;
 
   if (!policy.allowed) {
-    await logIntent({ ...logBase, degraded_mode: 'ask_approval' });
+    await logIntent({ ...logBase, ...logExtra, degraded_mode: 'ask_approval' });
     return { policy, proactivity };
   }
 
@@ -53,14 +59,58 @@ export async function runCapabilityWithRole<T>(
         outcome = await impl.suggest?.();
         break;
       case ProactivityMode.Ambisiøs:
-        outcome = await impl.prepare?.();
+        outcome = await (impl.prepare?.() ?? impl.suggest?.());
+        proposalResult = await createProposal({
+          tenantId: ctx.tenantId,
+          userId: ctx.roleBinding.userId,
+          featureId,
+          capabilityId,
+          payload,
+          preview: outcome,
+          idempotencyKey: executionKey ?? null,
+          basis: proactivity.basis,
+          requestedMode: proactivity.requested,
+          effectiveMode: proactivity.effective,
+        });
+        logExtra.proposalId = proposalResult.id;
+        if (proposalResult.idempotencyKey) logExtra.idempotencyKey = proposalResult.idempotencyKey;
         break;
       case ProactivityMode.Kraken:
-        outcome = await impl.execute?.();
+        if (impl.execute) {
+          executionKey = ensureIdempotencyKey(executionKey);
+          const connector = ctx.connectorName ?? capabilityId.split('.')[0] ?? 'capability';
+          const { response } = await executeConnectorAction(
+            {
+              connector,
+              capabilityId,
+              action: capabilityId,
+              payload,
+              idempotencyKey: executionKey,
+            },
+            () => impl.execute!(),
+          );
+          outcome = response as T;
+          logExtra.idempotencyKey = executionKey;
+        } else {
+          outcome = await impl.prepare?.();
+        }
         break;
       case ProactivityMode.Tsunami: {
         if (impl.execute) {
-          outcome = await impl.execute();
+          executionKey = ensureIdempotencyKey(executionKey);
+          const connector = ctx.connectorName ?? capabilityId.split('.')[0] ?? 'capability';
+          const { response } = await executeConnectorAction(
+            {
+              connector,
+              capabilityId,
+              action: capabilityId,
+              payload,
+              idempotencyKey: executionKey,
+            },
+            () => impl.execute!(),
+          );
+          outcome = response as T;
+          logExtra.idempotencyKey = executionKey;
         }
         if (impl.overlay) {
           const overlayResult = await impl.overlay();
@@ -73,8 +123,18 @@ export async function runCapabilityWithRole<T>(
         break;
     }
   } finally {
-    await logIntent({ ...logBase, outcome });
+    await logIntent({ ...logBase, ...logExtra, outcome });
   }
 
-  return { outcome, policy, proactivity };
+  if (proposalResult) {
+    return { policy, proactivity, proposal: sanitizeProposal(proposalResult), outcome };
+  }
+
+  return { outcome, policy, proactivity, idempotencyKey: executionKey };
+}
+
+function ensureIdempotencyKey(existing?: string): string {
+  if (existing && existing.length > 0) return existing;
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  return `idemp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }

--- a/src/core/policyRoleAware.ts
+++ b/src/core/policyRoleAware.ts
@@ -7,8 +7,11 @@ export interface RoleAwareContext {
   tenantId: string;
   roleBinding: UserRoleBinding;
   requestedMode?: ProactivityMode | number | string;
+  compatMode?: ProactivityMode | number | string;
   degradeRail?: ProactivityMode[];
   policyCap?: ProactivityMode;
+  idempotencyKey?: string;
+  connectorName?: string;
 }
 
 export interface PolicyRoleAwareResult {
@@ -32,6 +35,7 @@ export async function policyCheckRoleAware(
     roleBinding: ctx.roleBinding,
     featureId,
     requestedMode: ctx.requestedMode,
+    compatMode: ctx.compatMode,
     degradeRail: ctx.degradeRail,
     policyCap: ctx.policyCap,
   });

--- a/src/core/proactivity/context.ts
+++ b/src/core/proactivity/context.ts
@@ -11,6 +11,7 @@ export interface ProactivityContextInput {
   roleBinding?: UserRoleBinding;
   featureId?: string;
   requestedMode?: string | number | ProactivityMode;
+  compatMode?: string | number | undefined;
   policyCap?: ProactivityMode;
   degradeRail?: ProactivityMode[];
   basis?: string[];
@@ -21,6 +22,7 @@ export interface ProactivityState extends ProactivityResolution {
   requestedKey: string;
   effectiveKey: string;
   uiHints: typeof PROACTIVITY_MODE_META[ProactivityMode.Proaktiv]['uiHints'];
+  chip: typeof PROACTIVITY_MODE_META[ProactivityMode.Proaktiv]['chip'];
   meta: typeof PROACTIVITY_MODE_META[ProactivityMode.Proaktiv];
   subscription: SubscriptionCapSummary;
   featureId?: string;
@@ -53,24 +55,46 @@ function resolveRoleCap(
 export function buildProactivityContext(input: ProactivityContextInput): ProactivityState {
   const subscription = getSubscriptionCap(input.tenantId);
   const caps: ProactivityCap[] = [
-    { id: `subscription:${subscription.plan}`, label: `plan:${subscription.plan}`, mode: subscription.maxMode },
+    {
+      id: `subscription:${subscription.plan}`,
+      label: `plan:${subscription.plan}`,
+      mode: subscription.maxMode,
+      basis: [`tenantPlan:${subscription.plan}`].concat(subscription.secureTenant ? ['tenant<=3'] : []),
+      degradeTag: 'subscription',
+    },
   ];
   const basis = new Set<string>(input.basis ?? []);
-  basis.add(`subscription:${subscription.plan}`);
-  if (subscription.secureTenant) basis.add('subscription:secureTenant');
-  if (subscription.killSwitch) basis.add('subscription:killswitch');
+  basis.add(`tenantPlan:${subscription.plan}`);
+  if (subscription.secureTenant) basis.add('tenant<=3');
 
-  const requested = parseProactivityMode(input.requestedMode);
+  const compatRequested = mapCompatMode(input.compatMode);
+  const requested = parseProactivityMode(
+    input.requestedMode ?? compatRequested ?? undefined,
+    compatRequested ?? undefined,
+  );
   const rail = input.degradeRail && input.degradeRail.length ? input.degradeRail : DEFAULT_DEGRADE_RAIL;
 
   const { cap: roleCap, featureId } = resolveRoleCap(input.roleRegistry, input.tenantId, input.roleBinding, input.featureId);
   if (roleCap) {
-    caps.push({ id: featureId ? `role:${featureId}` : 'role', label: featureId ?? 'role', mode: roleCap });
-    basis.add(featureId ? `feature:${featureId}` : 'feature:default');
+    const featureTag = featureId ?? 'default';
+    caps.push({
+      id: featureId ? `role:${featureId}` : 'role',
+      label: featureId ?? 'role',
+      mode: roleCap,
+      basis: [`roleCap:${featureTag}=${roleCap}`],
+      degradeTag: `role:${featureTag}`,
+    });
+    basis.add(`roleCap:${featureTag}=${roleCap}`);
   }
 
   if (input.policyCap) {
-    caps.push({ id: 'policy', label: 'policy', mode: input.policyCap });
+    caps.push({
+      id: 'policy',
+      label: 'policy',
+      mode: input.policyCap,
+      basis: [`policyCap:policy=${input.policyCap}`],
+      degradeTag: 'policy',
+    });
   }
 
   const resolution = resolveEffectiveMode({
@@ -88,10 +112,21 @@ export function buildProactivityContext(input: ProactivityContextInput): Proacti
     requestedKey: modeToKey(resolution.requested),
     effectiveKey: modeToKey(resolution.effective),
     uiHints: meta.uiHints,
+    chip: meta.chip,
     meta,
     subscription,
     featureId,
     timestamp: new Date().toISOString(),
   };
   return state;
+}
+
+function mapCompatMode(input: unknown): ProactivityMode | undefined {
+  if (input === undefined || input === null) return undefined;
+  const numeric = typeof input === 'number' ? input : Number(input);
+  if (!Number.isFinite(numeric)) return undefined;
+  if (numeric <= 1) return ProactivityMode.Proaktiv;
+  if (numeric === 2) return ProactivityMode.Ambisiøs;
+  if (numeric >= 3) return ProactivityMode.Kraken;
+  return undefined;
 }

--- a/src/core/proactivity/guards.ts
+++ b/src/core/proactivity/guards.ts
@@ -9,11 +9,13 @@ export function requiresProMode(required: ProactivityMode) {
   return (req: BasicRequest, res: BasicResponse, next: Next) => {
     const state = req.proactivity;
     if (!state || state.effective < required) {
+      const basis = new Set<string>(state?.basis ?? []);
+      basis.add(`guard:min=${required}`);
       return res.status(403).json({
         error: 'proactivity_required',
         required: modeToKey(required),
         actual: state ? modeToKey(state.effective) : 'none',
-        basis: state?.basis ?? [],
+        basis: Array.from(basis),
       });
     }
     return next();

--- a/src/core/proactivity/modes.ts
+++ b/src/core/proactivity/modes.ts
@@ -22,11 +22,17 @@ export interface ProactivityModeMeta {
   description: string;
   degradeHint?: string;
   uiHints: {
+    surface: 'none' | 'passive' | 'cards' | 'draft' | 'backstage' | 'dom-overlay';
     overlay?: boolean;
     callToAction?: string;
     banner?: string;
     healthChecks?: boolean;
     reviewType?: 'none' | 'passive' | 'suggestion' | 'approval' | 'execution';
+  };
+  chip: {
+    key: string;
+    label: string;
+    icon: string;
   };
   basisExamples: string[];
 }
@@ -39,12 +45,14 @@ export const PROACTIVITY_MODE_META: Record<ProactivityMode, ProactivityModeMeta>
     description: 'Observe quietly with no UI surfaces or interventions.',
     degradeHint: 'baseline fall-back when tenant kill switch is engaged',
     uiHints: {
+      surface: 'none',
       overlay: false,
       banner: 'Observing silently',
       callToAction: undefined,
       healthChecks: false,
       reviewType: 'none',
     },
+    chip: { key: 'usynlig', label: 'Usynlig', icon: '🫧' },
     basisExamples: ['subscription:killswitch', 'policy:deny', 'roleCap:disabled'],
   },
   [ProactivityMode.Rolig]: {
@@ -54,12 +62,14 @@ export const PROACTIVITY_MODE_META: Record<ProactivityMode, ProactivityModeMeta>
     description: 'Observe system state and surface telemetry passively with no call to action.',
     degradeHint: 'fallback when automation is paused but monitoring continues',
     uiHints: {
+      surface: 'passive',
       overlay: false,
       banner: 'Monitoring in read-only mode',
       callToAction: undefined,
       healthChecks: false,
       reviewType: 'passive',
     },
+    chip: { key: 'rolig', label: 'Rolig', icon: '🌿' },
     basisExamples: ['roleCap:2', 'tenant:readonly'],
   },
   [ProactivityMode.Proaktiv]: {
@@ -69,12 +79,14 @@ export const PROACTIVITY_MODE_META: Record<ProactivityMode, ProactivityModeMeta>
     description: 'Suggest actions with lightweight call-to-action buttons.',
     degradeHint: 'default supervised mode when higher tiers not permitted',
     uiHints: {
+      surface: 'cards',
       overlay: false,
       banner: 'Suggestions ready',
       callToAction: 'Show suggestions',
       healthChecks: false,
       reviewType: 'suggestion',
     },
+    chip: { key: 'proaktiv', label: 'Proaktiv', icon: '💡' },
     basisExamples: ['plan:flex', 'roleCap:3'],
   },
   [ProactivityMode.Ambisiøs]: {
@@ -84,12 +96,14 @@ export const PROACTIVITY_MODE_META: Record<ProactivityMode, ProactivityModeMeta>
     description: 'Prepare changes, generate previews and require approval before execution.',
     degradeHint: 'requires reviewer sign-off before running automations',
     uiHints: {
+      surface: 'draft',
       overlay: false,
       banner: 'Previews prepared',
       callToAction: 'Review & approve',
       healthChecks: false,
       reviewType: 'approval',
     },
+    chip: { key: 'ambisiøs', label: 'Ambisiøs', icon: '✍️' },
     basisExamples: ['plan:flex', 'policy:requires_approval'],
   },
   [ProactivityMode.Kraken]: {
@@ -99,12 +113,14 @@ export const PROACTIVITY_MODE_META: Record<ProactivityMode, ProactivityModeMeta>
     description: 'Execute automations directly under policy guardrails.',
     degradeHint: 'falls back when execution guard fails',
     uiHints: {
+      surface: 'backstage',
       overlay: false,
       banner: 'Executing with guardrails',
       callToAction: 'View execution log',
       healthChecks: true,
       reviewType: 'execution',
     },
+    chip: { key: 'kraken', label: 'Kraken', icon: '🐙' },
     basisExamples: ['plan:secure', 'roleCap:5', 'policy:execute_allowed'],
   },
   [ProactivityMode.Tsunami]: {
@@ -114,12 +130,14 @@ export const PROACTIVITY_MODE_META: Record<ProactivityMode, ProactivityModeMeta>
     description: 'Execute, project overlay changes and continuously run health checks.',
     degradeHint: 'will degrade to Kraken on overlay or health-check failure',
     uiHints: {
+      surface: 'dom-overlay',
       overlay: true,
       banner: 'Hands-free automation engaged',
       callToAction: 'Inspect live overlay',
       healthChecks: true,
       reviewType: 'execution',
     },
+    chip: { key: 'tsunami', label: 'Tsunami', icon: '🌊' },
     basisExamples: ['plan:enterprise', 'roleCap:6', 'telemetry:overlay_ready'],
   },
 };

--- a/src/core/proposals/repository.ts
+++ b/src/core/proposals/repository.ts
@@ -1,0 +1,109 @@
+import crypto from 'node:crypto';
+import { ProposalCreateInput, ProposalListFilter, ProposalRecord, ProposalStatus, ProposalUpdateInput } from './types';
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export interface ProposalsRepository {
+  create(input: ProposalCreateInput): Promise<ProposalRecord>;
+  get(id: string): Promise<ProposalRecord | undefined>;
+  update(id: string, update: ProposalUpdateInput): Promise<ProposalRecord>;
+  list(filter?: ProposalListFilter): Promise<ProposalRecord[]>;
+  reset(): void;
+}
+
+class InMemoryProposalsRepository implements ProposalsRepository {
+  private readonly items = new Map<string, ProposalRecord>();
+  private readonly idempotencyIndex = new Map<string, string>();
+
+  async create(input: ProposalCreateInput): Promise<ProposalRecord> {
+    const now = new Date().toISOString();
+    const id = crypto.randomUUID();
+    if (input.idempotencyKey) {
+      const existingId = this.idempotencyIndex.get(input.idempotencyKey);
+      if (existingId) {
+        const existing = this.items.get(existingId);
+        if (existing) return clone(existing);
+      }
+    }
+    const record: ProposalRecord = {
+      id,
+      tenantId: input.tenantId,
+      userId: input.userId,
+      featureId: input.featureId,
+      capabilityId: input.capabilityId,
+      payload: input.payload,
+      preview: input.preview,
+      status: 'proposed',
+      idempotencyKey: input.idempotencyKey ?? null,
+      createdAt: now,
+      updatedAt: now,
+      approvedBy: null,
+      rejectedBy: null,
+      basis: clone(input.basis ?? []),
+      requestedMode: input.requestedMode,
+      effectiveMode: input.effectiveMode,
+      executionResult: undefined,
+      failureReason: null,
+    };
+    this.items.set(record.id, record);
+    if (record.idempotencyKey) {
+      this.idempotencyIndex.set(record.idempotencyKey, record.id);
+    }
+    return clone(record);
+  }
+
+  async get(id: string): Promise<ProposalRecord | undefined> {
+    const found = this.items.get(id);
+    return found ? clone(found) : undefined;
+  }
+
+  async update(id: string, update: ProposalUpdateInput): Promise<ProposalRecord> {
+    const existing = this.items.get(id);
+    if (!existing) throw new Error('proposal_not_found');
+    const next: ProposalRecord = {
+      ...existing,
+      ...update,
+      status: (update.status ?? existing.status) as ProposalStatus,
+      approvedBy: update.approvedBy ?? existing.approvedBy ?? null,
+      rejectedBy: update.rejectedBy ?? existing.rejectedBy ?? null,
+      executionResult: update.executionResult ?? existing.executionResult,
+      failureReason: update.failureReason ?? existing.failureReason ?? null,
+      idempotencyKey: update.idempotencyKey ?? existing.idempotencyKey ?? null,
+      updatedAt: new Date().toISOString(),
+    };
+    this.items.set(id, next);
+    if (next.idempotencyKey) {
+      this.idempotencyIndex.set(next.idempotencyKey, id);
+    }
+    return clone(next);
+  }
+
+  async list(filter?: ProposalListFilter): Promise<ProposalRecord[]> {
+    const values = Array.from(this.items.values());
+    const filtered = filter?.status
+      ? values.filter(item => item.status === filter.status)
+      : values;
+    return filtered.map(item => clone(item));
+  }
+
+  reset() {
+    this.items.clear();
+    this.idempotencyIndex.clear();
+  }
+}
+
+let repo: ProposalsRepository = new InMemoryProposalsRepository();
+
+export function getProposalsRepository(): ProposalsRepository {
+  return repo;
+}
+
+export function setProposalsRepository(next: ProposalsRepository) {
+  repo = next;
+}
+
+export function resetProposalsRepository() {
+  repo.reset();
+}

--- a/src/core/proposals/service.ts
+++ b/src/core/proposals/service.ts
@@ -1,0 +1,86 @@
+import crypto from 'node:crypto';
+import bus from '../eventBusV2';
+import { ProposalCreateInput, ProposalListFilter, ProposalRecord, ProposalUpdateInput } from './types';
+import { getProposalsRepository } from './repository';
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function ensureArray(input: string[] | undefined): string[] {
+  return Array.from(new Set(input ?? []));
+}
+
+export async function createProposal(input: ProposalCreateInput): Promise<ProposalRecord> {
+  const repo = getProposalsRepository();
+  const basis = ensureArray(input.basis);
+  const record = await repo.create({ ...input, basis });
+  await bus.emit('proposal.created', { proposal: clone(record) });
+  return record;
+}
+
+export async function listProposals(filter?: ProposalListFilter): Promise<ProposalRecord[]> {
+  const repo = getProposalsRepository();
+  return repo.list(filter);
+}
+
+export async function getProposal(id: string): Promise<ProposalRecord | undefined> {
+  const repo = getProposalsRepository();
+  return repo.get(id);
+}
+
+export async function updateProposal(id: string, update: ProposalUpdateInput): Promise<ProposalRecord> {
+  const repo = getProposalsRepository();
+  const record = await repo.update(id, update);
+  return record;
+}
+
+export async function markProposalApproved(id: string, approvedBy: string, idempotencyKey?: string): Promise<ProposalRecord> {
+  const record = await updateProposal(id, { status: 'approved', approvedBy, idempotencyKey });
+  await bus.emit('proposal.approved', { proposal: clone(record) });
+  return record;
+}
+
+export async function markProposalRejected(id: string, rejectedBy: string, reason?: string): Promise<ProposalRecord> {
+  const record = await updateProposal(id, { status: 'rejected', rejectedBy, failureReason: reason ?? null });
+  await bus.emit('proposal.rejected', { proposal: clone(record) });
+  return record;
+}
+
+export async function markProposalExecuted(id: string, executionResult: any): Promise<ProposalRecord> {
+  const record = await updateProposal(id, { status: 'executed', executionResult, failureReason: null });
+  await bus.emit('proposal.executed', { proposal: clone(record) });
+  return record;
+}
+
+export async function markProposalFailed(id: string, failureReason: string): Promise<ProposalRecord> {
+  const record = await updateProposal(id, { status: 'failed', failureReason });
+  await bus.emit('proposal.failed', { proposal: clone(record) });
+  return record;
+}
+
+export function generateProposalIdempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
+export function sanitizeProposal(record: ProposalRecord) {
+  return {
+    id: record.id,
+    tenantId: record.tenantId,
+    userId: record.userId,
+    featureId: record.featureId,
+    capabilityId: record.capabilityId,
+    status: record.status,
+    preview: record.preview,
+    basis: record.basis,
+    idempotencyKey: record.idempotencyKey ?? undefined,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    approvedBy: record.approvedBy ?? undefined,
+    rejectedBy: record.rejectedBy ?? undefined,
+    requestedMode: record.requestedMode,
+    effectiveMode: record.effectiveMode,
+    executionResult: record.executionResult,
+    failureReason: record.failureReason ?? undefined,
+  };
+}

--- a/src/core/proposals/types.ts
+++ b/src/core/proposals/types.ts
@@ -1,0 +1,50 @@
+import type { ProactivityMode } from '../proactivity/modes';
+
+export type ProposalStatus = 'proposed' | 'approved' | 'rejected' | 'executed' | 'failed';
+
+export interface ProposalRecord {
+  id: string;
+  tenantId: string;
+  userId: string;
+  featureId?: string;
+  capabilityId: string;
+  payload: any;
+  preview?: any;
+  status: ProposalStatus;
+  idempotencyKey?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  approvedBy?: string | null;
+  rejectedBy?: string | null;
+  basis: string[];
+  requestedMode?: ProactivityMode;
+  effectiveMode?: ProactivityMode;
+  executionResult?: any;
+  failureReason?: string | null;
+}
+
+export interface ProposalCreateInput {
+  tenantId: string;
+  userId: string;
+  featureId?: string;
+  capabilityId: string;
+  payload: any;
+  preview?: any;
+  idempotencyKey?: string | null;
+  basis?: string[];
+  requestedMode?: ProactivityMode;
+  effectiveMode?: ProactivityMode;
+}
+
+export interface ProposalUpdateInput {
+  status?: ProposalStatus;
+  approvedBy?: string | null;
+  rejectedBy?: string | null;
+  executionResult?: any;
+  failureReason?: string | null;
+  idempotencyKey?: string | null;
+}
+
+export interface ProposalListFilter {
+  status?: ProposalStatus;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,8 @@ safeMount('/api', '../backend/routes/admin.subscription');
 safeMount('/api', '../backend/routes/explainability');
 safeMount('/api', '../backend/routes/features');
 safeMount('/api', '../backend/routes/usage');
+safeMount('/api', '../backend/routes/proposals');
+safeMount('/api', '../backend/routes/connectors.health');
 
 app.use('/api', knowledgeRouter);
 app.use('/api/audit', auditRouter());

--- a/tests/connectors/breaker.test.ts
+++ b/tests/connectors/breaker.test.ts
@@ -1,0 +1,60 @@
+import { executeConnectorAction } from '../../src/connectors/execution';
+import { resetConnectorCallRepository } from '../../src/connectors/internal/callsRepository';
+import { getConnectorCircuit, getConnectorCircuitState, resetConnectorCircuits } from '../../src/connectors/internal/circuitRegistry';
+
+describe('connector circuit breaker', () => {
+  beforeEach(() => {
+    resetConnectorCallRepository();
+    resetConnectorCircuits();
+  });
+
+  it('opens after repeated failures and recovers after cooldown', async () => {
+    const breaker = getConnectorCircuit('breaker-test', { failureThreshold: 2, halfOpenAfterMs: 5, failureWindowMs: 50 });
+
+    const failingCall = async () => {
+      throw new Error('boom');
+    };
+
+    const attempt = async (key: string) => {
+      await executeConnectorAction(
+        {
+          connector: 'breaker-test',
+          capabilityId: 'demo.action',
+          payload: { key },
+          idempotencyKey: key,
+          maxRetries: 0,
+          retryBaseMs: 1,
+          breaker,
+          sleepFn: async () => {},
+        },
+        failingCall,
+      );
+    };
+
+    await expect(attempt('k1')).rejects.toThrow('boom');
+    await expect(attempt('k2')).rejects.toThrow('boom');
+
+    await expect(attempt('k3')).rejects.toThrow(/circuit_open/);
+    expect(getConnectorCircuitState('breaker-test')).toBe('open');
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const successCall = jest.fn(async () => ({ ok: true }));
+    const result = await executeConnectorAction(
+      {
+        connector: 'breaker-test',
+        capabilityId: 'demo.action',
+        payload: { key: 'k4' },
+        idempotencyKey: 'k4',
+        breaker,
+        maxRetries: 0,
+        retryBaseMs: 1,
+        sleepFn: async () => {},
+      },
+      successCall,
+    );
+
+    expect(result.response).toEqual({ ok: true });
+    expect(getConnectorCircuitState('breaker-test')).toBe('closed');
+  });
+});

--- a/tests/connectors/idempotency.test.ts
+++ b/tests/connectors/idempotency.test.ts
@@ -1,0 +1,28 @@
+import { executeConnectorAction } from '../../src/connectors/execution';
+import { resetConnectorCallRepository } from '../../src/connectors/internal/callsRepository';
+import { resetConnectorCircuits } from '../../src/connectors/internal/circuitRegistry';
+import bus from '../../src/core/eventBusV2';
+
+describe('connector execution idempotency', () => {
+  beforeEach(() => {
+    resetConnectorCallRepository();
+    resetConnectorCircuits();
+    bus.reset?.();
+  });
+
+  it('returns cached response when same idempotency key is reused', async () => {
+    const callFn = jest.fn(async () => ({ ok: true, ts: Date.now() }));
+    const opts = {
+      connector: 'idempotency',
+      capabilityId: 'demo.execute',
+      payload: { foo: 'bar' },
+      idempotencyKey: 'key-1',
+    };
+
+    const first = await executeConnectorAction(opts, callFn);
+    const second = await executeConnectorAction(opts, callFn);
+
+    expect(callFn).toHaveBeenCalledTimes(1);
+    expect(second.response).toEqual(first.response);
+  });
+});

--- a/tests/connectors/retry-dlq.test.ts
+++ b/tests/connectors/retry-dlq.test.ts
@@ -1,0 +1,45 @@
+import { executeConnectorAction } from '../../src/connectors/execution';
+import { resetConnectorCallRepository, getConnectorCallRepository } from '../../src/connectors/internal/callsRepository';
+import { resetConnectorCircuits } from '../../src/connectors/internal/circuitRegistry';
+import bus from '../../src/core/eventBusV2';
+
+describe('connector retry and DLQ handling', () => {
+  beforeEach(() => {
+    resetConnectorCallRepository();
+    resetConnectorCircuits();
+    bus.reset?.();
+  });
+
+  it('retries on transient failures and emits to DLQ on exhaustion', async () => {
+    const attempts: number[] = [];
+    const failingCall = jest.fn(async () => {
+      attempts.push(Date.now());
+      const error: any = new Error('server_error');
+      error.statusCode = 500;
+      throw error;
+    });
+
+    await expect(executeConnectorAction(
+      {
+        connector: 'retry-test',
+        capabilityId: 'demo.action',
+        payload: { n: 1 },
+        idempotencyKey: 'retry-key',
+        maxRetries: 2,
+        retryBaseMs: 1,
+        sleepFn: async () => {},
+      },
+      failingCall,
+    )).rejects.toThrow('connector_execution_failed');
+
+    expect(failingCall).toHaveBeenCalledTimes(3); // initial + 2 retries
+    const repo = getConnectorCallRepository();
+    const record = await repo.find('retry-key');
+    expect(record?.status).toBe('failed');
+    expect(record?.retries).toBeGreaterThanOrEqual(3);
+
+    const peek = bus._peek?.();
+    const dlqEvents = peek?.dlq ?? [];
+    expect(dlqEvents.some(event => event.type === 'eventbus.dlq' && event.payload?.connector === 'retry-test')).toBe(true);
+  });
+});

--- a/tests/policy/guards.1-6.test.ts
+++ b/tests/policy/guards.1-6.test.ts
@@ -1,0 +1,54 @@
+import { requiresProMode } from '../../src/core/proactivity/guards';
+import { ProactivityMode } from '../../src/core/proactivity/modes';
+import { buildProactivityContext } from '../../src/core/proactivity/context';
+import { setSubscriptionForTenant, resetSubscriptionState } from '../../src/core/subscription/state';
+
+describe('requiresProMode guard', () => {
+  beforeEach(() => {
+    resetSubscriptionState();
+  });
+
+  it('rejects when effective mode is below minimum', () => {
+    const guard = requiresProMode(ProactivityMode.Kraken);
+    const req: any = { proactivity: { effective: ProactivityMode.Ambisiøs, basis: ['mode:effective=4'] } };
+    const res: any = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    const next = jest.fn();
+
+    guard(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.basis).toEqual(expect.arrayContaining(['mode:effective=4', 'guard:min=5']));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows when effective mode meets requirement', () => {
+    const guard = requiresProMode(ProactivityMode.Kraken);
+    const req: any = { proactivity: { effective: ProactivityMode.Kraken, basis: ['mode:effective=5'] } };
+    const res: any = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    const next = jest.fn();
+
+    guard(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('secure tenants are capped at <=3', () => {
+    setSubscriptionForTenant('SEC', { plan: 'enterprise', secureTenant: true });
+    const state = buildProactivityContext({ tenantId: 'SEC', requestedMode: ProactivityMode.Tsunami });
+    expect(state.effective).toBeLessThanOrEqual(ProactivityMode.Proaktiv);
+    expect(state.basis).toEqual(expect.arrayContaining(['tenant<=3', 'degraded:subscription', 'mode:effective=3']));
+  });
+
+  it('kill switch forces usynlig', () => {
+    setSubscriptionForTenant('KILL', { plan: 'enterprise', killSwitch: true });
+    const state = buildProactivityContext({ tenantId: 'KILL', requestedMode: ProactivityMode.Kraken });
+    expect(state.effective).toBe(ProactivityMode.Usynlig);
+    expect(state.basis).toEqual(expect.arrayContaining(['kill', 'degraded:kill', 'mode:effective=1']));
+  });
+});

--- a/tests/policy/rolecap.test.ts
+++ b/tests/policy/rolecap.test.ts
@@ -23,7 +23,7 @@ describe('policy role cap enforcement', () => {
     );
 
     expect(result.proactivity.effective).toBe(ProactivityMode.Proaktiv);
-    expect(result.proactivity.basis).toEqual(expect.arrayContaining(['cap:role:crm:proaktiv']));
+    expect(result.proactivity.basis).toEqual(expect.arrayContaining(['roleCap:crm=3', 'degraded:role:crm']));
     expect(policySpy).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({ autonomy_level: ProactivityMode.Proaktiv })

--- a/tests/proactivity/api-state.test.ts
+++ b/tests/proactivity/api-state.test.ts
@@ -23,6 +23,9 @@ describe('GET /api/proactivity/state', () => {
     expect(res.body.requestedKey).toBe('tsunami');
     expect(res.body.effectiveKey).toBe('ambisiøs');
     expect(res.body.uiHints).toHaveProperty('callToAction');
+    expect(res.body.uiHints.surface).toBe('draft');
+    expect(res.body.chip).toEqual(expect.objectContaining({ key: 'ambisiøs', icon: '✍️' }));
+    expect(res.body.basis).toEqual(expect.arrayContaining(['mode:requested=6', 'mode:effective=4']));
     expect(res.body.subscription.plan).toBe('flex');
     const events = getRecentProactivityEvents(1);
     expect(events[0].tenantId).toBe('TENANT');
@@ -40,6 +43,7 @@ describe('GET /api/proactivity/state', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.effective).toBe(ProactivityMode.Kraken);
-    expect(Array.isArray(res.body.basis)).toBe(true);
+    expect(res.body.uiHints.surface).toBe('backstage');
+    expect(res.body.basis).toEqual(expect.arrayContaining(['mode:requested=5', 'mode:effective=5']));
   });
 });

--- a/tests/proactivity/runner-paths.test.ts
+++ b/tests/proactivity/runner-paths.test.ts
@@ -60,6 +60,6 @@ describe('runCapabilityWithRole', () => {
     }
     expect(result.proactivity.effective).toBeLessThanOrEqual(mode);
     const logEvent = (logIntent.mock.calls[0] || [])[0];
-    expect(logEvent?.proactivity?.basis?.some((entry: string) => entry.startsWith('requested:'))).toBe(true);
+    expect(logEvent?.proactivity?.basis?.some((entry: string) => entry.startsWith('mode:requested='))).toBe(true);
   });
 });

--- a/tests/proactivity/state-resolver.test.ts
+++ b/tests/proactivity/state-resolver.test.ts
@@ -12,9 +12,12 @@ describe('proactivity state resolver', () => {
     });
     expect(res.effective).toBe(ProactivityMode.Proaktiv);
     expect(res.basis).toEqual(expect.arrayContaining([
-      'requested:tsunami',
-      'cap:subscription:flex:ambisiøs',
-      'cap:role:feature:proaktiv',
+      'mode:requested=6',
+      'mode:effective=3',
+      'tenantPlan:flex',
+      'roleCap:feature=3',
+      'degraded:subscription',
+      'degraded:role:feature',
     ]));
   });
 
@@ -25,7 +28,7 @@ describe('proactivity state resolver', () => {
       caps: [{ id: 'subscription:enterprise', mode: ProactivityMode.Tsunami }],
     });
     expect(res.effective).toBe(ProactivityMode.Usynlig);
-    expect(res.basis).toContain('cap:killswitch');
+    expect(res.basis).toEqual(expect.arrayContaining(['kill', 'degraded:kill', 'mode:effective=1']));
   });
 
   it('degrades along rail when error occurs', () => {

--- a/tests/proactivity/ui-hints.test.ts
+++ b/tests/proactivity/ui-hints.test.ts
@@ -1,0 +1,33 @@
+import { buildProactivityContext } from '../../src/core/proactivity/context';
+import { ProactivityMode } from '../../src/core/proactivity/modes';
+import { resetSubscriptionState, setSubscriptionForTenant } from '../../src/core/subscription/state';
+
+describe('proactivity ui hints and chip', () => {
+  beforeEach(() => {
+    resetSubscriptionState();
+  });
+
+  it('exposes chip metadata for effective mode', () => {
+    setSubscriptionForTenant('ENT', { plan: 'enterprise' });
+    const state = buildProactivityContext({ tenantId: 'ENT', requestedMode: ProactivityMode.Tsunami });
+    expect(state.effective).toBe(ProactivityMode.Tsunami);
+    expect(state.uiHints.surface).toBe('dom-overlay');
+    expect(state.chip).toEqual(expect.objectContaining({ key: 'tsunami', icon: '🌊' }));
+  });
+
+  it('maps compat header values to modern modes', () => {
+    setSubscriptionForTenant('COMP', { plan: 'enterprise' });
+    const state = buildProactivityContext({ tenantId: 'COMP', compatMode: 2 });
+    expect(state.requested).toBe(ProactivityMode.Ambisiøs);
+    expect(state.effective).toBe(ProactivityMode.Ambisiøs);
+    expect(state.uiHints.surface).toBe('draft');
+  });
+
+  it('degrades ui hints when plan caps apply', () => {
+    setSubscriptionForTenant('FLEX', { plan: 'flex' });
+    const state = buildProactivityContext({ tenantId: 'FLEX', requestedMode: ProactivityMode.Tsunami });
+    expect(state.effective).toBe(ProactivityMode.Ambisiøs);
+    expect(state.uiHints.surface).toBe('draft');
+    expect(state.chip.icon).toBe('✍️');
+  });
+});

--- a/tests/proposals/flow.test.ts
+++ b/tests/proposals/flow.test.ts
@@ -1,0 +1,129 @@
+import request from 'supertest';
+import app from '../../src/server';
+import { resetSubscriptionState, setSubscriptionForTenant } from '../../src/core/subscription/state';
+import { resetProposalsRepository } from '../../src/core/proposals/repository';
+import { registerCapability } from '../../src/capabilities/registry';
+import {
+  resetConnectorCallRepository,
+  getConnectorCallRepository,
+} from '../../src/connectors/internal/callsRepository';
+import { resetConnectorCircuits } from '../../src/connectors/internal/circuitRegistry';
+
+describe('proposal approval flow', () => {
+  beforeEach(() => {
+    resetSubscriptionState();
+    resetProposalsRepository();
+    resetConnectorCallRepository();
+    resetConnectorCircuits();
+  });
+
+  it('creates proposal in mode 4 and executes on approval', async () => {
+    setSubscriptionForTenant('DEV', { plan: 'enterprise' });
+
+    const prepareRes = await request(app)
+      .post('/api/dev/run')
+      .set('x-tenant', 'DEV')
+      .set('x-user', 'approver')
+      .set('x-role', 'sales_rep')
+      .set('x-proactivity', 'ambisiøs')
+      .send({ capability: 'crm.lead.route', payload: {} });
+
+    expect(prepareRes.status).toBe(200);
+    expect(prepareRes.body.proposal).toBeDefined();
+    const proposalId = prepareRes.body.proposal.id;
+    expect(prepareRes.body.proposal.preview).toBeDefined();
+    expect(prepareRes.body.proposal.status).toBe('proposed');
+
+    const approveRes = await request(app)
+      .post(`/api/proposals/${proposalId}/approve`)
+      .set('x-tenant', 'DEV')
+      .set('x-user', 'approver')
+      .set('x-role', 'sales_rep')
+      .set('x-proactivity', 'kraken');
+
+    expect(approveRes.status).toBe(200);
+    expect(approveRes.body.proposal.status).toBe('executed');
+    expect(approveRes.body.outcome).toEqual(expect.objectContaining({ routed: true }));
+    expect(typeof approveRes.body.idempotencyKey).toBe('string');
+  });
+
+  it('rejects proposal without executing capability', async () => {
+    setSubscriptionForTenant('TEN', { plan: 'enterprise' });
+
+    const createRes = await request(app)
+      .post('/api/proposals')
+      .set('x-tenant', 'TEN')
+      .set('x-user', 'reviewer')
+      .set('x-role', 'sales_rep')
+      .set('x-proactivity', 'ambisiøs')
+      .send({ capabilityId: 'finance.invoice.prepareDraft', payload: { dealId: 'D-1' } });
+
+    expect(createRes.status).toBe(201);
+    const proposalId = createRes.body.proposal.id;
+
+    const rejectRes = await request(app)
+      .post(`/api/proposals/${proposalId}/reject`)
+      .set('x-tenant', 'TEN')
+      .set('x-user', 'reviewer')
+      .set('x-role', 'sales_rep')
+      .set('x-proactivity', 'ambisiøs')
+      .send({ reason: 'Needs clarification' });
+
+    expect(rejectRes.status).toBe(200);
+    expect(rejectRes.body.proposal.status).toBe('rejected');
+  });
+
+  it('re-approves a failed proposal with a fresh idempotency key', async () => {
+    setSubscriptionForTenant('RETRY', { plan: 'enterprise' });
+    let attempts = 0;
+    registerCapability('test.fail.once', {
+      execute: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          const error: any = new Error('transient_failure');
+          error.statusCode = 500;
+          throw error;
+        }
+        return { ok: true, attempts };
+      },
+    });
+
+    const createRes = await request(app)
+      .post('/api/proposals')
+      .set('x-tenant', 'RETRY')
+      .set('x-user', 'agent')
+      .set('x-role', 'sales_rep')
+      .set('x-proactivity', 'ambisiøs')
+      .send({ capabilityId: 'test.fail.once', payload: { foo: 'bar' } });
+
+    expect(createRes.status).toBe(201);
+    const proposalId = createRes.body.proposal.id;
+    const originalKey = createRes.body.proposal.idempotencyKey;
+
+    const firstApprove = await request(app)
+      .post(`/api/proposals/${proposalId}/approve`)
+      .set('x-tenant', 'RETRY')
+      .set('x-user', 'agent')
+      .set('x-role', 'sales_rep')
+      .set('x-proactivity', 'kraken');
+
+    expect(firstApprove.status).toBe(500);
+    expect(firstApprove.body.proposal.status).toBe('failed');
+
+    const secondApprove = await request(app)
+      .post(`/api/proposals/${proposalId}/approve`)
+      .set('x-tenant', 'RETRY')
+      .set('x-user', 'agent')
+      .set('x-role', 'sales_rep')
+      .set('x-proactivity', 'kraken');
+
+    expect(secondApprove.status).toBe(200);
+    expect(secondApprove.body.proposal.status).toBe('executed');
+    expect(secondApprove.body.idempotencyKey).not.toBe(originalKey);
+    const repo = getConnectorCallRepository();
+    const failedCall = await repo.find(originalKey);
+    expect(failedCall?.status).toBe('failed');
+    const retriedCall = await repo.find(secondApprove.body.idempotencyKey);
+    expect(retriedCall?.status).toBe('success');
+  });
+});


### PR DESCRIPTION
## Summary
### Detected-as-present / skipped
- Proactivity core (context resolver, telemetry, policy integration) and runner wiring were already merged; kept existing structure and extended in-place.
- Connector execution scaffolding, capability registry wiring, and docs/tests from prior iteration were intact; resumed from partially updated OpenAPI spec.

### Added / changed files
- Finalized proposal repository/service plumbing and approval routes, including idempotency key overrides on re-approval and enriched basis propagation.
- Completed connector execution idempotency + retry/backoff + DLQ + circuit breaker support with health routes and repository shims.
- Extended policy guards, proactivity mode metadata, compat mapping, and UI hint outputs, with dedicated guard/unit/flow tests.
- Finished OpenAPI (`openapi/proactivity.yaml`) and docs (`docs/proactivity.md`, `docs/CONNECTORS.md`, `docs/api.md`) to document proposals, guards, connectors, and UI hints.
- Added Jest coverage for proposals, connectors, policy guards, and UI hints; ensured repositories/circuits reset between tests.

### Compat shim mapping (0–3 ➜ 1–6)
- `0` / `1` ⇒ `3 (proaktiv)`
- `2` ⇒ `4 (ambisiøs)`
- `3` ⇒ `5 (kraken)`

### Proposal flow sequence
1. `prepare` under mode 4 produces preview, persists `proposal` (`status=proposed`, `basis`, `idempotencyKey`) and emits `proposal.created`.
2. `POST /api/proposals` supports manual creation (idempotency header optional).
3. `POST /api/proposals/{id}/approve` (≥5 Kraken) marks `approved`, executes with connector safeguards, then stores `executed`/`failed` and emits lifecycle events; failed approvals can re-run with fresh key.
4. `POST /api/proposals/{id}/reject` transitions to `rejected` without execution.
5. `GET /api/proposals` lists by status for UI review.

### Idempotency / retry / breaker semantics
- Connector executions persist `connector_calls` keyed by `Idempotency-Key`; repeated success returns cached response.
- Exponential backoff (`base=250ms` default) with jitter, respecting `Retry-After`; stop after `maxRetries=5` unless overriding.
- After exhaustion, mark `failed` and emit `eventbus.dlq` with context.
- Circuit breaker per connector: opens on threshold failures within sliding window, half-open after cooldown, closes on success; health exposed via `/api/connectors/{name}/health` and aggregate list.

### Guard matrix (minimum effective mode)
- `simulate` ≥ 2 (Rolig)
- `prepare` ≥ 4 (Ambisiøs)
- `approve/reject proposal`, `execute` ≥ 5 (Kraken for approval, 4 for rejection/create)
- `overlay` ≥ 6 (Tsunami)

### OpenAPI & docs
- Added proposal + connector health paths to `openapi/proactivity.yaml`, plus schemas for state chips/uiHints.
- Updated docs: `docs/proactivity.md` (approval flow, basis), `docs/CONNECTORS.md` (idempotency/retry/DLQ/breaker), `docs/api.md` (curl samples).

### Acceptance checks
- `npm test` (backend Jest suite – proposals, connectors, policy guard, proactivity UI hint coverage).

### Curl examples
```bash
# Resolve proactivity state with compat header
curl -H "x-tenant: TENANT" -H "x-user: user" -H "x-role: sales_rep" \
     -H "x-proactivity-compat: 2" https://api.workbuoy.local/api/proactivity/state

# Approve a proposal (Kraken guard)
curl -X POST -H "x-tenant: TENANT" -H "x-user: approver" -H "x-role: manager" \
     -H "x-proactivity: kraken" -H "Idempotency-Key: proposal-123" \
     https://api.workbuoy.local/api/proposals/PROPOSAL_ID/approve
```

------
https://chatgpt.com/codex/tasks/task_e_68cee0d0ebb4832a8c2ef43b1382d03d