### PR TITLE
Add caching to CI workflows and Docker builds

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -30,17 +30,16 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node 20
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
 
-      - name: Cache npm
+      - name: Cache SWC artifacts
         uses: actions/cache@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/backend-persistence.yml
+++ b/.github/workflows/backend-persistence.yml
@@ -42,17 +42,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
 
-      - name: Cache npm
+      - name: Cache SWC artifacts
         uses: actions/cache@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -33,6 +33,13 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+
       - run: npm ci
       - run: npx prisma generate --schema=apps/backend/prisma/schema.prisma
       - run: npm run typecheck -w @workbuoy/backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       - uses: actions/checkout@v5
       - id: versions
         run: echo "node=20.x" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.versions.outputs.node }}
-          cache: npm
+          cache: 'npm'
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
       - run: npm ci
 
   typecheck:
@@ -25,10 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.setup.outputs.node_version }}
-          cache: npm
+          cache: 'npm'
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
       - run: npm ci
       - run: npm run typecheck
       - run: npm run typecheck:meta --if-present
@@ -38,10 +50,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.setup.outputs.node_version }}
-          cache: npm
+          cache: 'npm'
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
       - run: npm ci
       - run: npm test -- --ci --reporters=default --reporters=jest-junit
         env:
@@ -53,10 +71,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.setup.outputs.node_version }}
-          cache: npm
+          cache: 'npm'
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
       - run: npm ci
       - name: Seed dry run (no DB writes)
         run: npm run seed:dry-run -w @workbuoy/backend || true

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -36,6 +36,8 @@ jobs:
           file: apps/backend/Dockerfile
           tags: workbuoy/backend:pr
           load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # --- Build frontend image ---
       - name: Build frontend image
@@ -45,6 +47,8 @@ jobs:
           file: apps/frontend/Dockerfile
           tags: workbuoy/frontend:pr
           load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # --- Trivy scan (backend) ---
       - name: Trivy Scan (backend) — non-blocking

--- a/.github/workflows/frontend-unit.yml
+++ b/.github/workflows/frontend-unit.yml
@@ -25,9 +25,17 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node 20
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('frontend/package-lock.json') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
       - run: npm ci
       - name: Security audit (report only)
         run: npm audit --omit=dev || true

--- a/.github/workflows/repo-guards.yml
+++ b/.github/workflows/repo-guards.yml
@@ -38,6 +38,15 @@ jobs:
     needs: ban-tracked-deps
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         run: npm ci
       - name: Generate repository size report

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -17,9 +17,7 @@ COPY packages/backend-rbac/package*.json packages/backend-rbac/
 COPY packages/backend-metrics/package*.json packages/backend-metrics/
 
 # Install with the root lockfile and workspace manifests present
-RUN --mount=type=cache,target=/root/.npm \
-    --mount=type=cache,target=/repo/node_modules/.cache/swc \
-    npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # Now copy the rest of the repo (respects root .dockerignore)
 COPY . .

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # Workspace-aware build using repo root context
 # --- builder ---
 
@@ -16,7 +17,9 @@ COPY packages/backend-rbac/package*.json packages/backend-rbac/
 COPY packages/backend-metrics/package*.json packages/backend-metrics/
 
 # Install with the root lockfile and workspace manifests present
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/repo/node_modules/.cache/swc \
+    npm ci
 
 # Now copy the rest of the repo (respects root .dockerignore)
 COPY . .

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -9,9 +9,7 @@ COPY package*.json ./
 RUN mkdir -p apps/frontend
 COPY apps/frontend/package*.json apps/frontend/
 # Installer kun deps for frontend-workspacet
-RUN --mount=type=cache,target=/root/.npm \
-    --mount=type=cache,target=/repo/node_modules/.cache/swc \
-    npm ci --workspace @workbuoy/frontend
+RUN --mount=type=cache,target=/root/.npm npm ci --workspace @workbuoy/frontend
 # Kopier resten av repoet (for kildekode)
 COPY . .
 

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # Workspace-aware build using repo root context
 # --- builder ---
 
@@ -8,7 +9,9 @@ COPY package*.json ./
 RUN mkdir -p apps/frontend
 COPY apps/frontend/package*.json apps/frontend/
 # Installer kun deps for frontend-workspacet
-RUN npm ci --workspace @workbuoy/frontend
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/repo/node_modules/.cache/swc \
+    npm ci --workspace @workbuoy/frontend
 # Kopier resten av repoet (for kildekode)
 COPY . .
 


### PR DESCRIPTION
## Summary
- enable npm and swc caching across CI workflows that install dependencies
- add GitHub Actions cache configuration for buildx-based Docker builds
- update backend and frontend Dockerfiles to use BuildKit cache mounts

## Testing
- npm run typecheck -w @workbuoy/backend
- npm run lint
- npm test -w @workbuoy/backend

------
https://chatgpt.com/codex/tasks/task_e_68d83408d9e0832abb7dd929095cab8b