### PR TITLE
api(openapi): lint with Spectral + report breaking-change diff vs main in CI

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,107 @@
+name: openapi
+
+on:
+  pull_request:
+    paths:
+      - '**/openapi.yaml'
+      - '**/openapi.yml'
+      - '**/openapi.json'
+      - '**/openapi/**/*.yaml'
+      - '**/openapi/**/*.yml'
+      - '**/openapi/**/*.json'
+      - '.spectral.yaml'
+      - '.github/workflows/openapi.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/openapi.yaml'
+      - '**/openapi.yml'
+      - '**/openapi.json'
+      - '**/openapi/**/*.yaml'
+      - '**/openapi/**/*.yml'
+      - '**/openapi/**/*.json'
+      - '.spectral.yaml'
+      - '.github/workflows/openapi.yml'
+
+jobs:
+  lint-and-diff:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Find OpenAPI specs
+        id: find_specs
+        run: |
+          SPECS=$(git ls-files | grep -E '(^|/)(openapi\.(ya?ml|json)|openapi/.+\.(ya?ml|json))$' || true)
+          echo "specs<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$SPECS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ -n "$SPECS" ]; then
+            echo "Found specs:"
+            echo "$SPECS"
+          else
+            echo "No OpenAPI specs found"
+          fi
+
+      - name: Persist spec list
+        if: steps.find_specs.outputs.specs != ''
+        run: |
+          printf '%s\n' "$SPEC_LIST" > specs.txt
+        env:
+          SPEC_LIST: ${{ steps.find_specs.outputs.specs }}
+
+      - name: Run Spectral on each spec
+        if: steps.find_specs.outputs.specs != ''
+        run: |
+          while IFS= read -r spec; do
+            [ -z "$spec" ] && continue
+            echo "=== Lint: $spec ==="
+            npx --yes @stoplight/spectral-cli@6 lint "$spec" -r .spectral.yaml || true
+          done < specs.txt
+
+      - name: Prepare diff against main
+        if: steps.find_specs.outputs.specs != ''
+        run: |
+          git fetch origin main:refs/remotes/origin/main
+          : > diff.md
+          while IFS= read -r spec; do
+            [ -z "$spec" ] && continue
+            echo "## $spec" >> diff.md
+            if git show origin/main:"$spec" >/dev/null 2>&1; then
+              TMP=$(mktemp)
+              git show origin/main:"$spec" > "$TMP"
+              npx --yes openapi-diff@3.0.1 \
+                --fail-on-changed false \
+                --fail-on-incompatible false \
+                -f markdown \
+                "$TMP" "$spec" >> diff.md || true
+              rm -f "$TMP"
+            else
+              echo "_No baseline on main (new spec)_" >> diff.md
+            fi
+            echo "" >> diff.md
+          done < specs.txt
+
+      - name: Upload diff report
+        if: steps.find_specs.outputs.specs != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-diff-report
+          path: diff.md
+          if-no-files-found: warn
+
+      - name: Print diff summary
+        if: steps.find_specs.outputs.specs != ''
+        run: |
+          echo "---- OpenAPI Diff (vs main) ----"
+          sed -n '1,200p' diff.md || true
+          echo "--------------------------------"

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,25 @@
+extends:
+  - "spectral:oas"
+rules:
+  workbuoy-operation-operationId:
+    description: "Operations must have non-empty operationId"
+    message: "Operation is missing a non-empty operationId"
+    given: "$.paths[*][*]"
+    severity: error
+    then:
+      field: operationId
+      function: truthy
+  workbuoy-info-contact:
+    description: "Provide a contact for the API"
+    given: "$.info"
+    severity: warn
+    then:
+      field: contact
+      function: truthy
+  workbuoy-schema-description:
+    description: "Schemas should document purpose"
+    given: "$.components.schemas[*]"
+    severity: warn
+    then:
+      field: description
+      function: truthy

--- a/docs/CI_NOTES.md
+++ b/docs/CI_NOTES.md
@@ -54,3 +54,16 @@ docker run --rm -p 8080:80 workbuoy-frontend:dev
 - CI renders manifests via `helm template` (using `values.ci.yaml` when present).
 - CI validates YAML against Kubernetes schemas using `kubeconform` (`-strict -summary`).
 - Currently non-blocking (report-only). Flip `continue-on-error` off once charts stabilize.
+
+## OpenAPI Quality Gates
+
+- **Lint:** Run Spectral (`@stoplight/spectral-cli`) against any `openapi.yaml|yml|json` under `apps/**` or `**/openapi/**`.
+- **Diff vs main:** Generate a report with `openapi-diff` to surface potential breaking changes.
+- Both steps are non-blocking right now (report-first). We may flip to blocking once specs stabilize.
+
+### Local usage
+
+```bash
+npm run openapi:lint
+npm run openapi:diff
+```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "guard:ban-empty-logs": "node scripts/guards/banEmptyLogs.mjs",
     "guard:orphan-workspaces": "node tools/guard/orphan-workspaces.js",
     "lint:apps": "npx eslint apps --ext .ts,.tsx,.js --max-warnings=0",
-    "format:check": "npx prettier --check ."
+    "format:check": "npx prettier --check .",
+    "openapi:lint": "bash -lc 'SPECS=$(git ls-files | grep -E \"(^|/)(openapi\\\\.(ya?ml|json)|openapi/.+\\\\.(ya?ml|json))$\" || true); if [ -z \"$SPECS\" ]; then echo \"No OpenAPI specs found\"; exit 0; fi; echo \"$SPECS\" | while read -r spec; do echo \"=== Lint: $spec ===\"; npx @stoplight/spectral-cli@6 lint \"$spec\" -r .spectral.yaml || true; done'",
+    "openapi:diff": "bash -lc 'SPECS=$(git ls-files | grep -E \"(^|/)(openapi\\\\.(ya?ml|json)|openapi/.+\\\\.(ya?ml|json))$\" || true); if [ -z \"$SPECS\" ]; then echo \"No OpenAPI specs found\"; exit 0; fi; git fetch origin main:refs/remotes/origin/main >/dev/null 2>&1 || true; echo \"$SPECS\" | while read -r spec; do echo \"=== Diff: $spec ===\"; if git show origin/main:\"$spec\" >/dev/null 2>&1; then TMP=$(mktemp); git show origin/main:\"$spec\" > \"$TMP\"; npx openapi-diff@3.0.1 --fail-on-changed false --fail-on-incompatible false -f text \"$TMP\" \"$spec\" || true; rm -f \"$TMP\"; else echo \"[new] $spec\"; fi; echo; done'"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
## Summary
- add repo-level Spectral ruleset for pragmatic OpenAPI checks
- run non-blocking Spectral lint and openapi-diff reporting in CI
- provide npm scripts and docs so contributors can run the quality gates locally

## Testing
- npm run openapi:lint
- npm run openapi:diff

------
https://chatgpt.com/codex/tasks/task_e_68d57d913c3c832a8684edc7821f5d35