### PR TITLE
chore(npm): remove legacy http-proxy config in CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -41,6 +41,10 @@ jobs:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
 
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/backend-persistence.yml
+++ b/.github/workflows/backend-persistence.yml
@@ -53,6 +53,10 @@ jobs:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
 
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -40,6 +40,10 @@ jobs:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
 
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
+
       - run: npm ci
       - run: npx prisma generate --schema=apps/backend/prisma/schema.prisma
       - run: npm run typecheck -w @workbuoy/backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
       - run: npm ci
 
   typecheck:
@@ -41,6 +44,9 @@ jobs:
         with:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
       - run: npm ci
       - run: npm run typecheck
       - run: npm run typecheck:meta --if-present
@@ -60,6 +66,9 @@ jobs:
         with:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
       - run: npm ci
       - run: npm test -- --ci --reporters=default --reporters=jest-junit
         env:
@@ -81,6 +90,9 @@ jobs:
         with:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
       - run: npm ci
       - name: Seed dry run (no DB writes)
         run: npm run seed:dry-run -w @workbuoy/backend || true

--- a/.github/workflows/frontend-unit.yml
+++ b/.github/workflows/frontend-unit.yml
@@ -37,6 +37,11 @@ jobs:
           path: frontend/node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('frontend/package-lock.json') }}
 
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        working-directory: ..
+        run: scripts/ci/sanitize-npm-proxy.sh
+
       - name: Install dependencies
         run: |
           if [ -f package-lock.json ]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
       - run: npm ci
       - name: Security audit (report only)
         run: npm audit --omit=dev || true

--- a/.github/workflows/repo-guards.yml
+++ b/.github/workflows/repo-guards.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           path: node_modules/.cache/swc
           key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
       - name: Install dependencies
         run: npm ci
       - name: Generate repository size report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,8 @@
 - Do not commit node_modules, dist, coverage, or data files.
 - Follow feature branch naming: cleanup/<scope>.
 - Repo is ESM-first with NodeNext. Import specifiers must include .js when importing transpiled files.
+
+## Proxy settings
+
+- `http-proxy` is deprecated/unsupported in npm; use `proxy` and `https-proxy` instead.
+- CI auto-sanitizes legacy `http-proxy` to avoid warnings.

--- a/scripts/ci/sanitize-npm-proxy.sh
+++ b/scripts/ci/sanitize-npm-proxy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove legacy npm config key that triggers warnings
+npm config delete http-proxy || true
+
+# Unset env variants that npm parses as "env config"
+unset npm_config_http_proxy || true
+unset npm_config_http-proxy || true  # hyphenated variant sometimes appears
+unset NPM_CONFIG_HTTP_PROXY || true
+unset http_proxy || true
+unset HTTP_PROXY || true
+
+# Leave valid keys (proxy / https-proxy) intact if a CI proxy is actually used.
+echo "[sanitize-npm-proxy] Active npm proxy config after cleanup:"
+npm config get proxy || true
+npm config get https-proxy || true


### PR DESCRIPTION
## Summary
- add a sanitize-npm-proxy script to remove deprecated npm http-proxy configuration
- call the sanitization script before npm installs across CI workflows
- document supported proxy keys in contributing guidance

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d83f2da244832ab5b6ccc55724afaa