### PR TITLE
Fix persistence schema relations and CI seeding

### DIFF
--- a/.github/workflows/backend-persistence-ci.yml
+++ b/.github/workflows/backend-persistence-ci.yml
@@ -35,21 +35,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install root tooling deps
-        run: |
-          if [ -f package-lock.json ]; then
-            npm ci --omit=optional --no-audit --fund=false
-          else
-            npm install --no-audit --fund=false
-          fi
+      - name: Install root dependencies
+        run: npm install --no-audit --fund=false
 
-      - name: Install backend deps
-        run: |
-          if [ -f backend/package-lock.json ]; then
-            npm ci --prefix backend --omit=optional --no-audit --fund=false
-          else
-            npm install --prefix backend --no-audit --fund=false
-          fi
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm install --no-audit --fund=false
 
       - name: Generate Prisma client
         working-directory: backend
@@ -59,9 +50,8 @@ jobs:
         working-directory: backend
         run: npx prisma migrate deploy --schema=prisma/schema.prisma
 
-      - name: Seed baseline roles (ESM)
-        working-directory: backend
-        run: node --loader ts-node/esm scripts/seed-roles-from-json.ts
+      - name: Seed baseline roles
+        run: npm run seed:roles
 
       - name: Run persistence tests
         working-directory: backend

--- a/.github/workflows/backend-persistence.yml
+++ b/.github/workflows/backend-persistence.yml
@@ -29,9 +29,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install dependencies
-        run: npm install
+      - name: Install root dependencies
+        run: npm install --no-audit --fund=false
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm install --no-audit --fund=false
       - name: Generate Prisma client
         run: npx prisma generate --schema=prisma/schema.prisma
       - name: Seed baseline roles
-        run: node --loader ts-node/esm scripts/seed-roles-from-json.ts
+        run: npm run seed:roles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
-      - run: npm ci
+      - name: Install dependencies
+        run: npm install --no-audit --fund=false
       - name: Seed baseline roles (via tsx)
         run: npm run seed:roles

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,173 +8,194 @@ datasource db {
 }
 
 model Tenant {
-  id        String  @id @default(cuid())
-  slug      String  @unique
-  name      String
-  users     User[]
-  orgs      Organization[]
-  contacts  Contact[]
-  pipelines Pipeline[]
-  opps      Opportunity[]
-  roles     RoleBinding[]
-  audits    AuditLog[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id                String             @id @default(cuid())
+  slug              String             @unique
+  name              String
+  users             User[]             @relation("TenantUsers")
+  orgs              Organization[]
+  contacts          Contact[]
+  pipelines         Pipeline[]
+  stages            Stage[]            @relation("TenantStages")
+  opportunities     Opportunity[]      @relation("TenantOpps")
+  activities        Activity[]         @relation("TenantActivities")
+  customFieldDefs   CustomFieldDef[]   @relation("TenantCFDefs")
+  customFieldValues CustomFieldValue[] @relation("TenantCFVals")
+  roles             RoleBinding[]
+  audits            AuditLog[]
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
 }
 
 model User {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  email     String  @unique
-  displayName String
-  roleBinds RoleBinding[]
-  activities Activity[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id            String        @id @default(cuid())
+  tenantId      String?
+  tenant        Tenant?       @relation("TenantUsers", fields: [tenantId], references: [id])
+  email         String        @unique
+  displayName   String
+  contacts      Contact[]     @relation("UserContacts")
+  opportunities Opportunity[] @relation("UserOpps")
+  roleBinds     RoleBinding[]
+  activities    Activity[]
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
 }
 
 model Organization {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
+  id        String             @id @default(cuid())
+  tenant    Tenant             @relation(fields: [tenantId], references: [id])
   tenantId  String
   name      String
   domain    String?
   contacts  Contact[]
   opps      Opportunity[]
-  custom    CustomFieldValue[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  custom    CustomFieldValue[] @relation("OrgCF")
+  createdAt DateTime           @default(now())
+  updatedAt DateTime           @updatedAt
+
   @@index([tenantId, name])
 }
 
 model Contact {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  organization   Organization? @relation(fields: [organizationId], references: [id])
+  id             String             @id @default(cuid())
+  tenant         Tenant             @relation(fields: [tenantId], references: [id])
+  tenantId       String
+  organization   Organization?      @relation(fields: [organizationId], references: [id])
   organizationId String?
-  owner     User?   @relation(fields: [ownerId], references: [id])
-  ownerId   String?
-  name      String
-  email     String?
-  phone     String?
-  tags      String[]
-  custom    CustomFieldValue[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  owner          User?              @relation("UserContacts", fields: [ownerId], references: [id])
+  ownerId        String?
+  name           String
+  email          String?
+  phone          String?
+  tags           String[]
+  custom         CustomFieldValue[] @relation("ContactCF")
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+
   @@index([tenantId, ownerId])
 }
 
 model Pipeline {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  name      String
+  id          String        @id @default(cuid())
+  tenant      Tenant        @relation(fields: [tenantId], references: [id])
+  tenantId    String
+  name        String
   description String?
-  stages    Stage[]
-  opps      Opportunity[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  stages      Stage[]
+  opps        Opportunity[]
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
   @@index([tenantId, name])
 }
 
 model Stage {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  pipeline  Pipeline @relation(fields: [pipelineId], references: [id])
-  pipelineId String
-  name      String
-  order     Int
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id            String        @id @default(cuid())
+  tenant        Tenant        @relation("TenantStages", fields: [tenantId], references: [id])
+  tenantId      String
+  pipeline      Pipeline      @relation(fields: [pipelineId], references: [id])
+  pipelineId    String
+  name          String
+  order         Int
+  opportunities Opportunity[] @relation("StageOpps")
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+
   @@index([tenantId, pipelineId, order])
 }
 
 model Opportunity {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  pipeline  Pipeline @relation(fields: [pipelineId], references: [id])
-  pipelineId String
-  stage     Stage    @relation(fields: [stageId], references: [id])
-  stageId   String
-  organization   Organization? @relation(fields: [organizationId], references: [id])
+  id             String             @id @default(cuid())
+  tenant         Tenant             @relation("TenantOpps", fields: [tenantId], references: [id])
+  tenantId       String
+  pipeline       Pipeline           @relation(fields: [pipelineId], references: [id])
+  pipelineId     String
+  stage          Stage              @relation("StageOpps", fields: [stageId], references: [id])
+  stageId        String
+  organization   Organization?      @relation(fields: [organizationId], references: [id])
   organizationId String?
-  owner     User?   @relation(fields: [ownerId], references: [id])
-  ownerId   String?
-  title     String
-  valueCents Int?
-  currency  String? @default("USD")
-  status    String  @default("open") // open|won|lost
-  tags      String[]
-  custom    CustomFieldValue[]
-  activities Activity[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  owner          User?              @relation("UserOpps", fields: [ownerId], references: [id])
+  ownerId        String?
+  title          String
+  valueCents     Int?
+  currency       String?            @default("USD")
+  status         String             @default("open") // open|won|lost
+  tags           String[]
+  custom         CustomFieldValue[] @relation("OppCF")
+  activities     Activity[]         @relation("OppActivities")
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+
   @@index([tenantId, pipelineId, stageId, ownerId])
 }
 
 model Activity {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  user      User?   @relation(fields: [userId], references: [id])
-  userId    String?
-  opportunity Opportunity? @relation(fields: [opportunityId], references: [id])
+  id            String       @id @default(cuid())
+  tenant        Tenant       @relation("TenantActivities", fields: [tenantId], references: [id])
+  tenantId      String
+  user          User?        @relation(fields: [userId], references: [id])
+  userId        String?
+  opportunity   Opportunity? @relation("OppActivities", fields: [opportunityId], references: [id])
   opportunityId String?
-  subject   String
-  note      String?
-  createdAt DateTime @default(now())
+  subject       String
+  note          String?
+  createdAt     DateTime     @default(now())
 }
 
 model CustomFieldDef {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
+  id        String   @id @default(cuid())
+  tenant    Tenant   @relation("TenantCFDefs", fields: [tenantId], references: [id])
   tenantId  String
-  entity    String  // organization|contact|opportunity
+  entity    String // organization|contact|opportunity
   key       String
-  type      String  // string|number|boolean|date|json
-  required  Boolean @default(false)
+  type      String // string|number|boolean|date|json
+  required  Boolean  @default(false)
   createdAt DateTime @default(now())
+
   @@unique([tenantId, entity, key])
 }
 
 model CustomFieldValue {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  entity    String  // organization|contact|opportunity
-  entityId  String
-  key       String
-  stringVal String?
-  numberVal Float?
-  boolVal   Boolean?
-  dateVal   DateTime?
-  jsonVal   Json?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             String        @id @default(cuid())
+  tenant         Tenant        @relation("TenantCFVals", fields: [tenantId], references: [id])
+  tenantId       String
+  entity         String // organization|contact|opportunity
+  entityId       String
+  key            String
+  stringVal      String?
+  numberVal      Float?
+  boolVal        Boolean?
+  dateVal        DateTime?
+  jsonVal        Json?
+  organizationId String?
+  organization   Organization? @relation("OrgCF", fields: [organizationId], references: [id])
+  contactId      String?
+  contact        Contact?      @relation("ContactCF", fields: [contactId], references: [id])
+  opportunityId  String?
+  opportunity    Opportunity?  @relation("OppCF", fields: [opportunityId], references: [id])
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
   @@index([tenantId, entity, entityId])
 }
 
 model RoleBinding {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
-  tenantId  String
-  user      User?   @relation(fields: [userId], references: [id])
-  userId    String?
-  group     String?
-  role      String  // admin|manager|contributor|viewer
+  id           String   @id @default(cuid())
+  tenant       Tenant   @relation(fields: [tenantId], references: [id])
+  tenantId     String
+  user         User?    @relation(fields: [userId], references: [id])
+  userId       String?
+  group        String?
+  role         String // admin|manager|contributor|viewer
   resourceKind String? // pipeline|record|org
   resourceId   String?
-  createdAt DateTime @default(now())
+  createdAt    DateTime @default(now())
+
   @@index([tenantId, userId])
 }
 
 model AuditLog {
-  id        String  @id @default(cuid())
-  tenant    Tenant  @relation(fields: [tenantId], references: [id])
+  id        String   @id @default(cuid())
+  tenant    Tenant   @relation(fields: [tenantId], references: [id])
   tenantId  String
   actorId   String?
   action    String
@@ -183,5 +204,6 @@ model AuditLog {
   oldJson   Json?
   newJson   Json?
   createdAt DateTime @default(now())
+
   @@index([tenantId, entity, entityId, createdAt])
 }

--- a/scripts/roles-io.ts
+++ b/scripts/roles-io.ts
@@ -2,41 +2,182 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+export interface FileLoadResult<T> {
+  data: T;
+  path?: string;
+}
+
+const ROLE_CANDIDATES = [
+  'core/roles/roles.json',
+  'roles/roles.json',
+  'backend/roles/roles.json',
+  'data/roles.json',
+];
+
+const FEATURE_CANDIDATES = [
+  'core/roles/features.json',
+  'roles/features.json',
+  'backend/roles/features.json',
+  'data/features.json',
+];
+
+const SKIP_DIRS = new Set([
+  '.git',
+  '.next',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'tmp',
+]);
+
 export function loadJSON(filePath: string) {
-  const abs = path.resolve(process.cwd(), filePath);
+  const abs = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath);
   if (!fs.existsSync(abs)) throw new Error(`Missing file: ${abs}`);
   const raw = fs.readFileSync(abs, 'utf8');
   return JSON.parse(raw);
 }
 
-export function loadRolesFromRepo(): any[] {
-  const rolesPathCandidates = [
-    'roles/roles.json',
-    'backend/roles/roles.json',
-    'data/roles.json',
-  ];
-  for (const p of rolesPathCandidates) {
+function getSearchBases(): string[] {
+  const bases: string[] = [];
+  let dir = process.cwd();
+  for (let i = 0; i < 3; i += 1) {
+    if (!bases.includes(dir)) bases.push(dir);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return bases;
+}
+
+function toRelative(absPath: string): string {
+  const cwd = process.cwd();
+  const rel = path.relative(cwd, absPath);
+  return rel && !rel.startsWith('..') ? rel : absPath;
+}
+
+function extractList(json: any, key: string): any[] | undefined {
+  if (Array.isArray(json)) {
+    return json;
+  }
+  if (json && typeof json === 'object' && Array.isArray(json[key])) {
+    return json[key] as any[];
+  }
+  return undefined;
+}
+
+function resolveCandidate(candidate: string): string | undefined {
+  if (!candidate) return undefined;
+  const attempts = new Set<string>();
+  if (path.isAbsolute(candidate)) {
+    attempts.add(candidate);
+  } else {
+    for (const base of getSearchBases()) {
+      attempts.add(path.resolve(base, candidate));
+    }
+  }
+  for (const attempt of attempts) {
     try {
-      const json = loadJSON(p);
-      if (Array.isArray((json as any)?.roles)) return (json as any).roles as any[];
-      if (Array.isArray(json)) return json as any[];
+      const stat = fs.statSync(attempt);
+      if (stat.isFile()) {
+        return attempt;
+      }
     } catch {}
   }
+  return undefined;
+}
+
+function searchRepoFor(fileName: string): string | undefined {
+  const queue: string[] = [...new Set(getSearchBases())];
+  const visited = new Set<string>();
+
+  while (queue.length) {
+    const dir = queue.shift()!;
+    if (visited.has(dir)) continue;
+    visited.add(dir);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isFile() && entry.name === fileName) {
+        return fullPath;
+      }
+      if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+        queue.push(fullPath);
+      }
+    }
+  }
+  return undefined;
+}
+
+function loadUsingEnv(envVar: 'ROLES_PATH' | 'FEATURES_PATH', key: string): FileLoadResult<any[]> | undefined {
+  const override = process.env[envVar];
+  if (!override) return undefined;
+  const resolved = resolveCandidate(override);
+  if (!resolved) {
+    throw new Error(`${envVar} points to missing file: ${override}`);
+  }
+  const data = extractList(loadJSON(resolved), key);
+  if (!data) {
+    throw new Error(`${envVar} must reference a JSON array or object containing '${key}'`);
+  }
+  return { data, path: toRelative(resolved) };
+}
+
+function loadUsingCandidates(candidates: string[], key: string): FileLoadResult<any[]> | undefined {
+  for (const candidate of candidates) {
+    const resolved = resolveCandidate(candidate);
+    if (!resolved) continue;
+    try {
+      const data = extractList(loadJSON(resolved), key);
+      if (data) {
+        return { data, path: toRelative(resolved) };
+      }
+    } catch {
+      // ignore and continue to next candidate
+    }
+  }
+  return undefined;
+}
+
+function loadBySearch(fileName: string, key: string): FileLoadResult<any[]> | undefined {
+  const found = searchRepoFor(fileName);
+  if (!found) return undefined;
+  const data = extractList(loadJSON(found), key);
+  if (!data) return undefined;
+  return { data, path: toRelative(found) };
+}
+
+export function loadRolesFromRepo(): FileLoadResult<any[]> {
+  const envResult = loadUsingEnv('ROLES_PATH', 'roles');
+  if (envResult) return envResult;
+
+  const candidateResult = loadUsingCandidates(ROLE_CANDIDATES, 'roles');
+  if (candidateResult) return candidateResult;
+
+  const searched = loadBySearch('roles.json', 'roles');
+  if (searched) return searched;
+
   throw new Error('Could not locate roles.json');
 }
 
-export function loadFeaturesFromRepo(): any[] {
-  const featureCandidates = [
-    'roles/features.json',
-    'backend/roles/features.json',
-    'data/features.json',
-  ];
-  for (const p of featureCandidates) {
-    try {
-      const json = loadJSON(p);
-      if (Array.isArray((json as any)?.features)) return (json as any).features as any[];
-      if (Array.isArray(json)) return json as any[];
-    } catch {}
-  }
-  return [];
+export function loadFeaturesFromRepo(): FileLoadResult<any[]> {
+  const envResult = loadUsingEnv('FEATURES_PATH', 'features');
+  if (envResult) return envResult;
+
+  const candidateResult = loadUsingCandidates(FEATURE_CANDIDATES, 'features');
+  if (candidateResult) return candidateResult;
+
+  const searched = loadBySearch('features.json', 'features');
+  if (searched) return searched;
+
+  return { data: [], path: undefined };
 }

--- a/scripts/seed-roles-from-json.ts
+++ b/scripts/seed-roles-from-json.ts
@@ -2,7 +2,23 @@
 // This runner intentionally avoids importing ./seed-roles-lib.ts to prevent cycles when executed via ts-node/esm.
 // It only uses local IO helpers and lazily imports the importer module after env/file checks.
 
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
 import { loadRolesFromRepo, loadFeaturesFromRepo } from './roles-io.ts';
+
+const require = createRequire(import.meta.url);
+
+function extendNodePath() {
+  const backendNodeModules = path.resolve(process.cwd(), 'backend/node_modules');
+  if (!fs.existsSync(backendNodeModules)) return;
+  const existing = process.env.NODE_PATH ? process.env.NODE_PATH.split(path.delimiter) : [];
+  if (!existing.includes(backendNodeModules)) {
+    const next = [...existing.filter(Boolean), backendNodeModules].join(path.delimiter);
+    process.env.NODE_PATH = next;
+    require('module').Module._initPaths();
+  }
+}
 
 async function main() {
   const persist = (process.env.FF_PERSISTENCE || '').toLowerCase() === 'true';
@@ -14,24 +30,56 @@ async function main() {
     throw new Error('DATABASE_URL must be set when FF_PERSISTENCE=true');
   }
 
+  extendNodePath();
+
   // IO first (no external imports)
-  const roles = loadRolesFromRepo();
-  const features = loadFeaturesFromRepo();
+  const rolesResult = loadRolesFromRepo();
+  const featuresResult = loadFeaturesFromRepo();
+
+  const rolesPath = rolesResult.path ?? '<unknown>';
+  const featuresPath = featuresResult.path ?? '<default>';
+  console.log(`[seed-roles-from-json] roles path: ${rolesPath}`);
+  console.log(`[seed-roles-from-json] features path: ${featuresPath}`);
 
   // Lazy dynamic import after IO/env to avoid loader recursion
   let importer: any;
-  try {
-    importer = await import('../src/roles/service/importer.ts');
-  } catch {
-    importer = await import('../src/roles/service/importer.js');
+  let importerModule: string | null = null;
+  const importerCandidates = [
+    '../src/roles/service/importer.ts',
+    '../src/roles/service/importer.js',
+    '../src/roles/service.ts',
+    '../src/roles/service.js',
+  ];
+  let lastError: unknown;
+  for (const candidate of importerCandidates) {
+    try {
+      importer = await import(candidate);
+      if (importer?.importRolesAndFeatures) {
+        importerModule = candidate;
+        break;
+      }
+    } catch (err) {
+      lastError = err;
+    }
   }
 
   if (!importer?.importRolesAndFeatures) {
+    if (lastError) {
+      console.error('[seed-roles-from-json] importer load error:', lastError);
+    }
     throw new Error('importRolesAndFeatures not found in importer module');
   }
 
-  const summary = await importer.importRolesAndFeatures(roles, features);
-  console.log(JSON.stringify({ ok: true, summary }));
+  const summary = await importer.importRolesAndFeatures(rolesResult.data, featuresResult.data);
+  console.log(
+    JSON.stringify({
+      ok: true,
+      summary,
+      rolesPath: rolesResult.path ?? null,
+      featuresPath: featuresResult.path ?? null,
+      importerModule,
+    }),
+  );
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Schema-relasjoner: Tenant.users↔User.tenant ("TenantUsers"), Tenant.stages↔Stage.tenant ("TenantStages"), Stage.opportunities↔Opportunity.stage ("StageOpps"), User.contacts↔Contact.owner ("UserContacts"), User.opportunities↔Opportunity.owner ("UserOpps"), Tenant.opportunities↔Opportunity.tenant ("TenantOpps"), Tenant.activities↔Activity.tenant ("TenantActivities"), Tenant.customFieldDefs↔CustomFieldDef.tenant ("TenantCFDefs"), Tenant.customFieldValues↔CustomFieldValue.tenant ("TenantCFVals"), Organization.custom↔CustomFieldValue.organization ("OrgCF"), Contact.custom↔CustomFieldValue.contact ("ContactCF"), Opportunity.custom↔CustomFieldValue.opportunity ("OppCF"), Opportunity.activities↔Activity.opportunity ("OppActivities").
- CI: fjernet lockfile-cache og byttet begge jobbene til `npm install` før kjøring.
- Seeding: auto-lokasjon av `core/roles/roles.json`/`features.json`, logger valgt sti og beholder env-override.
- Seed-runner: kjører via `npm run seed:roles`/tsx, utvider NODE_PATH for backend-moduler og laster importer dynamisk med fallbacks.

## Testing
- `npx prisma generate --schema=backend/prisma/schema.prisma`
- `FF_PERSISTENCE=false npm run seed:roles`


------
https://chatgpt.com/codex/tasks/task_e_68d0fb35d5a8832abba031cda407702e