### PR TITLE
Add Postgres-backed persistence CI job

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -46,3 +46,61 @@ jobs:
             tests/features/active.api.test.ts \
             tests/usage/usage.api.test.ts \
             --runInBand --passWithNoTests
+
+  test-persistence:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: workbuoy
+        options: >-
+          --health-cmd "pg_isready -U postgres -d workbuoy"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/workbuoy?schema=public
+      FF_PERSISTENCE: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install root tooling deps
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci --omit=optional --no-audit --fund=false
+          else
+            npm install --no-audit --fund=false
+          fi
+
+      - name: Install backend deps
+        run: |
+          if [ -f backend/package-lock.json ]; then
+            npm ci --prefix backend --omit=optional --no-audit --fund=false
+          else
+            npm install --prefix backend --no-audit --fund=false
+          fi
+
+      - name: Generate Prisma client
+        run: npx prisma generate --schema=prisma/schema.prisma
+
+      - name: Apply Prisma migrations
+        run: npx prisma migrate deploy --schema=prisma/schema.prisma
+
+      - name: Seed baseline roles
+        run: node --loader ts-node/esm scripts/seed-roles-from-json.ts
+
+      - name: Run persistence tests
+        working-directory: backend
+        run: npx jest --config jest.persistence.config.cjs --runInBand --passWithNoTests

--- a/backend/jest.persistence.config.cjs
+++ b/backend/jest.persistence.config.cjs
@@ -1,0 +1,12 @@
+const baseConfig = require('./jest.config.cjs');
+
+module.exports = {
+  ...baseConfig,
+  testMatch: [
+    '<rootDir>/../tests/admin/roles.api.test.ts',
+    '<rootDir>/../tests/features/active.api.test.ts',
+    '<rootDir>/../tests/proactivity/context.integration.test.ts',
+    '<rootDir>/../tests/roles/db.registry.test.ts',
+    '<rootDir>/../tests/usage/db.usage.test.ts',
+  ],
+};


### PR DESCRIPTION
## Summary
- add a `test-persistence` job to the backend CI workflow that provisions Postgres, installs tooling, runs Prisma generate/migrate, seeds baseline roles and executes the DB suites
- add `backend/jest.persistence.config.cjs` that reuses the base Jest config while targeting only the persistence-aware tests

## Testing
- CI only (new workflow job exercises the persistence suites)

## How to run locally
1. `npm install --no-audit --fund=false`
2. `npm install --prefix backend --no-audit --fund=false`
3. Start Postgres and export `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/workbuoy?schema=public`
4. `npx prisma generate --schema=prisma/schema.prisma`
5. `npx prisma migrate deploy --schema=prisma/schema.prisma`
6. `node --loader ts-node/esm scripts/seed-roles-from-json.ts`
7. `cd backend && npx jest --config jest.persistence.config.cjs --runInBand`

## Safety
- limits changes to CI workflows and a dedicated test config, leaving runtime code untouched

------
https://chatgpt.com/codex/tasks/task_e_68d027ede1c0832a8ca05f32f04c6484