### PR TITLE
DB persistence for roles & usage + caps integration (proactivity-aware, gap fill)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -45,4 +45,6 @@ jobs:
           npm test -- \
             tests/features/active.api.test.ts \
             tests/usage/usage.api.test.ts \
+            tests/admin/roles.api.test.ts \
+            tests/admin/subscription.api.test.ts \
             --runInBand --passWithNoTests

--- a/.github/workflows/ci
+++ b/.github/workflows/ci
@@ -7,6 +7,17 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: workbuoy
+          POSTGRES_PASSWORD: workbuoy
+          POSTGRES_DB: workbuoy
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U workbuoy" --health-interval 5s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
         node-version: [18.x, 20.x]
@@ -23,6 +34,11 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Run Prisma migrations
+        env:
+          DATABASE_URL: postgresql://workbuoy:workbuoy@localhost:5432/workbuoy
+        run: npx prisma migrate deploy --schema=prisma/schema.prisma
+
       - name: Lint (if present)
         run: npm run lint --if-present
 
@@ -32,7 +48,20 @@ jobs:
       - name: Test with coverage
         env:
           TEST_CORRELATION: "1"
+          DATABASE_URL: postgresql://workbuoy:workbuoy@localhost:5432/workbuoy
         run: npm test -- --coverage --runInBand
+
+      - name: Persistence smoke suite
+        env:
+          FF_PERSISTENCE: 'true'
+          DATABASE_URL: postgresql://workbuoy:workbuoy@localhost:5432/workbuoy
+        run: npm test -- --runTestsByPath \
+          tests/roles/db.registry.test.ts \
+          tests/usage/db.usage.test.ts \
+          tests/features/active.db.test.ts \
+          tests/admin/roles.api.test.ts \
+          tests/admin/subscription.api.test.ts \
+          --runInBand --passWithNoTests
 
       - name: Upload coverage
         if: always()

--- a/backend/jest.meta.config.cjs
+++ b/backend/jest.meta.config.cjs
@@ -7,6 +7,12 @@ module.exports = {
     '<rootDir>/tests/eventBus.stats.shape.test.ts',
     '<rootDir>/tests/mvp.crm-baseline.test.ts',
     '<rootDir>/../tests/meta/**/*.test.ts',
-    '<rootDir>/../tests/policy/**/*.test.ts'
+    '<rootDir>/../tests/policy/**/*.test.ts',
+    '<rootDir>/../tests/features/**/*.test.ts',
+    '<rootDir>/../tests/proactivity/**/*.test.ts',
+    '<rootDir>/../tests/roles/**/*.test.ts',
+    '<rootDir>/../tests/usage/**/*.test.ts',
+    '<rootDir>/../tests/admin/**/*.test.ts',
+    '<rootDir>/../tests/subscription/**/*.test.ts'
   ],
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,12 +10,14 @@
     "start:compliance": "node dist/compliance/server.js"
   },
   "dependencies": {
+    "@prisma/client": "^5.17.0",
     "express": "^4.19.2",
     "express-rate-limit": "^6.10.0",
     "prom-client": "^15.1.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "prisma": "^5.17.0",
     "typescript": "^5.4.5",
     "ts-node": "^10.9.2",
     "@types/node": "^20.11.30",

--- a/backend/routes/admin.roles.ts
+++ b/backend/routes/admin.roles.ts
@@ -1,0 +1,59 @@
+import { Router } from 'express';
+import { importRolesAndFeatures } from '../../src/roles/seed/importer';
+import { getRoleRegistry } from '../../src/roles/registryProvider';
+import { OverrideRepo } from '../../src/roles/db/OverrideRepo';
+
+const router = Router();
+const admin = Router({ mergeParams: true });
+
+function tenantFrom(req: any) {
+  return String(req.header('x-tenant') || req.header('x-tenant-id') || req.query?.tenant || 'demo');
+}
+
+function requireAdmin(req: any, res: any, next: any) {
+  const roles = String(req.header('x-roles') || req.header('x-role') || '').split(',').map((r: string) => r.trim());
+  if (!roles.includes('admin')) {
+    return res.status(403).json({ error: 'admin_required' });
+  }
+  return next();
+}
+
+admin.post('/roles/import', async (_req, res) => {
+  const summary = await importRolesAndFeatures();
+  await getRoleRegistry(true);
+  res.json({ ok: true, summary });
+});
+
+admin.put('/roles/:roleId/overrides', async (req, res) => {
+  const tenantId = tenantFrom(req);
+  const roleId = String(req.params.roleId);
+  const { featureCaps, disabledFeatures } = req.body || {};
+  const repo = new OverrideRepo();
+  await repo.upsertOverride(tenantId, roleId, {
+    tenantId,
+    role_id: roleId,
+    featureCaps: featureCaps ?? undefined,
+    disabledFeatures: Array.isArray(disabledFeatures) ? disabledFeatures : undefined,
+  });
+  const registry = await getRoleRegistry(true);
+  const ctx = registry.getUserContext(tenantId, { userId: `admin:${tenantId}`, primaryRole: roleId });
+  res.json({ tenantId, roleId, featureCaps: ctx.featureCaps, features: ctx.features });
+});
+
+admin.get('/roles/:roleId', async (req, res) => {
+  const tenantId = tenantFrom(req);
+  const roleId = String(req.params.roleId);
+  const registry = await getRoleRegistry();
+  const ctx = registry.getUserContext(tenantId, { userId: `admin:${tenantId}`, primaryRole: roleId });
+  if (!ctx.roles.length) {
+    return res.status(404).json({ error: 'role_not_found', roleId });
+  }
+  const repo = new OverrideRepo();
+  const overrides = await repo.listOverridesForTenant(tenantId);
+  const override = overrides.find(o => o.role_id === roleId) ?? null;
+  res.json({ tenantId, roleId, roles: ctx.roles, featureCaps: ctx.featureCaps, override, features: ctx.features });
+});
+
+router.use('/admin', requireAdmin, admin);
+
+export default router;

--- a/backend/routes/dev.runner.ts
+++ b/backend/routes/dev.runner.ts
@@ -1,12 +1,10 @@
 import { Router } from 'express';
-import { RoleRegistry } from '../../src/roles/registry';
-import { loadRolesFromRepo, loadFeaturesFromRepo } from '../../src/roles/loader';
+import { getRoleRegistry, resolveUserBinding } from '../../src/roles/registryProvider';
 import { runCapabilityWithRole } from '../../src/core/capabilityRunnerRole';
 import { testCaps } from '../../src/capabilities/testCaps';
 import { parseProactivityMode } from '../../src/core/proactivity/modes';
 
 const router: any = Router();
-const rr = new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
 
 async function policyAllowAlways() { return { allowed: true, basis: ['dev:allow'] }; }
 async function logIntent(event: any) { console.log('[intent]', JSON.stringify(event)); }
@@ -25,22 +23,31 @@ router.post('/dev/run', async (req: any, res: any) => {
   const role = String(req.header('x-role') ?? 'sales_rep');
   const requestedHeader = req.header('x-proactivity');
 
-  const result = await runCapabilityWithRole(
-    rr,
-    capability,
-    featureId,
-    payload,
-    {
-      tenantId,
-      roleBinding: { userId, primaryRole: role },
-      requestedMode: parseProactivityMode(requestedHeader ?? req.body?.mode),
-    },
-    impl,
-    policyAllowAlways,
-    logIntent
-  );
+  try {
+    const [registry, binding] = await Promise.all([
+      getRoleRegistry(),
+      resolveUserBinding(userId, role),
+    ]);
 
-  res.json(result);
+    const result = await runCapabilityWithRole(
+      registry,
+      capability,
+      featureId,
+      payload,
+      {
+        tenantId,
+        roleBinding: binding,
+        requestedMode: parseProactivityMode(requestedHeader ?? req.body?.mode),
+      },
+      impl,
+      policyAllowAlways,
+      logIntent
+    );
+
+    res.json(result);
+  } catch (err: any) {
+    res.status(500).json({ error: 'dev_runner_failed', message: err?.message || String(err) });
+  }
 });
 
 export default router;

--- a/backend/routes/usage.ts
+++ b/backend/routes/usage.ts
@@ -1,16 +1,36 @@
 import { Router } from 'express';
 import { recordFeatureUsage, aggregateFeatureUseCount } from '../../src/telemetry/usageSignals';
+import { persistenceEnabled } from '../../src/core/config/dbFlag';
+
 const r = Router();
 
-r.post('/api/usage/feature', (req,res)=>{
-  const { userId, featureId, action } = req.body||{};
-  if (!userId || !featureId || !action) return res.status(400).json({ error: 'Missing userId/featureId/action' });
-  recordFeatureUsage({ userId, featureId, action, ts: new Date().toISOString() });
-  res.json({ ok: true });
+r.post('/usage/feature', async (req, res) => {
+  const { userId, featureId, action, ts, metadata } = req.body || {};
+  const tenantId = String(req.header('x-tenant') ?? req.header('x-tenant-id') ?? req.body?.tenantId ?? 'DEV');
+
+  if (!userId || !featureId || !action) {
+    return res.status(400).json({ error: 'Missing userId/featureId/action' });
+  }
+
+  try {
+    await recordFeatureUsage({ userId, featureId, action, ts, metadata, tenantId });
+    return res.json({ ok: true, mode: persistenceEnabled() ? 'db' : 'memory' });
+  } catch (err: any) {
+    return res.status(500).json({ error: 'usage_record_failed', message: err?.message || String(err) });
+  }
 });
 
-r.get('/api/usage/aggregate/:userId', (req,res)=>{
-  res.json(aggregateFeatureUseCount(String(req.params.userId)));
+r.get('/usage/aggregate/:userId', async (req, res) => {
+  const tenantId = String(req.header('x-tenant') ?? req.header('x-tenant-id') ?? 'DEV');
+  try {
+    const counts = await aggregateFeatureUseCount(String(req.params.userId), tenantId);
+    if (!Object.keys(counts).length && !persistenceEnabled()) {
+      return res.status(204).end();
+    }
+    return res.json({ tenantId, counts });
+  } catch (err: any) {
+    return res.status(500).json({ error: 'usage_aggregate_failed', message: err?.message || String(err) });
+  }
 });
 
 export default r;

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,5 +6,29 @@
 - Buoy: `openapi/buoy.yaml`
 - Manual: `openapi/manual.yaml`
 - Proactivity: `openapi/proactivity.yaml`
+- Core (roles/usage/admin): `openapi/openapi.yaml`
 
 CI runs Spectral (non-blocking) over all specs.
+
+## New endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/features/active` | Ranked feature activation list (requires `x-tenant`, `x-user`, `x-role`). |
+| POST | `/api/usage/feature` | Record feature usage events (`open`, `complete`, `dismiss`). |
+| GET | `/api/usage/aggregate/{userId}` | Aggregate usage counts per feature for a user. |
+| POST | `/api/admin/roles/import` | Seed roles/features from `roles/roles.json`. Requires admin header. |
+| PUT | `/api/admin/roles/{roleId}/overrides` | Upsert tenant overrides (caps / disabled). |
+| GET | `/api/admin/roles/{roleId}` | Inspect merged role caps for a tenant. |
+| GET/PUT | `/api/admin/subscription` | Inspect or update plan, kill switch, secure flags and overrides. |
+
+Example import call:
+
+```bash
+curl -X POST \
+  -H 'x-tenant: TENANT' \
+  -H 'x-roles: admin' \
+  http://localhost:3000/api/admin/roles/import
+```
+
+The OpenAPI spec now documents request/response schemas for the new routes so tooling (SDK generation, contract tests) stays in sync.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,45 @@
+# Role persistence & registry
+
+Workbuoy now stores the role catalogue, feature catalogue and tenant overrides in Postgres via Prisma. The tables are seeded from `roles/roles.json` and the built-in feature seed (`src/roles/seed/features.ts`) when persistence is enabled (`FF_PERSISTENCE=true`).
+
+## Data model
+
+| Table                | Purpose                                           |
+|----------------------|---------------------------------------------------|
+| `Role`               | Canonical role definitions + inheritance + caps.  |
+| `Feature`            | Feature catalogue (id, title, default autonomy).  |
+| `OrgRoleOverride`    | Tenant-level overrides & disabled feature lists.  |
+| `UserRole`           | Persisted user ⇄ role bindings.                   |
+
+Tenant overrides win over the canonical definition: overrides can set new caps or mark features as disabled (`0`). The `RoleRegistry` reads roles, features and overrides from the database, merges them and exposes feature caps to proactivity and capability runners.
+
+## Seeding from JSON
+
+Run the seed helper after configuring `DATABASE_URL` and enabling persistence:
+
+```bash
+FF_PERSISTENCE=true npx ts-node scripts/seed-roles-from-json.ts
+```
+
+The script is idempotent (it upserts definitions). The `/api/admin/roles/import` endpoint uses the same helper so operators can reseed from CI or a control plane.
+
+## Tenant overrides
+
+Use the admin API to manage overrides:
+
+```bash
+curl -X PUT \
+  -H 'x-tenant: TENANT' \
+  -H 'x-roles: admin' \
+  -H 'content-type: application/json' \
+  http://localhost:3000/api/admin/roles/sales-junior-account-executive/overrides \
+  -d '{"featureCaps":{"cashflow_forecast":5},"disabledFeatures":["contract_compliance"]}'
+```
+
+Fetching `GET /api/admin/roles/:roleId` shows the merged caps (`featureCaps`), the raw override stored in Postgres and the feature list that will be exposed to capability runners.
+
+## User bindings
+
+`resolveUserBinding` persists fallback bindings when a request provides `x-user` and `x-role`. That means the first call seeds the `UserRole` table; subsequent calls reuse the stored binding. This keeps proactivity context, feature activation and policy guards consistent across requests and background workers.
+
+When `FF_PERSISTENCE=false` the registry falls back to the in-repo JSON loader and in-memory overrides so existing in-memory behaviour remains unchanged.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,23 @@
+# Usage signals
+
+Usage telemetry for features is persisted in Postgres when `FF_PERSISTENCE=true`. Each event in the `FeatureUsage` table captures the tenant, user, feature id, action (`open | complete | dismiss`) and timestamp. In-memory storage is retained for `FF_PERSISTENCE=false` to keep local dev lightweight.
+
+## Recording events
+
+POST `/api/usage/feature` accepts JSON:
+
+```json
+{
+  "userId": "u-123",
+  "featureId": "cashflow_forecast",
+  "action": "open"
+}
+```
+
+The handler normalises the payload, attaches the tenant from `x-tenant` and writes it to the database (or in-memory store when persistence is disabled).
+
+## Aggregation
+
+GET `/api/usage/aggregate/:userId` returns aggregate counts per feature for the requested user (scoped to the tenant header). Aggregation uses a Postgres `GROUP BY` when persistence is enabled. In-memory mode still returns the computed counts if any events were recorded during the process lifetime.
+
+These aggregates feed the feature activation service so the `/api/features/active` endpoint can rank features by autonomy cap, usage intensity and tenant context.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -185,6 +185,157 @@ paths:
         '400': { $ref: '#/components/responses/BadRequest' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
+  /api/features/active:
+    get:
+      summary: List active features for a user
+      tags: [Features]
+      parameters:
+        - in: header
+          name: x-tenant
+          schema: { type: string }
+          required: false
+          description: Tenant identifier (defaults to DEV)
+        - in: header
+          name: x-user
+          schema: { type: string }
+          required: false
+          description: User identifier (defaults to dev-user)
+        - in: header
+          name: x-role
+          schema: { type: string }
+          required: false
+          description: Role binding (persisted when persistence is enabled)
+      responses:
+        '200':
+          description: Feature activation list
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FeatureActivationResponse' }
+        '204': { description: No content (in-memory fallback) }
+
+  /api/usage/feature:
+    post:
+      summary: Record feature usage event
+      tags: [Usage]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FeatureUsageEvent' }
+      responses:
+        '200':
+          description: Acknowledged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  mode: { type: string, enum: [db, memory] }
+        '400': { $ref: '#/components/responses/BadRequest' }
+
+  /api/usage/aggregate/{userId}:
+    get:
+      summary: Aggregate usage counts by feature
+      tags: [Usage]
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema: { type: string }
+        - in: header
+          name: x-tenant
+          required: false
+          schema: { type: string }
+          description: Tenant identifier (defaults to DEV)
+      responses:
+        '200':
+          description: Usage counts per feature
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FeatureUsageAggregate' }
+        '204': { description: No events recorded }
+
+  /api/admin/roles/import:
+    post:
+      summary: Import role + feature catalogue from repository seed
+      tags: [Admin]
+      responses:
+        '200':
+          description: Import summary
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RoleImportResponse' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/roles/{roleId}/overrides:
+    put:
+      summary: Upsert tenant overrides for a role
+      tags: [Admin]
+      parameters:
+        - in: path
+          name: roleId
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/RoleOverrideRequest' }
+      responses:
+        '200':
+          description: Updated feature caps for the tenant/role
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RoleOverrideResponse' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/roles/{roleId}:
+    get:
+      summary: Inspect effective caps for a role within a tenant
+      tags: [Admin]
+      parameters:
+        - in: path
+          name: roleId
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Effective caps and overrides
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RoleDetailResponse' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/admin/subscription:
+    get:
+      summary: Inspect subscription plan/caps for a tenant
+      tags: [Admin]
+      responses:
+        '200':
+          description: Subscription settings
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SubscriptionResponse' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    put:
+      summary: Update subscription plan or tenant flags
+      tags: [Admin]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SubscriptionUpdateRequest' }
+      responses:
+        '200':
+          description: Updated subscription summary
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SubscriptionResponse' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
 components:
   schemas:
     Explanation:
@@ -260,6 +411,126 @@ components:
         level: { type: string, enum: [info, warn, error], default: info }
         msg: { type: string }
         meta: { type: object }
+
+    FeatureActivationItem:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        capabilities:
+          type: array
+          items: { type: string }
+        autonomyCap: { type: integer, minimum: 0, maximum: 6 }
+        usageCount: { type: integer, minimum: 0 }
+        score: { type: number }
+        basis:
+          type: array
+          items: { type: string }
+
+    FeatureActivationResponse:
+      type: object
+      properties:
+        tenantId: { type: string }
+        userId: { type: string }
+        features:
+          type: array
+          items: { $ref: '#/components/schemas/FeatureActivationItem' }
+
+    FeatureUsageEvent:
+      type: object
+      required: [userId, featureId, action]
+      properties:
+        userId: { type: string }
+        featureId: { type: string }
+        action: { type: string, enum: [open, complete, dismiss] }
+        ts: { type: string, format: date-time }
+
+    FeatureUsageAggregate:
+      type: object
+      properties:
+        tenantId: { type: string }
+        counts:
+          type: object
+          additionalProperties: { type: integer, minimum: 0 }
+
+    RoleImportResponse:
+      type: object
+      properties:
+        ok: { type: boolean }
+        summary:
+          type: object
+          properties:
+            roles: { type: integer }
+            features: { type: integer }
+
+    RoleOverrideRequest:
+      type: object
+      properties:
+        featureCaps:
+          type: object
+          additionalProperties: { type: integer, minimum: 0, maximum: 6 }
+        disabledFeatures:
+          type: array
+          items: { type: string }
+
+    RoleOverrideResponse:
+      type: object
+      properties:
+        tenantId: { type: string }
+        roleId: { type: string }
+        featureCaps:
+          type: object
+          additionalProperties: { type: integer, minimum: 0, maximum: 6 }
+        features:
+          type: array
+          items: { $ref: '#/components/schemas/FeatureActivationItem' }
+
+    RoleDetailResponse:
+      type: object
+      properties:
+        tenantId: { type: string }
+        roleId: { type: string }
+        roles:
+          type: array
+          items: { type: object }
+        featureCaps:
+          type: object
+          additionalProperties: { type: integer, minimum: 0, maximum: 6 }
+        override:
+          type: object
+          nullable: true
+          properties:
+            featureCaps:
+              type: object
+              additionalProperties: { type: integer, minimum: 0, maximum: 6 }
+            disabledFeatures:
+              type: array
+              items: { type: string }
+        features:
+          type: array
+          items: { $ref: '#/components/schemas/FeatureActivationItem' }
+
+    SubscriptionResponse:
+      type: object
+      properties:
+        tenantId: { type: string }
+        plan: { type: string, enum: [flex, secure, enterprise] }
+        killSwitch: { type: boolean }
+        secureTenant: { type: boolean }
+        maxMode: { type: integer, minimum: 1, maximum: 6 }
+        maxOverride: { type: integer, nullable: true }
+
+    SubscriptionUpdateRequest:
+      type: object
+      properties:
+        plan: { type: string, enum: [flex, secure, enterprise] }
+        killSwitch: { type: boolean }
+        secureTenant: { type: boolean }
+        maxOverride:
+          oneOf:
+            - { type: integer, minimum: 1, maximum: 6 }
+            - { type: 'null' }
 
   responses:
     BadRequest:

--- a/prisma/migrations/20250920170000_roles_usage_persistence/migration.sql
+++ b/prisma/migrations/20250920170000_roles_usage_persistence/migration.sql
@@ -1,0 +1,100 @@
+-- CreateEnum
+CREATE TYPE "FeatureUsageAction" AS ENUM ('open', 'complete', 'dismiss');
+
+-- CreateTable
+CREATE TABLE "Role" (
+    "roleId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "inherits" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "featureCaps" JSONB,
+    "scopeHints" JSONB,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Role_pkey" PRIMARY KEY ("roleId")
+);
+
+-- CreateTable
+CREATE TABLE "Feature" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "defaultAutonomyCap" INTEGER NOT NULL DEFAULT 3,
+    "capabilities" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Feature_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrgRoleOverride" (
+    "tenantId" TEXT NOT NULL,
+    "roleId" TEXT NOT NULL,
+    "featureCaps" JSONB,
+    "disabledFeatures" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrgRoleOverride_pkey" PRIMARY KEY ("tenantId","roleId")
+);
+
+-- CreateTable
+CREATE TABLE "UserRole" (
+    "userId" TEXT NOT NULL,
+    "primaryRole" TEXT NOT NULL,
+    "secondaryRoles" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserRole_pkey" PRIMARY KEY ("userId")
+);
+
+-- CreateTable
+CREATE TABLE "FeatureUsage" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT,
+    "userId" TEXT NOT NULL,
+    "featureId" TEXT NOT NULL,
+    "action" "FeatureUsageAction" NOT NULL,
+    "ts" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FeatureUsage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SubscriptionSetting" (
+    "tenantId" TEXT NOT NULL,
+    "plan" TEXT NOT NULL DEFAULT 'flex',
+    "killSwitch" BOOLEAN NOT NULL DEFAULT false,
+    "secureTenant" BOOLEAN NOT NULL DEFAULT false,
+    "maxOverride" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubscriptionSetting_pkey" PRIMARY KEY ("tenantId")
+);
+
+-- CreateIndex
+CREATE INDEX "Role_title_idx" ON "Role"("title");
+
+-- CreateIndex
+CREATE INDEX "OrgRoleOverride_tenantId_idx" ON "OrgRoleOverride"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "UserRole_primaryRole_idx" ON "UserRole"("primaryRole");
+
+-- CreateIndex
+CREATE INDEX "FeatureUsage_userId_idx" ON "FeatureUsage"("userId");
+
+-- CreateIndex
+CREATE INDEX "FeatureUsage_featureId_idx" ON "FeatureUsage"("featureId");
+
+-- CreateIndex
+CREATE INDEX "FeatureUsage_tenantId_userId_idx" ON "FeatureUsage"("tenantId", "userId");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,12 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum FeatureUsageAction {
+  open
+  complete
+  dismiss
+}
+
 model Contact {
   id        String   @id @default(uuid())
   name      String
@@ -42,4 +48,76 @@ model AuditChain {
   id        String   @id @default(uuid())
   createdAt DateTime @default(now())
   headHash  String?
+}
+
+model Role {
+  roleId       String   @id
+  title        String
+  inherits     String[] @default([])
+  featureCaps  Json?
+  scopeHints   Json?
+  metadata     Json?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([title])
+}
+
+model Feature {
+  id                  String   @id
+  title               String
+  description         String?
+  defaultAutonomyCap  Int      @default(3)
+  capabilities        String[] @default([])
+  metadata            Json?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+}
+
+model OrgRoleOverride {
+  tenantId         String
+  roleId           String
+  featureCaps      Json?
+  disabledFeatures String[] @default([])
+  notes            String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@id([tenantId, roleId])
+  @@index([tenantId])
+}
+
+model UserRole {
+  userId          String   @id
+  primaryRole     String
+  secondaryRoles  String[] @default([])
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([primaryRole])
+}
+
+model FeatureUsage {
+  id        String              @id @default(uuid())
+  tenantId  String?
+  userId    String
+  featureId String
+  action    FeatureUsageAction
+  ts        DateTime            @default(now())
+  metadata  Json?
+  createdAt DateTime            @default(now())
+
+  @@index([userId])
+  @@index([featureId])
+  @@index([tenantId, userId])
+}
+
+model SubscriptionSetting {
+  tenantId     String   @id
+  plan         String   @default("flex")
+  killSwitch   Boolean  @default(false)
+  secureTenant Boolean  @default(false)
+  maxOverride  Int?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 }

--- a/scripts/seed-roles-from-json.ts
+++ b/scripts/seed-roles-from-json.ts
@@ -1,0 +1,14 @@
+import { importRolesAndFeatures } from '../src/roles/seed/importer';
+
+async function main() {
+  try {
+    const summary = await importRolesAndFeatures();
+    console.log(`[seed] imported ${summary.roles} roles, ${summary.features} features`);
+    process.exit(0);
+  } catch (err: any) {
+    console.error('[seed] failed to import roles', err?.message || err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/core/config/dbFlag.ts
+++ b/src/core/config/dbFlag.ts
@@ -1,7 +1,18 @@
 /**
  * DB feature flag.
- * If DB_ENABLED !== "true", controllers should use in-memory stores.
+ * If FF_PERSISTENCE !== "true", controllers should use in-memory stores.
  */
+const truthyValues = new Set(['true', '1', 'yes']);
+
+export function persistenceEnabled(): boolean {
+  const flag = process.env.FF_PERSISTENCE ?? process.env.DB_ENABLED ?? '';
+  return truthyValues.has(String(flag).toLowerCase());
+}
+
 export function dbEnabled(): boolean {
-  return process.env.DB_ENABLED === "true";
+  return persistenceEnabled();
+}
+
+export function persistenceMode(): 'db' | 'memory' {
+  return persistenceEnabled() ? 'db' : 'memory';
 }

--- a/src/core/policyRoleAware.ts
+++ b/src/core/policyRoleAware.ts
@@ -2,6 +2,7 @@ import { RoleRegistry } from '../roles/registry';
 import type { UserRoleBinding } from '../roles/types';
 import { buildProactivityContext, ProactivityState } from './proactivity/context';
 import { ProactivityMode } from './proactivity/modes';
+import { ensureSubscriptionHydrated } from './subscription/state';
 
 export interface RoleAwareContext {
   tenantId: string;
@@ -26,6 +27,7 @@ export async function policyCheckRoleAware(
   const userCtx = rr.getUserContext(ctx.tenantId, ctx.roleBinding);
   const featureId = base.featureId || userCtx.features.find(f => f.capabilities.includes(base.capability))?.id;
 
+  await ensureSubscriptionHydrated(ctx.tenantId);
   const proactivity = buildProactivityContext({
     tenantId: ctx.tenantId,
     roleRegistry: rr,

--- a/src/core/subscription/db/SubscriptionRepo.ts
+++ b/src/core/subscription/db/SubscriptionRepo.ts
@@ -1,0 +1,46 @@
+import { prisma as defaultClient } from '../../db/prisma';
+import type { SubscriptionSettings } from '../types';
+
+function toRecord(settings: SubscriptionSettings) {
+  return {
+    tenantId: settings.tenantId,
+    plan: settings.plan,
+    killSwitch: Boolean(settings.killSwitch),
+    secureTenant: Boolean(settings.secureTenant),
+    maxOverride: settings.maxOverride ?? null,
+  };
+}
+
+function fromRecord(row: any): SubscriptionSettings {
+  return {
+    tenantId: row.tenantId,
+    plan: row.plan,
+    killSwitch: Boolean(row.killSwitch),
+    secureTenant: Boolean(row.secureTenant),
+    maxOverride: row.maxOverride ?? undefined,
+  };
+}
+
+export class SubscriptionRepo {
+  constructor(private client: typeof defaultClient = defaultClient) {}
+
+  async get(tenantId: string): Promise<SubscriptionSettings | undefined> {
+    const row = await (this.client as any).subscriptionSetting.findUnique({ where: { tenantId } });
+    return row ? fromRecord(row) : undefined;
+  }
+
+  async upsert(settings: SubscriptionSettings): Promise<SubscriptionSettings> {
+    const data = toRecord(settings);
+    const row = await (this.client as any).subscriptionSetting.upsert({
+      where: { tenantId: data.tenantId },
+      create: data,
+      update: { ...data },
+    });
+    return fromRecord(row);
+  }
+
+  async list(): Promise<SubscriptionSettings[]> {
+    const rows = await (this.client as any).subscriptionSetting.findMany();
+    return rows.map(fromRecord);
+  }
+}

--- a/src/features/activation/featureActivation.ts
+++ b/src/features/activation/featureActivation.ts
@@ -3,17 +3,44 @@ import { RoleRegistry } from '../../roles/registry';
 export interface UserContext {
   tenantId: string;
   userId: string;
-  roleBinding: { userId:string; primaryRole:string; secondaryRoles?:string[] };
+  roleBinding: { userId: string; primaryRole: string; secondaryRoles?: string[] };
   workPatterns?: { featureUseCount: Record<string, number> };
-  orgContext?: { industry?: string; region?: string; size?: 'smb'|'mid'|'ent' };
+  orgContext?: { industry?: string; region?: string; size?: 'smb' | 'mid' | 'ent' };
 }
 
-export function getActiveFeatures(rr: RoleRegistry, uc: UserContext){
+export interface ActiveFeature {
+  id: string;
+  title: string;
+  description?: string;
+  capabilities: string[];
+  autonomyCap: number;
+  defaultAutonomyCap?: number;
+  usageCount: number;
+  score: number;
+  basis: string[];
+}
+
+export function getActiveFeatures(rr: RoleRegistry, uc: UserContext): ActiveFeature[] {
   const ctx = rr.getUserContext(uc.tenantId, uc.roleBinding);
-  return ctx.features.map((f: any) => {
-    const usage = uc.workPatterns?.featureUseCount?.[f.id] ?? 0;
-    const industryBoost = (uc.orgContext?.industry === 'finance' && f.id.includes('cashflow')) ? 1 : 0;
-    const score = (f.autonomyCap ?? 3) + usage * 0.1 + industryBoost;
-    return { ...f, score };
-  }).sort((a,b)=> b.score - a.score);
+  return ctx.features
+    .map((feature: any) => {
+      const usageCount = uc.workPatterns?.featureUseCount?.[feature.id] ?? 0;
+      const cap = ctx.featureCaps[feature.id] ?? feature.autonomyCap ?? feature.defaultAutonomyCap ?? 3;
+      const usageWeight = usageCount > 0 ? Math.log(usageCount + 1) : 0;
+      const industryBoost = uc.orgContext?.industry && feature.id.includes(uc.orgContext.industry) ? 1 : 0;
+      const score = cap + usageWeight + industryBoost;
+      const basis = [
+        `cap:${cap}`,
+        `usage:${usageCount}`,
+        ...(industryBoost ? [`boost:${uc.orgContext?.industry}`] : []),
+      ];
+      return {
+        ...feature,
+        autonomyCap: cap,
+        usageCount,
+        score,
+        basis,
+      } as ActiveFeature;
+    })
+    .sort((a, b) => b.score - a.score);
 }

--- a/src/roles/db/FeatureRepo.ts
+++ b/src/roles/db/FeatureRepo.ts
@@ -1,0 +1,73 @@
+import { prisma as defaultClient } from '../../core/db/prisma';
+import type { FeatureDef } from '../types';
+
+type FeatureRecord = {
+  id: string;
+  title: string;
+  description?: string | null;
+  defaultAutonomyCap: number;
+  capabilities: string[];
+  metadata: Record<string, any> | null;
+};
+
+function toRecord(feature: FeatureDef): FeatureRecord {
+  const { id, title, description, defaultAutonomyCap, capabilities, ...rest } = feature;
+  const metadata = rest && Object.keys(rest).length ? rest : null;
+  return {
+    id,
+    title,
+    description: description ?? null,
+    defaultAutonomyCap: defaultAutonomyCap ?? 3,
+    capabilities: capabilities ?? [],
+    metadata,
+  };
+}
+
+function fromRecord(row: any): FeatureDef {
+  const metadata = (row?.metadata as Partial<FeatureDef> | undefined) ?? {};
+  return {
+    ...metadata,
+    id: row.id,
+    title: row.title ?? metadata.title ?? row.id,
+    description: row.description ?? metadata.description,
+    defaultAutonomyCap: row.defaultAutonomyCap ?? metadata.defaultAutonomyCap ?? 3,
+    capabilities: row.capabilities ?? metadata.capabilities ?? [],
+  };
+}
+
+export class FeatureRepo {
+  constructor(private client: typeof defaultClient = defaultClient) {}
+
+  async listFeatures(): Promise<FeatureDef[]> {
+    const rows = await (this.client as any).feature.findMany({ orderBy: { id: 'asc' } });
+    return rows.map(fromRecord);
+  }
+
+  async getFeature(id: string): Promise<FeatureDef | undefined> {
+    const row = await (this.client as any).feature.findUnique({ where: { id } });
+    return row ? fromRecord(row) : undefined;
+  }
+
+  async upsertFeature(feature: FeatureDef): Promise<void> {
+    const data = toRecord(feature);
+    await (this.client as any).feature.upsert({
+      where: { id: data.id },
+      create: data,
+      update: { ...data },
+    });
+  }
+
+  async upsertMany(features: FeatureDef[]): Promise<void> {
+    if (!features.length) return;
+    await (this.client as any).$transaction(
+      features.map(feature => {
+        const data = toRecord(feature);
+        return (this.client as any).feature.upsert({
+          where: { id: data.id },
+          create: data,
+          update: { ...data },
+        });
+      })
+    );
+  }
+}

--- a/src/roles/db/OverrideRepo.ts
+++ b/src/roles/db/OverrideRepo.ts
@@ -1,0 +1,56 @@
+import { prisma as defaultClient } from '../../core/db/prisma';
+import type { OrgRoleOverride } from '../types';
+
+type OverrideRecord = {
+  tenantId: string;
+  roleId: string;
+  featureCaps: Record<string, number> | null;
+  disabledFeatures: string[];
+  notes?: string | null;
+};
+
+function toRecord(override: OrgRoleOverride): OverrideRecord {
+  return {
+    tenantId: override.tenantId,
+    roleId: override.role_id,
+    featureCaps: override.featureCaps ? { ...override.featureCaps } : null,
+    disabledFeatures: override.disabledFeatures ?? [],
+    notes: (override as any).notes ?? null,
+  };
+}
+
+function fromRecord(row: any): OrgRoleOverride {
+  return {
+    tenantId: row.tenantId,
+    role_id: row.roleId,
+    featureCaps: (row.featureCaps as Record<string, number> | undefined) ?? undefined,
+    disabledFeatures: row.disabledFeatures ?? [],
+  };
+}
+
+export class OverrideRepo {
+  constructor(private client: typeof defaultClient = defaultClient) {}
+
+  async listOverrides(): Promise<OrgRoleOverride[]> {
+    const rows = await (this.client as any).orgRoleOverride.findMany();
+    return rows.map(fromRecord);
+  }
+
+  async listOverridesForTenant(tenantId: string): Promise<OrgRoleOverride[]> {
+    const rows = await (this.client as any).orgRoleOverride.findMany({ where: { tenantId } });
+    return rows.map(fromRecord);
+  }
+
+  async upsertOverride(tenantId: string, roleId: string, override: Partial<OrgRoleOverride>): Promise<void> {
+    const data = toRecord({ tenantId, role_id: roleId, ...override });
+    await (this.client as any).orgRoleOverride.upsert({
+      where: { tenantId_roleId: { tenantId: data.tenantId, roleId: data.roleId } },
+      create: data,
+      update: { ...data },
+    });
+  }
+
+  async deleteOverride(tenantId: string, roleId: string): Promise<void> {
+    await (this.client as any).orgRoleOverride.delete({ where: { tenantId_roleId: { tenantId, roleId } } }).catch(() => {});
+  }
+}

--- a/src/roles/db/RoleRepo.ts
+++ b/src/roles/db/RoleRepo.ts
@@ -1,0 +1,75 @@
+import { prisma as defaultClient } from '../../core/db/prisma';
+import type { RoleProfile } from '../types';
+
+type RoleRecord = {
+  roleId: string;
+  title: string;
+  inherits: string[];
+  featureCaps: Record<string, number> | null;
+  scopeHints: Record<string, any> | null;
+  metadata: Record<string, any> | null;
+};
+
+function toRecord(role: RoleProfile): RoleRecord {
+  const { role_id, canonical_title, inherits, featureCaps, scopeHints, ...rest } = role;
+  const metadata = rest && Object.keys(rest).length ? rest : null;
+  return {
+    roleId: role_id,
+    title: canonical_title,
+    inherits: inherits ?? [],
+    featureCaps: featureCaps ? { ...featureCaps } : null,
+    scopeHints: scopeHints ? { ...scopeHints } : null,
+    metadata: metadata ? { ...metadata } : null,
+  };
+}
+
+function fromRecord(row: any): RoleProfile {
+  const metadata = (row?.metadata as Partial<RoleProfile> | undefined) ?? {};
+  const featureCaps = (row?.featureCaps as Record<string, number> | undefined) ?? metadata.featureCaps ?? {};
+  const scopeHints = (row?.scopeHints as Record<string, any> | undefined) ?? metadata.scopeHints;
+  return {
+    ...metadata,
+    role_id: row.roleId,
+    canonical_title: row.title ?? metadata.canonical_title ?? row.roleId,
+    inherits: row.inherits ?? metadata.inherits ?? [],
+    featureCaps: featureCaps as RoleProfile['featureCaps'],
+    scopeHints,
+  };
+}
+
+export class RoleRepo {
+  constructor(private client: typeof defaultClient = defaultClient) {}
+
+  async listRoles(): Promise<RoleProfile[]> {
+    const rows = await (this.client as any).role.findMany({ orderBy: { roleId: 'asc' } });
+    return rows.map(fromRecord);
+  }
+
+  async getRole(roleId: string): Promise<RoleProfile | undefined> {
+    const row = await (this.client as any).role.findUnique({ where: { roleId } });
+    return row ? fromRecord(row) : undefined;
+  }
+
+  async upsertRole(role: RoleProfile): Promise<void> {
+    const data = toRecord(role);
+    await (this.client as any).role.upsert({
+      where: { roleId: data.roleId },
+      create: data,
+      update: { ...data },
+    });
+  }
+
+  async upsertMany(roles: RoleProfile[]): Promise<void> {
+    if (!roles.length) return;
+    await (this.client as any).$transaction(
+      roles.map(role => {
+        const data = toRecord(role);
+        return (this.client as any).role.upsert({
+          where: { roleId: data.roleId },
+          create: data,
+          update: { ...data },
+        });
+      })
+    );
+  }
+}

--- a/src/roles/db/UserRoleRepo.ts
+++ b/src/roles/db/UserRoleRepo.ts
@@ -1,0 +1,54 @@
+import { prisma as defaultClient } from '../../core/db/prisma';
+import type { UserRoleBinding } from '../types';
+
+type UserRoleRecord = {
+  userId: string;
+  primaryRole: string;
+  secondaryRoles: string[];
+};
+
+function toRecord(binding: UserRoleBinding): UserRoleRecord {
+  return {
+    userId: binding.userId,
+    primaryRole: binding.primaryRole,
+    secondaryRoles: binding.secondaryRoles ?? [],
+  };
+}
+
+function fromRecord(row: any): UserRoleBinding {
+  return {
+    userId: row.userId,
+    primaryRole: row.primaryRole,
+    secondaryRoles: row.secondaryRoles ?? [],
+  };
+}
+
+export class UserRoleRepo {
+  constructor(private client: typeof defaultClient = defaultClient) {}
+
+  async getBinding(userId: string): Promise<UserRoleBinding | undefined> {
+    const row = await (this.client as any).userRole.findUnique({ where: { userId } });
+    return row ? fromRecord(row) : undefined;
+  }
+
+  async setBinding(binding: UserRoleBinding): Promise<void> {
+    const data = toRecord(binding);
+    await (this.client as any).userRole.upsert({
+      where: { userId: data.userId },
+      create: data,
+      update: { ...data },
+    });
+  }
+
+  async listBindingsForRole(roleId: string): Promise<UserRoleBinding[]> {
+    const rows = await (this.client as any).userRole.findMany({
+      where: {
+        OR: [
+          { primaryRole: roleId },
+          { secondaryRoles: { has: roleId } },
+        ],
+      },
+    });
+    return rows.map(fromRecord);
+  }
+}

--- a/src/roles/loader.ts
+++ b/src/roles/loader.ts
@@ -13,12 +13,98 @@ export function loadRolesFromRepo(): RoleProfile[] {
   for (const p of candidates) {
     const full = path.resolve(process.cwd(), p);
     if (fs.existsSync(full)) {
-      const raw = JSON.parse(fs.readFileSync(full, 'utf8'));
-      return raw as RoleProfile[];
+      const contents = fs.readFileSync(full, 'utf8').trim();
+      try {
+        const parsed = JSON.parse(contents);
+        return parsed as RoleProfile[];
+      } catch (err) {
+        const loose = parseLooseRoles(contents);
+        if (loose && loose.length) {
+          console.warn(`[roles.loader] parsed ${loose.length} roles from loosely formatted ${p}`);
+          return loose;
+        }
+        console.warn(`[roles.loader] failed to parse roles from ${p}: ${err instanceof Error ? err.message : err}`);
+      }
     }
   }
   console.warn('[roles.loader] roles.json not found; using empty list');
   return [];
+}
+
+function parseLooseRoles(payload: string): RoleProfile[] | null {
+  const results: RoleProfile[] = [];
+  let buffer = '';
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let failures = 0;
+
+  const pushChunk = (chunk: string) => {
+    let trimmed = chunk.trim();
+    if (!trimmed) return false;
+    if (trimmed.endsWith(',')) {
+      trimmed = trimmed.slice(0, -1).trimEnd();
+    }
+    if (trimmed.startsWith(',')) {
+      trimmed = trimmed.slice(1).trimStart();
+    }
+    if (!trimmed) return false;
+    try {
+      const value = JSON.parse(trimmed);
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          if (entry) results.push(entry as RoleProfile);
+        }
+      } else {
+        results.push(value as RoleProfile);
+      }
+      return true;
+    } catch (err) {
+      failures += 1;
+      return false;
+    }
+  };
+
+  for (const char of payload) {
+    if (!inString && depth === 0 && !char.trim()) {
+      continue;
+    }
+
+    buffer += char;
+
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (char === '\\') {
+        escape = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+    } else if (char === '{' || char === '[') {
+      depth += 1;
+    } else if (char === '}' || char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        pushChunk(buffer);
+        buffer = '';
+      }
+    }
+  }
+
+  if (buffer.trim()) {
+    pushChunk(buffer);
+  }
+
+  if (results.length && failures) {
+    console.warn(`[roles.loader] parsed ${results.length} roles with ${failures} chunk errors`);
+  }
+
+  return results.length ? results : null;
 }
 
 export function loadFeaturesFromRepo(): FeatureDef[] {

--- a/src/roles/registryProvider.ts
+++ b/src/roles/registryProvider.ts
@@ -1,0 +1,56 @@
+import { persistenceEnabled } from '../core/config/dbFlag';
+import { RoleRegistry } from './registry';
+import { loadFeaturesFromRepo, loadRolesFromRepo } from './loader';
+import type { UserRoleBinding } from './types';
+import { RoleRepo } from './db/RoleRepo';
+import { FeatureRepo } from './db/FeatureRepo';
+import { OverrideRepo } from './db/OverrideRepo';
+import { UserRoleRepo } from './db/UserRoleRepo';
+
+let cached: { registry: RoleRegistry; mode: 'db' | 'memory'; loadedAt: number } | undefined;
+const TTL_MS = 5_000;
+
+async function buildDbRegistry(): Promise<RoleRegistry> {
+  const [roles, features, overrides] = await Promise.all([
+    new RoleRepo().listRoles(),
+    new FeatureRepo().listFeatures(),
+    new OverrideRepo().listOverrides(),
+  ]);
+  return new RoleRegistry(roles, features, overrides);
+}
+
+async function buildMemoryRegistry(): Promise<RoleRegistry> {
+  return new RoleRegistry(loadRolesFromRepo(), loadFeaturesFromRepo(), []);
+}
+
+export async function getRoleRegistry(force = false): Promise<RoleRegistry> {
+  const mode: 'db' | 'memory' = persistenceEnabled() ? 'db' : 'memory';
+  const now = Date.now();
+  if (!cached || cached.mode !== mode || force || now - cached.loadedAt > TTL_MS) {
+    const registry = mode === 'db' ? await buildDbRegistry() : await buildMemoryRegistry();
+    cached = { registry, mode, loadedAt: now };
+  }
+  return cached.registry;
+}
+
+export async function resolveUserBinding(
+  userId: string,
+  fallbackRole: string,
+  secondaryRoles?: string[]
+): Promise<UserRoleBinding> {
+  if (persistenceEnabled()) {
+    const repo = new UserRoleRepo();
+    const binding = await repo.getBinding(userId);
+    if (binding) return binding;
+    const fallback = { userId, primaryRole: fallbackRole, secondaryRoles };
+    await repo.setBinding(fallback);
+    return fallback;
+  }
+  return { userId, primaryRole: fallbackRole, secondaryRoles };
+}
+
+export async function persistUserBinding(binding: UserRoleBinding): Promise<void> {
+  if (!persistenceEnabled()) return;
+  const repo = new UserRoleRepo();
+  await repo.setBinding(binding);
+}

--- a/src/roles/seed/importer.ts
+++ b/src/roles/seed/importer.ts
@@ -1,0 +1,17 @@
+import { loadRolesFromRepo, loadFeaturesFromRepo } from '../loader';
+import { RoleRepo } from '../db/RoleRepo';
+import { FeatureRepo } from '../db/FeatureRepo';
+
+export interface ImportSummary {
+  roles: number;
+  features: number;
+}
+
+export async function importRolesAndFeatures(): Promise<ImportSummary> {
+  const roles = loadRolesFromRepo();
+  const features = loadFeaturesFromRepo();
+  const roleRepo = new RoleRepo();
+  const featureRepo = new FeatureRepo();
+  await Promise.all([roleRepo.upsertMany(roles), featureRepo.upsertMany(features)]);
+  return { roles: roles.length, features: features.length };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,7 @@ function safeMount(path: string, modPath: string, factory?: string) {
 }
 
 // Feature routers (mounted only if files exist in repo)
-safeMount('/api/crm/contacts', './src/features/crm/routes', 'crmRouter');
+safeMount('/api/crm', './src/features/crm/routes', 'crmRouter');
 safeMount('/api/tasks', './src/features/tasks/routes', 'tasksRouter');
 safeMount('/api/logs', './src/features/log/routes', 'logRouter');
 safeMount('/api', './src/features/deals/deals.router');
@@ -58,7 +58,10 @@ safeMount('/api/finance', './src/routes/finance.reminder', 'financeReminderRoute
 safeMount('/api', './src/routes/manual.complete', 'manualCompleteRouter');
 safeMount('/', './src/routes/genesis.autonomy', 'metaGenesisRouter');
 safeMount('/api', '../backend/routes/proactivity');
+safeMount('/api', '../backend/routes/features');
+safeMount('/api', '../backend/routes/usage');
 safeMount('/api', '../backend/routes/admin.subscription');
+safeMount('/api', '../backend/routes/admin.roles');
 safeMount('/api', '../backend/routes/explainability');
 
 app.use('/api', knowledgeRouter);

--- a/src/telemetry/usageSignals.db.ts
+++ b/src/telemetry/usageSignals.db.ts
@@ -1,0 +1,39 @@
+import { prisma as defaultClient } from '../core/db/prisma';
+import type { FeatureUsage } from './usageSignals';
+
+type AggregationResult = Record<string, number>;
+
+function normalizeEvent(evt: FeatureUsage) {
+  return {
+    id: evt.id ?? undefined,
+    tenantId: evt.tenantId ?? null,
+    userId: evt.userId,
+    featureId: evt.featureId,
+    action: evt.action,
+    ts: new Date(evt.ts ?? new Date().toISOString()),
+    metadata: evt.metadata ?? null,
+  };
+}
+
+export async function recordFeatureUsageDb(evt: FeatureUsage, client: typeof defaultClient = defaultClient): Promise<void> {
+  const data = normalizeEvent(evt);
+  await (client as any).featureUsage.create({ data: { ...data, id: data.id ?? undefined } });
+}
+
+export async function aggregateFeatureUseCountDb(
+  userId: string,
+  tenantId?: string,
+  client: typeof defaultClient = defaultClient
+): Promise<AggregationResult> {
+  const where: Record<string, any> = { userId };
+  if (tenantId) where.tenantId = tenantId;
+  const rows = await (client as any).featureUsage.groupBy({
+    by: ['featureId'],
+    where,
+    _count: { featureId: true },
+  });
+  return rows.reduce((acc: AggregationResult, row: any) => {
+    acc[row.featureId] = Number(row._count?.featureId ?? 0);
+    return acc;
+  }, {} as AggregationResult);
+}

--- a/src/telemetry/usageSignals.ts
+++ b/src/telemetry/usageSignals.ts
@@ -1,7 +1,38 @@
-export interface FeatureUsage { userId: string; featureId: string; ts: string; action: 'open'|'complete'|'dismiss'; }
-const store: FeatureUsage[] = [];
-export function recordFeatureUsage(evt: FeatureUsage) { store.push(evt); }
-export function aggregateFeatureUseCount(userId: string) {
-  return store.filter(e=>e.userId===userId)
-    .reduce((acc,e)=>{ acc[e.featureId]=(acc[e.featureId]||0)+1; return acc; }, {} as Record<string,number>);
+import { persistenceEnabled } from '../core/config/dbFlag';
+import { aggregateFeatureUseCountDb, recordFeatureUsageDb } from './usageSignals.db';
+
+export interface FeatureUsage {
+  id?: string;
+  tenantId?: string;
+  userId: string;
+  featureId: string;
+  ts?: string;
+  action: 'open' | 'complete' | 'dismiss';
+  metadata?: Record<string, any>;
+}
+
+const memoryStore: FeatureUsage[] = [];
+
+export async function recordFeatureUsage(evt: FeatureUsage): Promise<void> {
+  if (persistenceEnabled()) {
+    await recordFeatureUsageDb(evt);
+    return;
+  }
+  memoryStore.push({ ...evt, ts: evt.ts ?? new Date().toISOString() });
+}
+
+export async function aggregateFeatureUseCount(userId: string, tenantId?: string): Promise<Record<string, number>> {
+  if (persistenceEnabled()) {
+    return aggregateFeatureUseCountDb(userId, tenantId);
+  }
+  return memoryStore
+    .filter(e => e.userId === userId && (!tenantId || e.tenantId === tenantId))
+    .reduce((acc, e) => {
+      acc[e.featureId] = (acc[e.featureId] ?? 0) + 1;
+      return acc;
+    }, {} as Record<string, number>);
+}
+
+export function resetUsageStore() {
+  memoryStore.length = 0;
 }

--- a/tests/admin/roles.api.test.ts
+++ b/tests/admin/roles.api.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import app from '../../src/server';
+import { prisma } from '../../src/core/db/prisma';
+
+const persistenceEnabled = String(process.env.FF_PERSISTENCE ?? '').toLowerCase() === 'true';
+
+(persistenceEnabled ? describe : describe.skip)('Admin roles API', () => {
+  beforeEach(async () => {
+    await (prisma as any).orgRoleOverride.deleteMany?.();
+    await (prisma as any).role.deleteMany?.();
+    await (prisma as any).feature.deleteMany?.();
+  });
+
+  it('rejects non-admin callers', async () => {
+    const res = await request(app).post('/api/admin/roles/import').set('x-tenant', 'TEN');
+    expect(res.status).toBe(403);
+  });
+
+  it('imports roles and applies tenant overrides', async () => {
+    const importRes = await request(app)
+      .post('/api/admin/roles/import')
+      .set('x-tenant', 'TEN')
+      .set('x-roles', 'admin')
+      .send();
+    expect(importRes.status).toBe(200);
+    expect(importRes.body.summary.roles).toBeGreaterThan(0);
+
+    const roleId = 'sales-junior-account-executive';
+    const overrideRes = await request(app)
+      .put(`/api/admin/roles/${roleId}/overrides`)
+      .set('x-tenant', 'TEN')
+      .set('x-roles', 'admin')
+      .send({ featureCaps: { cashflow_forecast: 5 }, disabledFeatures: ['contract_compliance'] });
+    expect(overrideRes.status).toBe(200);
+
+    const viewRes = await request(app)
+      .get(`/api/admin/roles/${roleId}`)
+      .set('x-tenant', 'TEN')
+      .set('x-roles', 'admin');
+    expect(viewRes.status).toBe(200);
+    expect(viewRes.body.featureCaps.cashflow_forecast).toBe(5);
+    expect(viewRes.body.override?.disabledFeatures).toContain('contract_compliance');
+  });
+});

--- a/tests/admin/subscription.api.test.ts
+++ b/tests/admin/subscription.api.test.ts
@@ -1,0 +1,34 @@
+import request from 'supertest';
+import app from '../../src/server';
+import { resetSubscriptionState } from '../../src/core/subscription/state';
+
+describe('Admin subscription API', () => {
+  beforeEach(() => {
+    resetSubscriptionState();
+  });
+
+  it('requires admin role', async () => {
+    const res = await request(app).get('/api/admin/subscription').set('x-tenant', 'TEN');
+    expect(res.status).toBe(403);
+  });
+
+  it('allows admin to inspect and update subscription', async () => {
+    const inspect = await request(app)
+      .get('/api/admin/subscription')
+      .set('x-tenant', 'TEN')
+      .set('x-roles', 'admin');
+
+    expect(inspect.status).toBe(200);
+    expect(inspect.body.plan).toBeDefined();
+
+    const update = await request(app)
+      .put('/api/admin/subscription')
+      .set('x-tenant', 'TEN')
+      .set('x-roles', 'admin')
+      .send({ plan: 'enterprise', killSwitch: true });
+
+    expect(update.status).toBe(200);
+    expect(update.body.plan).toBe('enterprise');
+    expect(update.body.killSwitch).toBe(true);
+  });
+});

--- a/tests/features/active.db.test.ts
+++ b/tests/features/active.db.test.ts
@@ -1,0 +1,38 @@
+import request from 'supertest';
+import app from '../../src/server';
+import { prisma } from '../../src/core/db/prisma';
+
+const persistenceEnabled = String(process.env.FF_PERSISTENCE ?? '').toLowerCase() === 'true';
+
+(persistenceEnabled ? describe : describe.skip)('Active features ranking with persistence', () => {
+  beforeEach(async () => {
+    await (prisma as any).featureUsage.deleteMany?.();
+    await (prisma as any).orgRoleOverride.deleteMany?.();
+    await (prisma as any).userRole.deleteMany?.();
+    await (prisma as any).role.deleteMany?.();
+    await (prisma as any).feature.deleteMany?.();
+  });
+
+  it('ranks features using usage counts', async () => {
+    await request(app).post('/api/admin/roles/import').set('x-tenant', 'TEN').set('x-roles', 'admin');
+
+    await request(app)
+      .post('/api/usage/feature')
+      .set('x-tenant', 'TEN')
+      .send({ userId: 'user', featureId: 'cashflow_forecast', action: 'open' });
+    await request(app)
+      .post('/api/usage/feature')
+      .set('x-tenant', 'TEN')
+      .send({ userId: 'user', featureId: 'cashflow_forecast', action: 'complete' });
+
+    const res = await request(app)
+      .get('/api/features/active')
+      .set('x-tenant', 'TEN')
+      .set('x-user', 'user')
+      .set('x-role', 'sales-junior-account-executive');
+
+    expect(res.status).toBe(200);
+    expect(res.body.features?.length).toBeGreaterThan(0);
+    expect(res.body.features[0].id).toBe('cashflow_forecast');
+  });
+});

--- a/tests/proactivity/api-state.test.ts
+++ b/tests/proactivity/api-state.test.ts
@@ -11,7 +11,7 @@ describe('GET /api/proactivity/state', () => {
   });
 
   it('returns requested and effective modes with ui hints', async () => {
-    setSubscriptionForTenant('TENANT', { plan: 'flex' });
+    await setSubscriptionForTenant('TENANT', { plan: 'flex' });
     const res = await request(app)
       .get('/api/proactivity/state')
       .set('x-tenant', 'TENANT')
@@ -30,7 +30,7 @@ describe('GET /api/proactivity/state', () => {
   });
 
   it('POST allows overriding requested mode', async () => {
-    setSubscriptionForTenant('TENANT', { plan: 'enterprise' });
+    await setSubscriptionForTenant('TENANT', { plan: 'enterprise' });
     const res = await request(app)
       .post('/api/proactivity/state')
       .set('x-tenant', 'TENANT')

--- a/tests/proactivity/context.integration.test.ts
+++ b/tests/proactivity/context.integration.test.ts
@@ -1,0 +1,41 @@
+import { RoleRegistry } from '../../src/roles/registry';
+import { buildProactivityContext } from '../../src/core/proactivity/context';
+import { ProactivityMode } from '../../src/core/proactivity/modes';
+import { resetSubscriptionState, setSubscriptionForTenant, ensureSubscriptionHydrated } from '../../src/core/subscription/state';
+
+describe('Proactivity context integration', () => {
+  beforeEach(() => {
+    resetSubscriptionState();
+  });
+
+  it('applies min of requested, role cap, plan cap and policy cap', async () => {
+    await setSubscriptionForTenant('TEN', { plan: 'enterprise', secureTenant: true });
+    await ensureSubscriptionHydrated('TEN');
+    const rr = new RoleRegistry(
+      [
+        { role_id: 'runner', canonical_title: 'Runner', featureCaps: { cashflow_forecast: 4 } },
+      ] as any,
+      [
+        { id: 'cashflow_forecast', title: 'Cashflow', capabilities: ['demo.cap'], defaultAutonomyCap: 4 },
+      ],
+      []
+    );
+
+    const state = buildProactivityContext({
+      tenantId: 'TEN',
+      roleRegistry: rr,
+      roleBinding: { userId: 'user', primaryRole: 'runner' },
+      requestedMode: ProactivityMode.Tsunami,
+      featureId: 'cashflow_forecast',
+      policyCap: ProactivityMode.Kraken,
+    });
+
+    expect(state.effective).toBe(ProactivityMode.Proaktiv);
+    expect(state.basis).toEqual(expect.arrayContaining([
+      'tenantPlan:enterprise',
+      'tenant<=3',
+      'roleCap:cashflow_forecast=4',
+      'degraded:proaktiv',
+    ]));
+  });
+});

--- a/tests/proactivity/runner-paths.test.ts
+++ b/tests/proactivity/runner-paths.test.ts
@@ -18,9 +18,9 @@ async function allowPolicy() {
 }
 
 describe('runCapabilityWithRole', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     resetSubscriptionState();
-    setSubscriptionForTenant('TEN', { plan: 'enterprise' });
+    await setSubscriptionForTenant('TEN', { plan: 'enterprise' });
   });
 
   it.each([

--- a/tests/roles/db.registry.test.ts
+++ b/tests/roles/db.registry.test.ts
@@ -1,0 +1,46 @@
+import { prisma } from '../../src/core/db/prisma';
+import { RoleRepo } from '../../src/roles/db/RoleRepo';
+import { FeatureRepo } from '../../src/roles/db/FeatureRepo';
+import { OverrideRepo } from '../../src/roles/db/OverrideRepo';
+import { getRoleRegistry } from '../../src/roles/registryProvider';
+
+const persistenceEnabled = String(process.env.FF_PERSISTENCE ?? '').toLowerCase() === 'true';
+
+(persistenceEnabled ? describe : describe.skip)('Role registry DB integration', () => {
+  const roleRepo = new RoleRepo();
+  const featureRepo = new FeatureRepo();
+  const overrideRepo = new OverrideRepo();
+
+  beforeEach(async () => {
+    await (prisma as any).orgRoleOverride.deleteMany?.();
+    await (prisma as any).userRole.deleteMany?.();
+    await (prisma as any).role.deleteMany?.();
+    await (prisma as any).feature.deleteMany?.();
+  });
+
+  it('merges feature caps and tenant overrides', async () => {
+    await featureRepo.upsertMany([
+      { id: 'forecast', title: 'Forecast', defaultAutonomyCap: 3, capabilities: ['demo.cap'] },
+      { id: 'insights', title: 'Insights', defaultAutonomyCap: 4, capabilities: ['demo.other'] },
+    ]);
+    await roleRepo.upsertMany([
+      {
+        role_id: 'sales_rep',
+        canonical_title: 'Sales Rep',
+        featureCaps: { forecast: 4, insights: 3 },
+      } as any,
+    ]);
+    await overrideRepo.upsertOverride('TENANT', 'sales_rep', {
+      tenantId: 'TENANT',
+      role_id: 'sales_rep',
+      featureCaps: { forecast: 2 },
+      disabledFeatures: ['insights'],
+    });
+
+    const registry = await getRoleRegistry(true);
+    const ctx = registry.getUserContext('TENANT', { userId: 'u1', primaryRole: 'sales_rep' });
+    expect(ctx.featureCaps.forecast).toBe(2);
+    expect(ctx.features.find(f => f.id === 'forecast')).toBeTruthy();
+    expect(ctx.features.find(f => f.id === 'insights')).toBeUndefined();
+  });
+});

--- a/tests/subscription/entitlements.test.ts
+++ b/tests/subscription/entitlements.test.ts
@@ -1,5 +1,10 @@
 import { getPlanMaxMode } from '../../src/core/subscription/entitlements';
-import { setSubscriptionForTenant, getSubscriptionCap, resetSubscriptionState } from '../../src/core/subscription/state';
+import {
+  setSubscriptionForTenant,
+  getSubscriptionCap,
+  resetSubscriptionState,
+  ensureSubscriptionHydrated,
+} from '../../src/core/subscription/state';
 import { ProactivityMode } from '../../src/core/proactivity/modes';
 
 describe('subscription entitlements', () => {
@@ -11,18 +16,20 @@ describe('subscription entitlements', () => {
     expect(getPlanMaxMode('enterprise')).toBe(ProactivityMode.Tsunami);
   });
 
-  it('respects secure tenant flag and kill switch', () => {
-    setSubscriptionForTenant('TEN', { plan: 'enterprise', secureTenant: true });
+  it('respects secure tenant flag and kill switch', async () => {
+    await setSubscriptionForTenant('TEN', { plan: 'enterprise', secureTenant: true });
+    await ensureSubscriptionHydrated('TEN');
     let cap = getSubscriptionCap('TEN');
     expect(cap.maxMode).toBe(ProactivityMode.Proaktiv);
 
-    setSubscriptionForTenant('TEN', { killSwitch: true });
+    await setSubscriptionForTenant('TEN', { killSwitch: true });
     cap = getSubscriptionCap('TEN');
     expect(cap.maxMode).toBe(ProactivityMode.Usynlig);
   });
 
-  it('allows temporary override', () => {
-    setSubscriptionForTenant('TEN', { plan: 'enterprise', maxOverride: ProactivityMode.Kraken });
+  it('allows temporary override', async () => {
+    await setSubscriptionForTenant('TEN', { plan: 'enterprise', maxOverride: ProactivityMode.Kraken });
+    await ensureSubscriptionHydrated('TEN');
     const cap = getSubscriptionCap('TEN');
     expect(cap.maxMode).toBe(ProactivityMode.Kraken);
   });

--- a/tests/usage/db.usage.test.ts
+++ b/tests/usage/db.usage.test.ts
@@ -1,0 +1,21 @@
+import { prisma } from '../../src/core/db/prisma';
+import { recordFeatureUsage, aggregateFeatureUseCount, resetUsageStore } from '../../src/telemetry/usageSignals';
+
+const persistenceEnabled = String(process.env.FF_PERSISTENCE ?? '').toLowerCase() === 'true';
+
+(persistenceEnabled ? describe : describe.skip)('Feature usage persistence', () => {
+  beforeEach(async () => {
+    resetUsageStore();
+    await (prisma as any).featureUsage.deleteMany?.();
+  });
+
+  it('records and aggregates usage events per feature', async () => {
+    await recordFeatureUsage({ tenantId: 'TEN', userId: 'user-1', featureId: 'forecast', action: 'open' });
+    await recordFeatureUsage({ tenantId: 'TEN', userId: 'user-1', featureId: 'forecast', action: 'complete' });
+    await recordFeatureUsage({ tenantId: 'TEN', userId: 'user-1', featureId: 'insights', action: 'open' });
+
+    const counts = await aggregateFeatureUseCount('user-1', 'TEN');
+    expect(counts.forecast).toBe(2);
+    expect(counts.insights).toBe(1);
+  });
+});

--- a/tests/usage/usage.api.test.ts
+++ b/tests/usage/usage.api.test.ts
@@ -10,6 +10,9 @@ describe('Usage router public paths', () => {
       .set('x-tenant', 'DEV')
       .send({ userId: 'u1', featureId: 'customer_health', action: 'open' });
     expect([200, 204]).toContain(res.status);
+    if (res.status === 200) {
+      expect(['db', 'memory']).toContain(res.body.mode);
+    }
   });
 
   it('GET /api/usage/aggregate/:userId', async () => {


### PR DESCRIPTION
## Summary
### Already in place (kept as-is)
- Reused the existing `RoleRegistry` resolver/JSON loader for the in-memory fallback path, so `FF_PERSISTENCE=false` behaviour is unchanged.
- Left the previously shipped audit/policy middleware, safeMount server bootstrapping, and explainability surfaces intact while wiring the new persistence-aware services through them.

### Added / Modified
- Defined the Prisma schema + migration for `Role`, `Feature`, `OrgRoleOverride`, `UserRole`, `FeatureUsage`, and `SubscriptionSetting`, and added an idempotent seed helper plus JSON importer wiring.
- Introduced database repositories for roles, features, overrides, user-role bindings, and subscription settings; extended the registry provider to hydrate from Postgres when persistence is on while caching for TTL efficiency.
- Delivered DB-capable usage telemetry (`recordFeatureUsage`, aggregation) and feature activation ranking that blends autonomy caps, usage intensity, and org hints.
- Added admin APIs for roles import/overrides and subscription configuration, refreshed the public features/usage endpoints, and mounted everything beneath `/api` (including CRM) through the server bootstrap.
- Enriched the proactivity context builder and policy bridge to incorporate role caps, subscription caps, tenant flags, and policy caps into a single basis array for explainability.
- Updated OpenAPI spec, roles/proactivity/usage docs, and CLI snippets to cover the new endpoints and persistence workflow.
- Expanded Jest meta coverage to include the new suites plus DB-gated smoke tests, and taught CI (main + backend-only) to run against Postgres with `FF_PERSISTENCE=true` smoke passes.

### DB schema / migrations / seed flow
- `prisma/schema.prisma` & migration `20250920170000_roles_usage_persistence` create the Postgres tables and indexes for roles, features, overrides, user bindings, usage events, and subscription settings.
- `scripts/seed-roles-from-json.ts` (and `/api/admin/roles/import`) upsert the catalogue from `roles/roles.json`; the importer shares the same helper for CI / operator workflows.
- Prisma client remains stubbed when `@prisma/client` isn’t installed; enable persistence by installing deps and running `npx prisma generate` before `FF_PERSISTENCE=true` operations.

### Effective mode resolution
- `buildProactivityContext` now composes requested mode, role/feature caps, subscription plan caps, kill switch, secure-tenant clamp, and optional policy cap; the resolved basis includes entries like `tenantPlan:flex`, `roleCap:cashflow_forecast=4`, and `degraded:proaktiv` for runner explainability.
- `policyCheckRoleAware` forwards the enriched basis to policy decisions and runner telemetry so explainability drawers and audit trails stay coherent.

### Endpoints & OpenAPI
- `/api/features/active` now surfaces DB-backed rankings (or in-memory fallback) using tenant/user headers and cached bindings.
- `/api/usage/feature` & `/api/usage/aggregate/:userId` persist and aggregate feature usage, returning 204s in memory mode when empty.
- `/api/admin/roles/import`, `/api/admin/roles/:roleId/overrides`, `/api/admin/roles/:roleId` manage catalogue + tenant overrides; `/api/admin/subscription` (GET/PUT) controls plans, kill switch, secure flags, and overrides.
- `openapi/openapi.yaml` documents these endpoints alongside request/response schemas so SDKs and lint stay aligned; `docs/api.md`, `docs/roles.md`, `docs/usage.md`, and `docs/proactivity.md` describe usage patterns and examples.

### CI & Coverage
- `.github/workflows/ci` now provisions Postgres, runs `npx prisma migrate deploy`, executes the full Jest meta suite with coverage, and follows with a persistence smoke suite under `FF_PERSISTENCE=true`.
- `.github/workflows/backend-ci.yml` executes key API smoke tests (features/usage/admin) in in-memory mode for backend-only changes.
- Jest meta config includes the new test directories so CI & local `npm test` exercise policy/proactivity/admin/usage suites; persistence-specific tests stay gated behind `FF_PERSISTENCE=true`.

### Next steps / TODOs
- Generate the Prisma client (`npm install && npx prisma generate`) before running DB-backed smoke suites locally; CI already installs dependencies.
- Run `npx prisma migrate deploy` (or `prisma migrate dev`) against a real Postgres instance to validate the migration outside CI.
- Triage noisy `parseLooseRoles` warnings once the upstream dataset is cleaned; logging remains to highlight malformed role chunks.

---
**Labels:** area:persistence, area:core, type:feature  
**Reviewers:** @CODEOWNERS

------
https://chatgpt.com/codex/tasks/task_e_68ced69837f8832a9f0f50fadf0d5761