### PR TITLE
Improve backend metrics runtime configuration and coverage

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -26,3 +26,12 @@ Then fetch the Prometheus snapshot:
 ```
 curl http://localhost:3000/metrics
 ```
+
+### Runtime configuration
+
+- `METRICS_ENABLED` &mdash; set to `true`, `1`, or `yes` to expose `/metrics`. When unset or falsy the route responds with `204 No Content` while keeping the endpoint available.
+- `METRICS_PREFIX` &mdash; optional prefix prepended to every exported metric name.
+- `METRICS_DEFAULT_LABELS` &mdash; comma-separated `key=value` pairs applied as default labels (for example `service=backend,env=dev`).
+- `METRICS_BUCKETS` &mdash; comma-separated list of histogram bucket boundaries shared by backend histograms.
+
+When `METRICS_ENABLED` is true, hitting `/metrics` returns a `200` response with Prometheus text and registers default Node.js/HTTP metrics against a shared registry. The registry, default labels, and prefix are all resolved at request time so you can toggle the feature between test runs.

--- a/apps/backend/src/connectors/metrics.ts
+++ b/apps/backend/src/connectors/metrics.ts
@@ -1,19 +1,32 @@
-import client from 'prom-client';
+import { Counter } from 'prom-client';
+import { createCounter } from '@workbuoy/backend-metrics';
+import { getRegistry } from '../metrics/registry.js';
+import { getMetricsPrefix, isMetricsEnabled } from '../observability/metricsConfig.js';
 
-export const wb_connector_ingest_total = new client.Counter({
-  name: 'wb_connector_ingest_total',
-  help: 'Number of records ingested from provider webhooks/polling',
-  labelNames: ['provider','mode'] as const,
-});
+function buildCounter(name: string, help: string, labelNames: readonly string[] = []) {
+  const metricName = `${getMetricsPrefix()}${name}`;
 
-export const wb_connector_errors_total = new client.Counter({
-  name: 'wb_connector_errors_total',
-  help: 'Number of connector errors',
-  labelNames: ['provider','mode'] as const,
-});
+  if (!isMetricsEnabled()) {
+    return new Counter({ name: metricName, help, labelNames, registers: [] });
+  }
 
-export const wb_connector_retries_total = new client.Counter({
-  name: 'wb_connector_retries_total',
-  help: 'Number of connector retries',
-  labelNames: ['provider'] as const,
-});
+  return createCounter(getRegistry(), metricName, help, [...labelNames]);
+}
+
+export const wb_connector_ingest_total = buildCounter(
+  'wb_connector_ingest_total',
+  'Number of records ingested from provider webhooks/polling',
+  ['provider', 'mode'] as const,
+);
+
+export const wb_connector_errors_total = buildCounter(
+  'wb_connector_errors_total',
+  'Number of connector errors',
+  ['provider', 'mode'] as const,
+);
+
+export const wb_connector_retries_total = buildCounter(
+  'wb_connector_retries_total',
+  'Number of connector retries',
+  ['provider'] as const,
+);

--- a/apps/backend/src/metrics/bridge.spec.ts
+++ b/apps/backend/src/metrics/bridge.spec.ts
@@ -9,10 +9,15 @@ describe('metrics bridge', () => {
 
   afterEach(() => {
     delete process.env.METRICS_ENABLED;
+    delete process.env.METRICS_PREFIX;
+    delete process.env.METRICS_DEFAULT_LABELS;
+    delete process.env.METRICS_BUCKETS;
   });
 
   it('increments RBAC and feature usage metrics when events fire', () => {
     jest.isolateModules(() => {
+      const registry = require('./registry.js') as typeof import('./registry.js');
+      registry.resetRegistryForTests();
       const bridge = require('./bridge.js') as typeof import('./bridge.js');
       const events = require('./events.js') as typeof import('./events.js');
       const metrics = require('./metrics.js') as typeof import('./metrics.js');

--- a/apps/backend/src/metrics/bridge.ts
+++ b/apps/backend/src/metrics/bridge.ts
@@ -1,5 +1,5 @@
 import { metricsEvents } from './events.js';
-import { metricsEnabled } from './registry.js';
+import { isMetricsEnabled } from '../observability/metricsConfig.js';
 import {
   feature_usage_total,
   rbac_denied_total,
@@ -20,7 +20,7 @@ function sanitizeLabel(value: unknown, fallback: string): string {
 let initialized = false;
 
 export function initializeMetricsBridge(): void {
-  if (initialized || !metricsEnabled) {
+  if (initialized || !isMetricsEnabled()) {
     return;
   }
 

--- a/apps/backend/src/metrics/metrics.e2e.spec.ts
+++ b/apps/backend/src/metrics/metrics.e2e.spec.ts
@@ -4,15 +4,67 @@ import request from 'supertest';
 describe('metrics exposure', () => {
   beforeEach(() => {
     jest.resetModules();
-    process.env.METRICS_ENABLED = 'true';
+    jest.clearAllMocks();
+    delete process.env.METRICS_ENABLED;
+    delete process.env.METRICS_PREFIX;
+    delete process.env.METRICS_DEFAULT_LABELS;
+    delete process.env.METRICS_BUCKETS;
   });
 
-  afterEach(() => {
-    delete process.env.METRICS_ENABLED;
+  it('responds with 204 when metrics are disabled', async () => {
+    const app = express();
+    const { resetRegistryForTests } = await import('./registry.js');
+    resetRegistryForTests();
+
+    const { createMetricsRouter } = await import('./router.js');
+    app.use('/metrics', createMetricsRouter());
+
+    const response = await request(app).get('/metrics');
+
+    expect(response.status).toBe(204);
+    expect(response.text).toBe('');
+
+    const promClient = await import('prom-client');
+    expect(promClient.collectDefaultMetrics).not.toHaveBeenCalled();
+  });
+
+  it('registers default metrics once when enabled', async () => {
+    process.env.METRICS_ENABLED = 'true';
+    const app = express();
+
+    const { resetRegistryForTests, getRegistry } = await import('./registry.js');
+    resetRegistryForTests();
+
+    const { createMetricsRouter } = await import('./router.js');
+    app.use('/metrics', createMetricsRouter());
+
+    const firstResponse = await request(app).get('/metrics');
+    expect(firstResponse.status).toBe(200);
+    expect(firstResponse.headers['content-type']).toContain('text/plain');
+
+    const registry = getRegistry();
+    const snapshotAfterFirst = await registry.metrics();
+    const helpCountAfterFirst = (snapshotAfterFirst.match(/# HELP/g) ?? []).length;
+
+    const secondResponse = await request(app).get('/metrics');
+    expect(secondResponse.status).toBe(200);
+
+    const promClient = await import('prom-client');
+    expect(promClient.collectDefaultMetrics).toHaveBeenCalledTimes(1);
+
+    const snapshotAfterSecond = await registry.metrics();
+    const helpCountAfterSecond = (snapshotAfterSecond.match(/# HELP/g) ?? []).length;
+
+    expect(helpCountAfterSecond).toBe(helpCountAfterFirst);
   });
 
   it('exposes RBAC and feature usage metrics when enabled', async () => {
+    process.env.METRICS_ENABLED = 'true';
     const app = express();
+
+    const { resetRegistryForTests } = await import('./registry.js');
+    resetRegistryForTests();
+
     const { initializeMetricsBridge } = await import('./bridge.js');
     const { createMetricsRouter } = await import('./router.js');
     const { metricsEvents } = await import('./events.js');

--- a/apps/backend/src/observability/metricsConfig.ts
+++ b/apps/backend/src/observability/metricsConfig.ts
@@ -1,0 +1,79 @@
+const TRUE_VALUES = new Set(['1', 'true', 'yes']);
+
+export function isMetricsEnabled(): boolean {
+  const raw = process.env.METRICS_ENABLED;
+  if (!raw) {
+    return false;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return TRUE_VALUES.has(normalized);
+}
+
+export function getMetricsPrefix(): string {
+  const raw = process.env.METRICS_PREFIX;
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  return raw;
+}
+
+export function getDefaultLabels(): Record<string, string> {
+  const raw = process.env.METRICS_DEFAULT_LABELS;
+  if (!raw) {
+    return {};
+  }
+
+  const labels: Record<string, string> = {};
+  for (const pair of raw.split(',')) {
+    if (!pair) {
+      continue;
+    }
+
+    const [key, ...valueParts] = pair.split('=');
+    if (!key) {
+      continue;
+    }
+
+    const value = valueParts.join('=');
+    if (value === undefined) {
+      continue;
+    }
+
+    const normalizedKey = key.trim();
+    if (!normalizedKey) {
+      continue;
+    }
+
+    labels[normalizedKey] = value.trim();
+  }
+
+  return labels;
+}
+
+export function getBuckets(): number[] {
+  const raw = process.env.METRICS_BUCKETS;
+  if (!raw) {
+    return [];
+  }
+
+  const buckets: number[] = [];
+  for (const token of raw.split(',')) {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const parsed = Number(trimmed);
+    if (Number.isNaN(parsed)) {
+      continue;
+    }
+    buckets.push(parsed);
+  }
+
+  return buckets;
+}

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -15,8 +15,9 @@ import {
 } from '../../../src/core/observability/metrics.js';
 import { withMetrics } from '@workbuoy/backend-metrics';
 import { createMetricsRouter } from './metrics/router.js';
-import { getRegistry, metricsEnabled as metricsFeatureEnabled } from './metrics/registry.js';
+import { getRegistry } from './metrics/registry.js';
 import { initializeMetricsBridge } from './metrics/bridge.js';
+import { isMetricsEnabled } from './observability/metricsConfig.js';
 
 function normalizeMetricsRoute(value?: string | null): string {
   if (!value) {
@@ -72,10 +73,9 @@ app.use(express.urlencoded({ extended: true }));
 app.use(correlationHeader);
 app.use(wbContext);
 
-const metricsEnabled = metricsFeatureEnabled;
 const metricsRoute = normalizeMetricsRoute(process.env.METRICS_ROUTE);
 
-if (metricsEnabled) {
+if (isMetricsEnabled()) {
   const registry = getRegistry();
   const collectEventBusMetrics = createEventBusMetricsCollector(registry);
   initializeMetricsBridge();


### PR DESCRIPTION
## Summary
- add runtime helpers for METRICS_* env parsing and manage a shared registry that guards default metric registration
- update metric factories, router, and server wiring to respect runtime enablement, prefixes/default labels, and return 204 when disabled
- document the new metrics configuration knobs for the backend

## Testing
- npm run test -w @workbuoy/backend *(fails: jest binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d81d157968832aa1ec04497daad400