### PR TITLE
chore(workspaces): mark enterprise & crm as optional and add light bootstrap

### DIFF
--- a/docs/CI_NOTES.md
+++ b/docs/CI_NOTES.md
@@ -9,6 +9,8 @@
 
 ## Typical pipeline
 
+CI performs a full dependency install (`npm ci`) before running jobs so every workspace, including optional ones, is available during validation.
+
 1. Repo guards
 2. Typecheck (`npm run typecheck`)
 3. Unit tests (`npm test`)

--- a/docs/DEV_QUICKSTART.md
+++ b/docs/DEV_QUICKSTART.md
@@ -13,11 +13,9 @@ Developer Quickstart
      ```
      Installs every workspace, including the heavy `enterprise/` and `crm/` apps. This is the mode used by CI and should be used when you need all applications locally.
 
-   - **Light install (skip heavy apps)**
-     ```
-     npm run bootstrap:light
-     ```
-     Runs `npm ci` with `--omit=optional` to skip optional workspaces. Use this for a faster local setup when you do not need the enterprise or CRM apps.
+   ### Light bootstrap
+   Run `npm run bootstrap:light` to install all core workspaces but omit optional deps and heavy devDependencies.  
+   Use `npm ci` for a full install (required in CI).
 
    > `npm run clean` uses `git clean -fdx` to reset the working tree; this removes untracked files and directories.
 

--- a/docs/DEV_QUICKSTART.md
+++ b/docs/DEV_QUICKSTART.md
@@ -1,12 +1,25 @@
 Developer Quickstart
 ====================
 
-1. Clean install
+1. Install dependencies
    ```
    npm run clean
-   npm ci
    ```
-   > Uses `git clean -fdx` to reset the working tree; this removes untracked files and directories.
+   Choose an install mode:
+
+   - **Full install (default / CI)**
+     ```
+     npm ci
+     ```
+     Installs every workspace, including the heavy `enterprise/` and `crm/` apps. This is the mode used by CI and should be used when you need all applications locally.
+
+   - **Light install (skip heavy apps)**
+     ```
+     npm run bootstrap:light
+     ```
+     Runs `npm ci` with `--omit=optional` to skip optional workspaces. Use this for a faster local setup when you do not need the enterprise or CRM apps.
+
+   > `npm run clean` uses `git clean -fdx` to reset the working tree; this removes untracked files and directories.
 
 2. Verify
    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,14 @@
       "workspaces": [
         "apps/*",
         "packages/*",
-        "enterprise/",
-        "crm/",
+        {
+          "location": "enterprise/",
+          "optional": true
+        },
+        {
+          "location": "crm/",
+          "optional": true
+        },
         "connectors/*",
         "desktop/",
         "desktop/ui",
@@ -141,6 +147,7 @@
     "crm": {
       "name": "workbuoy-crm",
       "version": "0.2.0",
+      "optional": true,
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.52.1",
@@ -467,6 +474,7 @@
     },
     "enterprise": {
       "name": "workbuoy-secure-dsr-patch",
+      "optional": true,
       "dependencies": {
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.50.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,8 @@
       "workspaces": [
         "apps/*",
         "packages/*",
-        {
-          "location": "enterprise/",
-          "optional": true
-        },
-        {
-          "location": "crm/",
-          "optional": true
-        },
+        "enterprise/",
+        "crm/",
         "connectors/*",
         "desktop/",
         "desktop/ui",
@@ -147,7 +141,6 @@
     "crm": {
       "name": "workbuoy-crm",
       "version": "0.2.0",
-      "optional": true,
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.52.1",
@@ -474,7 +467,6 @@
     },
     "enterprise": {
       "name": "workbuoy-secure-dsr-patch",
-      "optional": true,
       "dependencies": {
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/auto-instrumentations-node": "^0.50.1",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,8 @@
   "workspaces": [
     "apps/*",
     "packages/*",
-    {
-      "location": "enterprise/",
-      "optional": true
-    },
-    {
-      "location": "crm/",
-      "optional": true
-    },
+    "enterprise/",
+    "crm/",
     "connectors/*",
     "desktop/",
     "desktop/ui",
@@ -24,7 +18,7 @@
     "clean": "git clean -fdx",
     "guard:ban-large-files": "node tools/guard/ban-large-files.js",
     "bootstrap": "npm install --workspaces --include-workspace-root",
-    "bootstrap:light": "npm ci --workspaces --include-workspace-root --ignore-workspace-root-check --omit=optional",
+    "bootstrap:light": "npm ci --workspaces --include-workspace-root --omit=optional",
     "build": "npm run build -w @workbuoy/backend && npm run build -w @workbuoy/frontend",
     "typecheck": "npm run typecheck -w @workbuoy/backend && npm run typecheck -w @workbuoy/frontend",
     "test": "npm run -w apps/backend test && npm run -w apps/frontend test",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "workspaces": [
     "apps/*",
     "packages/*",
-    "enterprise/",
-    "crm/",
+    {
+      "location": "enterprise/",
+      "optional": true
+    },
+    {
+      "location": "crm/",
+      "optional": true
+    },
     "connectors/*",
     "desktop/",
     "desktop/ui",
@@ -18,6 +24,7 @@
     "clean": "git clean -fdx",
     "guard:ban-large-files": "node tools/guard/ban-large-files.js",
     "bootstrap": "npm install --workspaces --include-workspace-root",
+    "bootstrap:light": "npm ci --workspaces --include-workspace-root --ignore-workspace-root-check --omit=optional",
     "build": "npm run build -w @workbuoy/backend && npm run build -w @workbuoy/frontend",
     "typecheck": "npm run typecheck -w @workbuoy/backend && npm run typecheck -w @workbuoy/frontend",
     "test": "npm run -w apps/backend test && npm run -w apps/frontend test",


### PR DESCRIPTION
## Summary
- mark the enterprise and crm workspaces as optional in the root manifest so they can be omitted locally
- add an npm `bootstrap:light` script that runs a workspace-aware `npm ci` while omitting optional workspaces
- document the light install flow alongside the existing full install instructions and note that CI continues to run the full install

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b9955560832ab1fc40b02d95ba22