### PR TITLE
ci/assets: add large-file guard (>5 MB) with allowlist + docs linkage

### DIFF
--- a/.github/workflows/repo-guards.yml
+++ b/.github/workflows/repo-guards.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Enforce no tracked node_modules
-        run: |
-          npm run guard:ban-tracked-deps
-          # (Optional) room for other guards later, e.g., empty telemetry logs, disallow large binaries, etc.
+        run: npm run guard:ban-tracked-deps
+      - name: Enforce large file policy (>5MB)
+        run: GUARD_MAX_FILE_BYTES=$((5 * 1024 * 1024)) npm run guard:ban-large-files
   orphan-workspaces:
     runs-on: ubuntu-latest
     needs: ban-tracked-deps

--- a/docs/ASSET_POLICY.md
+++ b/docs/ASSET_POLICY.md
@@ -23,3 +23,9 @@ Checklist
 - [ ] Is this file required at runtime or for docs?
 - [ ] Can it be generated or fetched?
 - [ ] If unavoidable, documented in the PR and added to an allowlist.
+
+CI Guard
+--------
+
+A CI guard fails builds when tracked files exceed 5 MB (see `tools/guard/ban-large-files.js`).
+Add intentional exceptions to `tools/guard/large-files.allowlist` with a short justification in the PR.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "telemetry/"
   ],
   "scripts": {
+    "guard:ban-large-files": "node tools/guard/ban-large-files.js",
     "bootstrap": "npm install --workspaces --include-workspace-root",
     "build": "npm run build -w @workbuoy/backend && npm run build -w @workbuoy/frontend",
     "typecheck": "npm run typecheck -w @workbuoy/backend && npm run typecheck -w @workbuoy/frontend",

--- a/tools/guard/ban-large-files.js
+++ b/tools/guard/ban-large-files.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Guard that fails when tracked files exceed a configurable size threshold.
+ */
+
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const MAX_BYTES = Number.parseInt(
+  process.env.GUARD_MAX_FILE_BYTES ?? String(DEFAULT_MAX_BYTES),
+  10,
+);
+
+if (!Number.isFinite(MAX_BYTES) || MAX_BYTES <= 0) {
+  console.error('[guard] Invalid GUARD_MAX_FILE_BYTES value:', process.env.GUARD_MAX_FILE_BYTES);
+  process.exit(1);
+}
+
+const allowlistPath = path.resolve('tools/guard/large-files.allowlist');
+const allowlist = fs.existsSync(allowlistPath)
+  ? fs
+      .readFileSync(allowlistPath, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'))
+  : [];
+
+const allowlistMatchers = allowlist.map((pattern) => {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp('^' + escaped.replace(/\*/g, '.*') + '$');
+  return (filePath) => regex.test(filePath);
+});
+
+function isAllowed(filePath) {
+  return allowlistMatchers.some((match) => match(filePath));
+}
+
+function getTrackedFiles() {
+  try {
+    const output = execSync('git ls-files -z', { encoding: 'utf8' });
+    return output.split('\0').filter(Boolean);
+  } catch (error) {
+    console.error('[guard] Failed to enumerate tracked files via git ls-files.');
+    console.error(String(error));
+    process.exit(1);
+  }
+}
+
+function getFileSize(filePath) {
+  try {
+    return fs.statSync(filePath).size;
+  } catch (error) {
+    console.error(`[guard] Unable to stat ${filePath}`);
+    console.error(String(error));
+    process.exit(1);
+  }
+}
+
+const offenders = getTrackedFiles()
+  .map((filePath) => [filePath, getFileSize(filePath)])
+  .filter(([filePath, size]) => size > MAX_BYTES && !isAllowed(filePath));
+
+if (offenders.length > 0) {
+  console.error(`[guard] Large files detected (> ${MAX_BYTES} bytes):`);
+  for (const [filePath, size] of offenders) {
+    console.error(` - ${filePath} (${size} bytes)`);
+  }
+  console.error('[guard] Add intentional exceptions to tools/guard/large-files.allowlist with justification if unavoidable.');
+  process.exit(1);
+}
+
+console.log('[guard] OK: no large tracked files');

--- a/tools/guard/large-files.allowlist
+++ b/tools/guard/large-files.allowlist
@@ -1,0 +1,3 @@
+# Patterns allowed to exceed size threshold (justify in PR).
+# Example:
+# docs/diagrams/*.png


### PR DESCRIPTION
## Summary
- add a Node-based guard that scans tracked files for >5 MB payloads with allowlist patterns and expose it via an npm script
- integrate the large-file guard into the repo-guards workflow after the tracked dependencies check so CI fails on violations
- link the Asset Policy docs to the new guard and allowlist for documenting intentional exceptions

## Testing
- npm run guard:ban-large-files

------
https://chatgpt.com/codex/tasks/task_e_68d59e0007b0832a9d87681b8043b1d4