### PR TITLE
chore: unify NodeNext tsconfigs and drop legacy shim

### DIFF
--- a/apps/backend/src/types/any-module.d.ts
+++ b/apps/backend/src/types/any-module.d.ts
@@ -1,2 +1,0 @@
-declare const value: any;
-export = value;

--- a/apps/backend/tsconfig.typecheck.json
+++ b/apps/backend/tsconfig.typecheck.json
@@ -3,19 +3,8 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "target": "ES2022",
-    "lib": ["ES2022"],
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "types": ["node", "jest", "express"],
-    "baseUrl": ".",
-    "paths": {
-      "@workbuoy/backend-rbac": ["../../packages/backend-rbac/src/index.ts"],
-      "@workbuoy/backend-telemetry": ["../../packages/backend-telemetry/src/index.ts"],
-      "@workbuoy/backend-metrics": ["../../packages/backend-metrics/src/index.ts"],
-      "../../src/*": ["src/types/any-module.d.ts"],
-      "../../../src/*": ["src/types/any-module.d.ts"]
-    },
     "rootDir": "../.."
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,19 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
     "lib": [
       "ES2020",
       "DOM",
       "DOM.Iterable"
     ],
     "jsx": "react-jsx",
-    "strict": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
       "@/*": [
         "apps/frontend/src/*"
-      ],
-      "prom-client": [
-        "apps/backend/node_modules/prom-client"
       ]
     },
     "types": [


### PR DESCRIPTION
## Summary
- extend the root tsconfig from the shared base so the repo defaults to NodeNext resolution and remove the bespoke prom-client path override
- clean up the backend typecheck configuration to rely on the shared NodeNext settings and stop mapping to the old any-module shim
- delete the global any-module declaration to surface missing module typings instead of hiding them as any

## Testing
- npm run typecheck -w @workbuoy/backend
- npm run lint:apps

------
https://chatgpt.com/codex/tasks/task_e_68d7ae2af3a4832a930cce335010fb62