### PR TITLE
governance: add CODEOWNERS + Dependabot (npm workspaces & Actions) with safe grouping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,27 @@
-# Require review from core team; ai-proposal PRs labeled must be reviewed
-*       @workbuoy-core
-docs/*  @workbuoy-core @workbuoy-docs
-tests/* @workbuoy-core @workbuoy-qe
+CODEOWNERS
+Replace @org/* placeholders with real GH teams or usernames when available.
+Core applications
+
+/apps/backend/ @org/backend-team @repo-maintainers
+/apps/frontend/ @org/frontend-team @repo-maintainers
+
+Shared types & tooling
+
+/types/ @org/platform-team @repo-maintainers
+/tools/ @org/platform-team @repo-maintainers
+
+CI & workflows
+
+/.github/workflows/ @org/platform-team @repo-maintainers
+
+Infra: Helm & Kubernetes
+
+/deploy/helm/ @org/platform-team @org/devops-team @repo-maintainers
+/deploy/k8s/ @org/platform-team @org/devops-team @repo-maintainers
+
+Documentation
+
+/docs/ @org/docs-team @repo-maintainers
+
+Catch-all (optional): uncomment to require maintainer review by default
+# * @repo-maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+updates:
+  # 1) npm workspaces (root + apps + future packages)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Oslo"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "npm", "automated"]
+    # Group related updates to reduce noise
+    groups:
+      types:
+        patterns:
+          - "@types/"
+      testing:
+        patterns:
+          - "jest"
+          - "@jest/"
+          - "vitest"
+          - "@testing-library/"
+      linting:
+        patterns:
+          - "eslint"
+          - "@typescript-eslint/"
+          - "prettier"
+      build-tools:
+        patterns:
+          - "ts-node*"
+          - "tsx"
+          - "typescript"
+          - "rollup*"
+          - "vite*"
+          - "webpack*"
+    # Let Dependabot discover workspaces automatically
+    allow:
+      - dependency-type: "all"
+
+  # 2) GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:30"
+      timezone: "Europe/Oslo"
+    labels: ["dependencies", "actions", "automated"]
+    open-pull-requests-limit: 3
+    groups:
+      gh-actions:
+        patterns:
+          - "*"

--- a/docs/CI_NOTES.md
+++ b/docs/CI_NOTES.md
@@ -67,3 +67,19 @@ docker run --rm -p 8080:80 workbuoy-frontend:dev
 npm run openapi:lint
 npm run openapi:diff
 ```
+
+Governance & Automated Updates
+
+CODEOWNERS routes reviews automatically:
+
+- apps/backend/** → backend owners
+- apps/frontend/** → frontend owners
+- deploy/** → platform/devops owners
+- types/**, tools/**, .github/workflows/** → platform owners
+
+Dependabot:
+
+- Runs weekly for npm (root + workspaces) and GitHub Actions.
+- Groups common deps (types, testing, linting, build-tools) to reduce PR noise.
+- Caps concurrent PRs to keep review load manageable.
+- Labels: dependencies, plus ecosystem tags (npm, actions).


### PR DESCRIPTION
## Summary
- replace the legacy CODEOWNERS file with path-focused owners for apps, shared tooling, workflows, infra, and docs
- add a Dependabot configuration that covers npm workspaces and GitHub Actions on a weekly cadence with grouped updates and limited concurrency
- document how CODEOWNERS and Dependabot behave so contributors know what to expect from review routing and automated PRs

## Testing
- not run (docs and configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d584c10c4c832aa78e39fb97df1f33