### PR TITLE
test(backend): expand metrics/runtime + event-bus edge cases and CRM upload error paths

### DIFF
--- a/apps/backend/TESTING.md
+++ b/apps/backend/TESTING.md
@@ -1,0 +1,35 @@
+# Backend testing guide
+
+## Running tests locally
+
+From the repository root you can run the backend test suite in watch or CI-like modes:
+
+```bash
+npm run test -w @workbuoy/backend
+```
+
+For single files you can pass Jest's `--runTestsByPath` flag, e.g.:
+
+```bash
+npm run test -w @workbuoy/backend -- --runTestsByPath src/metrics/registry.runtime.spec.ts
+```
+
+## Metrics runtime configuration
+
+Some metrics tests rely on runtime environment flags. Set these when you need to exercise the happy path:
+
+- `METRICS_ENABLED=true` to enable metric exposure.
+- `METRICS_PREFIX=wb_` (optional) to namespace emitted metric names.
+- `METRICS_DEFAULT_LABELS=service=backend` (optional) to set default labels.
+
+Unset or set `METRICS_ENABLED=false` to simulate the disabled path (this is the default in CI).
+
+## CI-aligned commands
+
+Locally you can mirror the CI pipeline with:
+
+```bash
+npm run typecheck -w @workbuoy/backend
+npm run lint
+npm run test -w @workbuoy/backend -- --ci --runInBand --reporters=default --reporters=jest-junit --coverage
+```

--- a/apps/backend/src/core/events/priorityBus.edgecases.spec.ts
+++ b/apps/backend/src/core/events/priorityBus.edgecases.spec.ts
@@ -1,0 +1,73 @@
+import bus, { dlqList } from './priorityBus.js';
+
+describe('priority bus edge cases', () => {
+  beforeEach(() => {
+    bus.reset();
+  });
+
+  afterEach(() => {
+    bus.reset();
+  });
+
+  it('retries synchronous handler failures and eventually DLQs the event', async () => {
+    const attempts: number[] = [];
+
+    bus.subscribe('sync-error', (event) => {
+      attempts.push(event.retries);
+      throw new Error('boom');
+    });
+
+    await bus.emit({ type: 'sync-error', priority: 'high' });
+
+    expect(attempts[0]).toBe(0);
+    for (let i = 1; i < attempts.length; i += 1) {
+      expect(attempts[i]).toBe(i);
+    }
+
+    const failures = dlqList();
+    expect(failures).toHaveLength(1);
+    const failure = failures[0]!;
+    expect(failure.retries).toBe(attempts.length);
+    expect(failure.lastError).toBe('boom');
+  });
+
+  it('retries rejected promises and succeeds without DLQ once the handler resolves', async () => {
+    const attempts: number[] = [];
+    let shouldFail = true;
+
+    bus.subscribe('async-error', async (event) => {
+      attempts.push(event.retries);
+      if (shouldFail) {
+        shouldFail = false;
+        throw new Error('transient');
+      }
+    });
+
+    await bus.emit({ type: 'async-error', priority: 'high' });
+
+    expect(attempts).toEqual([0, 1]);
+    expect(dlqList()).toHaveLength(0);
+  });
+
+  it('keeps listener order intact even when a handler fails before succeeding later', async () => {
+    const seen: string[] = [];
+    let firstShouldFail = true;
+
+    bus.subscribe('ordered', 'first-listener', (event) => {
+      seen.push(`first:${event.retries}`);
+      if (firstShouldFail) {
+        firstShouldFail = false;
+        throw new Error('retry me');
+      }
+    });
+
+    bus.subscribe('ordered', 'second-listener', (event) => {
+      seen.push(`second:${event.retries}`);
+    });
+
+    await bus.publish({ type: 'ordered', priority: 'high', payload: { step: 1 } });
+
+    expect(seen).toEqual(['first:0', 'second:0', 'first:1', 'second:1']);
+    expect(dlqList()).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/crm/import_export.routes.upload.error.spec.ts
+++ b/apps/backend/src/crm/import_export.routes.upload.error.spec.ts
@@ -1,0 +1,70 @@
+import express from 'express';
+import request from 'supertest';
+import { upload } from '../lib/upload.js';
+
+describe('CRM import upload error handling', () => {
+  const createApp = () => {
+    const app = express();
+    app.post('/crm/import', upload.single('file'), (req, res) => {
+      const requestWithFile = req as typeof req & {
+        file?: { buffer: Buffer; fieldname: string };
+      };
+      const file = requestWithFile.file;
+
+      if (!file) {
+        return res.status(400).json({ ok: false, reason: 'missing file' });
+      }
+
+      if (!file.buffer || file.buffer.length === 0) {
+        return res.status(400).json({ ok: false, reason: 'empty file' });
+      }
+
+      return res.status(200).json({ ok: true });
+    });
+    app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      const maybeMulterError = err as { code?: string } | null;
+      if (maybeMulterError && maybeMulterError.code === 'LIMIT_UNEXPECTED_FILE') {
+        return res.status(400).json({ ok: false, reason: 'missing file' });
+      }
+
+      return res.status(400).json({ ok: false, reason: 'upload failed' });
+    });
+    return app;
+  };
+
+  it('rejects requests without a file field', async () => {
+    const app = createApp();
+
+    await request(app)
+      .post('/crm/import')
+      .field('entity', 'contacts')
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.reason).toBe('missing file');
+      });
+  });
+
+  it('rejects uploads with the wrong field name', async () => {
+    const app = createApp();
+
+    await request(app)
+      .post('/crm/import')
+      .attach('document', Buffer.from('name\n'), 'data.csv')
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.reason).toBe('missing file');
+      });
+  });
+
+  it('rejects empty CSV uploads with a validation message', async () => {
+    const app = createApp();
+
+    await request(app)
+      .post('/crm/import')
+      .attach('file', Buffer.alloc(0), 'empty.csv')
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.reason).toBe('empty file');
+      });
+  });
+});

--- a/apps/backend/src/metrics/registry.runtime.spec.ts
+++ b/apps/backend/src/metrics/registry.runtime.spec.ts
@@ -1,0 +1,95 @@
+import express from 'express';
+import request from 'supertest';
+
+describe('metrics registry runtime behavior', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.METRICS_ENABLED;
+    delete process.env.METRICS_PREFIX;
+    delete process.env.METRICS_DEFAULT_LABELS;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns 204 when metrics are disabled via runtime flag', async () => {
+    process.env.METRICS_ENABLED = 'false';
+
+    const { resetRegistryForTests } = await import('./registry.js');
+    resetRegistryForTests();
+
+    const { createMetricsRouter } = await import('./router.js');
+    const app = express();
+    app.use('/metrics', createMetricsRouter());
+
+    const response = await request(app).get('/metrics');
+
+    expect(response.status).toBe(204);
+    expect(response.text).toBe('');
+
+    const promClient = await import('prom-client');
+    expect(promClient.collectDefaultMetrics).not.toHaveBeenCalled();
+  });
+
+  it('exposes prefixed metrics with default labels when enabled', async () => {
+    process.env.METRICS_ENABLED = 'true';
+    process.env.METRICS_PREFIX = 'wb_';
+    process.env.METRICS_DEFAULT_LABELS = 'service=backend';
+
+    const { resetRegistryForTests, getRegistry } = await import('./registry.js');
+    resetRegistryForTests();
+    const registry = getRegistry();
+
+    const metricsSpy = jest
+      .spyOn(registry, 'metrics')
+      .mockResolvedValue([
+        '# HELP wb_process_cpu_user_seconds_total CPU',
+        '# TYPE wb_process_cpu_user_seconds_total counter',
+        'wb_process_cpu_user_seconds_total{service="backend"} 1',
+      ].join('\n'));
+
+    const { createMetricsRouter } = await import('./router.js');
+    const app = express();
+    app.use('/metrics', createMetricsRouter());
+
+    const response = await request(app).get('/metrics');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('wb_process_cpu_user_seconds_total');
+    expect(response.text).toContain('service="backend"');
+
+    expect(registry.setDefaultLabels).toHaveBeenCalledWith({ service: 'backend' });
+    expect(metricsSpy).toHaveBeenCalled();
+
+    const promClient = await import('prom-client');
+    expect(promClient.collectDefaultMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ prefix: 'wb_', register: registry }),
+    );
+  });
+
+  it('registers default metrics idempotently', async () => {
+    process.env.METRICS_ENABLED = 'true';
+
+    const { resetRegistryForTests, ensureDefaultNodeMetrics, getRegistry } = await import('./registry.js');
+    resetRegistryForTests();
+
+    await ensureDefaultNodeMetrics();
+    const registry = getRegistry();
+    const firstSnapshot = await registry.metrics();
+    const firstHelpCount = (firstSnapshot.match(/# HELP/g) ?? []).length;
+
+    await ensureDefaultNodeMetrics();
+    const secondSnapshot = await registry.metrics();
+    const secondHelpCount = (secondSnapshot.match(/# HELP/g) ?? []).length;
+
+    const promClient = await import('prom-client');
+    expect(promClient.collectDefaultMetrics).toHaveBeenCalledTimes(1);
+    expect(firstHelpCount).toBeGreaterThan(0);
+    expect(secondHelpCount).toBe(firstHelpCount);
+  });
+});

--- a/apps/backend/src/metrics/router.disabled.spec.ts
+++ b/apps/backend/src/metrics/router.disabled.spec.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import request from 'supertest';
+
+describe('metrics router toggle', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.METRICS_ENABLED;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('responds with 204 when metrics are disabled', async () => {
+    process.env.METRICS_ENABLED = 'false';
+
+    const { resetRegistryForTests } = await import('./registry.js');
+    resetRegistryForTests();
+
+    const { createMetricsRouter } = await import('./router.js');
+    const app = express();
+    app.use('/metrics', createMetricsRouter());
+
+    const response = await request(app).get('/metrics');
+
+    expect(response.status).toBe(204);
+    expect(response.text).toBe('');
+  });
+
+  it('responds with 200 when metrics are enabled', async () => {
+    process.env.METRICS_ENABLED = 'true';
+
+    const { resetRegistryForTests } = await import('./registry.js');
+    resetRegistryForTests();
+
+    const { createMetricsRouter } = await import('./router.js');
+    const app = express();
+    app.use('/metrics', createMetricsRouter());
+
+    const response = await request(app).get('/metrics');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('text/plain');
+  });
+});


### PR DESCRIPTION
## Summary
- add runtime metrics router and registry tests covering toggles, prefixes, and idempotent registration
- expand priority event bus tests to cover sync and async handler failures plus listener ordering
- cover CRM import upload error scenarios and document backend test commands

## Testing
- npm run typecheck -w @workbuoy/backend
- npm run lint
- npm run test -w @workbuoy/backend -- --ci --runInBand --reporters=default --reporters=jest-junit --coverage

------
https://chatgpt.com/codex/tasks/task_e_68d8305e2d48832a9a5e718a7b0249c2