### PR TITLE
ci(guards): make orphan-workspaces guard blocking + add clean script

### DIFF
--- a/.github/workflows/repo-guards.yml
+++ b/.github/workflows/repo-guards.yml
@@ -19,5 +19,16 @@ jobs:
     needs: ban-tracked-deps
     steps:
       - uses: actions/checkout@v5
-      - name: Report orphan workspaces (non-blocking)
-        run: npm run guard:orphan-workspaces
+      - name: Enforce orphan workspaces guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          report="$(mktemp)"
+          node tools/guard/orphan-workspaces.js | tee "$report"
+
+          if grep -q 'Orphan workspaces (not covered by root workspaces):' "$report"; then
+            echo "::error::Orphan workspaces detected. Please add them to workspaces or archive them."
+            exit 1
+          fi
+
+          rm -f "$report"

--- a/docs/DEV_QUICKSTART.md
+++ b/docs/DEV_QUICKSTART.md
@@ -3,9 +3,10 @@ Developer Quickstart
 
 1. Clean install
    ```
-   git clean -fdx
+   npm run clean
    npm ci
    ```
+   > Uses `git clean -fdx` to reset the working tree; this removes untracked files and directories.
 
 2. Verify
    ```

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "telemetry/"
   ],
   "scripts": {
+    "clean": "git clean -fdx",
     "guard:ban-large-files": "node tools/guard/ban-large-files.js",
     "bootstrap": "npm install --workspaces --include-workspace-root",
     "build": "npm run build -w @workbuoy/backend && npm run build -w @workbuoy/frontend",


### PR DESCRIPTION
## Summary
- enforce the orphan workspace guard as a blocking step in the repo-guards workflow
- add an npm run clean shortcut for git clean -fdx at the root
- document running npm run clean before npm ci in the developer quickstart guide

## Testing
- node tools/guard/orphan-workspaces.js

------
https://chatgpt.com/codex/tasks/task_e_68d5b18f9424832a86c9c586f2b1881f