### PR TITLE
ci(helm): add Helm lint + kubeconform schema validation (non-blocking report)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,60 @@
+name: helm
+
+on:
+  pull_request:
+    paths:
+      - "deploy/helm/**"
+      - "deploy/k8s/**"
+      - ".github/workflows/helm.yml"
+  push:
+    branches: [main]
+    paths:
+      - "deploy/helm/**"
+      - "deploy/k8s/**"
+      - ".github/workflows/helm.yml"
+
+jobs:
+  lint-and-validate:
+    runs-on: ubuntu-latest
+    continue-on-error: true # report-only for now
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.15.2
+
+      - name: Helm version
+        run: helm version
+
+      - name: Helm lint (workbuoy chart)
+        if: hashFiles('deploy/helm/workbuoy/Chart.yaml') != ''
+        run: |
+          helm lint deploy/helm/workbuoy
+
+      - name: Render manifests (helm template)
+        if: hashFiles('deploy/helm/workbuoy/Chart.yaml') != ''
+        run: |
+          if [ -f deploy/helm/workbuoy/values.ci.yaml ]; then
+            helm template workbuoy deploy/helm/workbuoy -f deploy/helm/workbuoy/values.ci.yaml > rendered.yaml
+          else
+            helm template workbuoy deploy/helm/workbuoy > rendered.yaml
+          fi
+          echo "Rendered to rendered.yaml"
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL -o kubeconform.tar.gz https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf kubeconform.tar.gz kubeconform
+          sudo mv kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Validate manifests with kubeconform (strict)
+        if: hashFiles('deploy/helm/workbuoy/Chart.yaml') != ''
+        run: |
+          if [ -f rendered.yaml ]; then
+            kubeconform -strict -summary -output tap rendered.yaml || true
+          else
+            echo "No rendered.yaml to validate"
+          fi

--- a/deploy/helm/workbuoy/values.ci.yaml
+++ b/deploy/helm/workbuoy/values.ci.yaml
@@ -1,0 +1,12 @@
+# Minimal values for CI rendering; adjust as your chart requires.
+replicaCount: 1
+image:
+  repository: workbuoy/backend
+  tag: "ci"
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 3000
+resources: {}
+ingress:
+  enabled: false

--- a/docs/CI_NOTES.md
+++ b/docs/CI_NOTES.md
@@ -47,3 +47,10 @@ docker run --rm -p 3000:3000 workbuoy-backend:dev
 docker build -t workbuoy-frontend:dev ./apps/frontend
 docker run --rm -p 8080:80 workbuoy-frontend:dev
 ```
+
+## Helm & Kubernetes Validation
+
+- CI runs Helm lint for `deploy/helm/workbuoy`.
+- CI renders manifests via `helm template` (using `values.ci.yaml` when present).
+- CI validates YAML against Kubernetes schemas using `kubeconform` (`-strict -summary`).
+- Currently non-blocking (report-only). Flip `continue-on-error` off once charts stabilize.


### PR DESCRIPTION
## Summary
- add helm lint + kubeconform workflow that runs on Helm/Kubernetes changes with continue-on-error for informational reporting
- provide minimal CI values file for the workbuoy chart so helm template can render during validation
- document the new Helm and kubeconform checks in CI notes

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d57bb26cd4832a958ee2ba16f6ab5a