### PR TITLE
refactor: enforce Prisma v6 generated types for roles and telemetry

### DIFF
--- a/apps/backend/src/roles/db/types.spec.ts
+++ b/apps/backend/src/roles/db/types.spec.ts
@@ -1,0 +1,96 @@
+import type { Prisma } from '@prisma/client';
+
+type JsonInput = Prisma.InputJsonValue;
+type JsonOutput = Prisma.JsonValue;
+
+type RoleUpsert = Prisma.RoleUpsertArgs;
+type FeatureUpsert = Prisma.FeatureUpsertArgs;
+type OrgOverrideUpsert = Prisma.OrgRoleOverrideUpsertArgs;
+type UserRoleUpsert = Prisma.UserRoleUpsertArgs;
+
+declare const jsonInput: JsonInput;
+
+declare const roleUpsertArgs: RoleUpsert;
+declare const featureUpsertArgs: FeatureUpsert;
+declare const orgOverrideUpsertArgs: OrgOverrideUpsert;
+declare const userRoleUpsertArgs: UserRoleUpsert;
+declare const jsonOutput: JsonOutput;
+
+const _roleUpsertArgs = {
+  where: { role_id: 'role-id' },
+  update: {
+    title: 'Role Title',
+    inherits: ['base-role'],
+    featureCaps: jsonInput,
+    scopeHints: jsonInput,
+    profile: jsonInput,
+  },
+  create: {
+    role_id: 'role-id',
+    title: 'Role Title',
+    inherits: ['base-role'],
+    featureCaps: jsonInput,
+    scopeHints: jsonInput,
+    profile: jsonInput,
+  },
+} satisfies RoleUpsert;
+
+const _featureUpsertArgs = {
+  where: { id: 'feature-id' },
+  update: {
+    title: 'Feature Title',
+    description: 'A helpful capability',
+    defaultAutonomyCap: 3,
+    capabilities: ['capability'],
+    metadata: jsonInput,
+  },
+  create: {
+    id: 'feature-id',
+    title: 'Feature Title',
+    description: 'A helpful capability',
+    defaultAutonomyCap: 3,
+    capabilities: ['capability'],
+    metadata: jsonInput,
+  },
+} satisfies FeatureUpsert;
+
+const _orgOverrideUpsertArgs = {
+  where: { tenant_id_role_id: { tenant_id: 'tenant', role_id: 'role' } },
+  update: {
+    featureCaps: jsonInput,
+    disabledFeatures: ['feature-a'],
+  },
+  create: {
+    tenant_id: 'tenant',
+    role_id: 'role',
+    featureCaps: jsonInput,
+    disabledFeatures: ['feature-a'],
+  },
+} satisfies OrgOverrideUpsert;
+
+const _userRoleUpsertArgs = {
+  where: { user_id: 'user' },
+  update: {
+    tenant_id: 'tenant',
+    primaryRole: 'role',
+    secondaryRoles: ['role-b'],
+  },
+  create: {
+    user_id: 'user',
+    tenant_id: 'tenant',
+    primaryRole: 'role',
+    secondaryRoles: ['role-b'],
+  },
+} satisfies UserRoleUpsert;
+
+void roleUpsertArgs;
+void featureUpsertArgs;
+void orgOverrideUpsertArgs;
+void userRoleUpsertArgs;
+void jsonOutput;
+void _roleUpsertArgs;
+void _featureUpsertArgs;
+void _orgOverrideUpsertArgs;
+void _userRoleUpsertArgs;
+
+export {};

--- a/src/roles/db/FeatureRepo.ts
+++ b/src/roles/db/FeatureRepo.ts
@@ -1,16 +1,9 @@
+import type { Feature, Prisma } from '@prisma/client';
 import { prisma } from '../../core/db/prisma';
 import { toPrismaJson } from '../../lib/prismaJson.js';
 import type { FeatureDef } from '../types';
 
-type FeatureRow = {
-  id: string;
-  title: string;
-  description: string | null;
-  defaultAutonomyCap: number | null;
-  capabilities: FeatureDef['capabilities'];
-};
-
-function mapRowToFeature(row: FeatureRow): FeatureDef {
+function mapRowToFeature(row: Feature): FeatureDef {
   return {
     id: row.id,
     title: row.title,
@@ -27,7 +20,7 @@ export class FeatureRepo {
   }
 
   async upsert(feature: FeatureDef): Promise<FeatureDef> {
-    const row = await prisma.feature.upsert({
+    const args: Prisma.FeatureUpsertArgs = {
       where: { id: feature.id },
       create: {
         id: feature.id,
@@ -35,16 +28,17 @@ export class FeatureRepo {
         description: feature.description,
         defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
         capabilities: feature.capabilities,
-        metadata: toPrismaJson({ ...feature }),
+        metadata: toPrismaJson({ ...feature }) as Prisma.InputJsonValue,
       },
       update: {
         title: feature.title,
         description: feature.description,
         defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
         capabilities: feature.capabilities,
-        metadata: toPrismaJson({ ...feature }),
+        metadata: toPrismaJson({ ...feature }) as Prisma.InputJsonValue,
       },
-    });
+    };
+    const row = await prisma.feature.upsert(args);
     return mapRowToFeature(row);
   }
 
@@ -59,14 +53,14 @@ export class FeatureRepo {
           description: feature.description,
           defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
           capabilities: feature.capabilities,
-          metadata: toPrismaJson({ ...feature }),
+          metadata: toPrismaJson({ ...feature }) as Prisma.InputJsonValue,
         },
         update: {
           title: feature.title,
           description: feature.description,
           defaultAutonomyCap: feature.defaultAutonomyCap ?? 3,
           capabilities: feature.capabilities,
-          metadata: toPrismaJson({ ...feature }),
+          metadata: toPrismaJson({ ...feature }) as Prisma.InputJsonValue,
         },
       })
     ));

--- a/src/roles/db/RoleRepo.ts
+++ b/src/roles/db/RoleRepo.ts
@@ -1,27 +1,25 @@
+import type { Prisma, Role } from '@prisma/client';
 import { prisma } from '../../core/db/prisma';
 import { toPrismaJson } from '../../lib/prismaJson.js';
 import type { RoleProfile } from '../types';
 
-type RoleRow = {
-  role_id: string;
-  title: string | null;
-  inherits: string[] | null;
-  featureCaps: unknown;
-  scopeHints: unknown;
-  profile: unknown;
-};
+function mapRowToProfile(row: Role): RoleProfile {
+  const profileJson = row.profile as Prisma.JsonValue | null;
+  const featureCapsJson = row.featureCaps as Prisma.JsonValue | null;
+  const scopeHintsJson = row.scopeHints as Prisma.JsonValue | null;
 
-function mapRowToProfile(row: RoleRow): RoleProfile {
-  const profile = (row.profile as unknown as RoleProfile | null) ?? ({} as RoleProfile);
-  const featureCaps = (row.featureCaps as Record<string, number> | null) ?? profile.featureCaps;
-  const scopeHints = (row.scopeHints as Record<string, any> | null) ?? profile.scopeHints;
+  const profile = (profileJson as Partial<RoleProfile> | null) ?? {};
+  const featureCaps = (featureCapsJson as RoleProfile['featureCaps'] | null) ?? profile.featureCaps;
+  const scopeHints = (scopeHintsJson as RoleProfile['scopeHints'] | null) ?? profile.scopeHints;
+  const inherits = (profile.inherits ?? row.inherits ?? []) as RoleProfile['inherits'];
+
   return {
     ...profile,
-    role_id: row.role_id,
+    role_id: row.role_id as RoleProfile['role_id'],
     canonical_title: profile.canonical_title ?? row.title,
-    inherits: profile.inherits ?? row.inherits ?? [],
-    featureCaps: featureCaps as RoleProfile['featureCaps'],
-    scopeHints: scopeHints as RoleProfile['scopeHints'],
+    inherits,
+    featureCaps: featureCaps ?? undefined,
+    scopeHints: scopeHints ?? undefined,
   };
 }
 
@@ -37,51 +35,53 @@ export class RoleRepo {
   }
 
   async upsert(role: RoleProfile): Promise<RoleProfile> {
-    const createData = {
+    const createData: Prisma.RoleCreateInput = {
       role_id: role.role_id,
       title: role.canonical_title ?? role.role_id,
       inherits: role.inherits ?? [],
-      featureCaps: toPrismaJson(role.featureCaps),
-      scopeHints: toPrismaJson(role.scopeHints),
-      profile: toPrismaJson(role),
+      featureCaps: toPrismaJson(role.featureCaps) as Prisma.InputJsonValue,
+      scopeHints: toPrismaJson(role.scopeHints) as Prisma.InputJsonValue,
+      profile: toPrismaJson(role) as Prisma.InputJsonValue,
     };
-    const args = {
+    const args: Prisma.RoleUpsertArgs = {
       where: { role_id: role.role_id },
       create: createData,
       update: {
         title: role.canonical_title ?? role.role_id,
         inherits: role.inherits ?? [],
-        featureCaps: toPrismaJson(role.featureCaps),
-        scopeHints: toPrismaJson(role.scopeHints),
-        profile: toPrismaJson(role),
+        featureCaps: toPrismaJson(role.featureCaps) as Prisma.InputJsonValue,
+        scopeHints: toPrismaJson(role.scopeHints) as Prisma.InputJsonValue,
+        profile: toPrismaJson(role) as Prisma.InputJsonValue,
       },
-    } as any;
+    };
     const updated = await prisma.role.upsert(args);
     return mapRowToProfile(updated);
   }
 
   async upsertMany(roles: RoleProfile[]): Promise<number> {
     if (!roles.length) return 0;
-    await prisma.$transaction(roles.map(role =>
-      prisma.role.upsert({
-        where: { role_id: role.role_id },
-        create: {
-          role_id: role.role_id,
-          title: role.canonical_title ?? role.role_id,
-          inherits: role.inherits ?? [],
-          featureCaps: toPrismaJson(role.featureCaps),
-          scopeHints: toPrismaJson(role.scopeHints),
-          profile: toPrismaJson(role),
-        },
-        update: {
-          title: role.canonical_title ?? role.role_id,
-          inherits: role.inherits ?? [],
-          featureCaps: toPrismaJson(role.featureCaps),
-          scopeHints: toPrismaJson(role.scopeHints),
-          profile: toPrismaJson(role),
-        },
-      }) as any
-    ));
+    await prisma.$transaction(
+      roles.map(role =>
+        prisma.role.upsert({
+          where: { role_id: role.role_id },
+          create: {
+            role_id: role.role_id,
+            title: role.canonical_title ?? role.role_id,
+            inherits: role.inherits ?? [],
+            featureCaps: toPrismaJson(role.featureCaps) as Prisma.InputJsonValue,
+            scopeHints: toPrismaJson(role.scopeHints) as Prisma.InputJsonValue,
+            profile: toPrismaJson(role) as Prisma.InputJsonValue,
+          },
+          update: {
+            title: role.canonical_title ?? role.role_id,
+            inherits: role.inherits ?? [],
+            featureCaps: toPrismaJson(role.featureCaps) as Prisma.InputJsonValue,
+            scopeHints: toPrismaJson(role.scopeHints) as Prisma.InputJsonValue,
+            profile: toPrismaJson(role) as Prisma.InputJsonValue,
+          },
+        })
+      )
+    );
     return roles.length;
   }
 }


### PR DESCRIPTION
## Summary
- replace local row shapes in roles repositories with @prisma/client models and InputJsonValue/JsonValue usage
- tighten telemetry Prisma storage to rely on generated enums and typed reducers
- add a compile-time Prisma upsert argument spec covering roles persistence

## Testing
- npm run typecheck -w @workbuoy/backend
- npm run lint
- npm run test -w @workbuoy/backend -- --ci --runInBand --reporters=default --reporters=jest-junit --coverage

------
https://chatgpt.com/codex/tasks/task_e_68d8250728cc832ab99cc79503920715