### PR TITLE
fix: harden backend version endpoint

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:prisma": "prisma generate --schema=prisma/schema.prisma",
-    "build:container": "npm run build:prisma && tsc -p tsconfig.container.json && node -e \"const fs=require('fs');const path=require('path');const source=path.join('dist','apps','backend','src','index.js');const target=path.join('dist','index.js');if(!fs.existsSync(source)){throw new Error('missing '+source);}fs.mkdirSync(path.dirname(target),{recursive:true});fs.copyFileSync(source,target);\"",
-    "build:container:verify": "node -e \"require('fs').accessSync('dist/index.js'); console.log('[verify] dist/index.js present')\"",
+    "build:container": "npm run build:prisma && tsc -p tsconfig.container.json && node -e \"const fs=require('fs');const path=require('path');const source=path.join('dist','apps','backend','src','index.js');const target=path.join('dist','index.js');if(!fs.existsSync(source)){throw new Error('missing '+source);}fs.mkdirSync(path.dirname(target),{recursive:true});fs.copyFileSync(source,target);fs.copyFileSync('package.json', path.join('dist','package.json'));\"",
+    "build:container:verify": "node -e \"const fs=require('fs');['dist/index.js','dist/package.json'].forEach(p=>fs.accessSync(p)); console.log('[verify] dist artifacts present');\"",
     "test": "jest --ci --runInBand --reporters=default --reporters=jest-junit --coverage",
     "test:ci": "npm run test -- --runInBand",
     "test:watch": "jest --watch",

--- a/apps/backend/src/http/version.ts
+++ b/apps/backend/src/http/version.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from "express";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+function readPkgVersion(): string | undefined {
+  try {
+    // I transpilet kode blir dette dist/src/http/version.js → ../../package.json = dist/package.json
+    // Mangler filen, returner undefined (ingen crash).
+    // @ts-ignore - type narrowing ved runtime
+    return (require("../../package.json").version as string) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function versionHandler(_req: Request, res: Response) {
+  const envVersion =
+    process.env.APP_VERSION ||
+    process.env.BACKEND_VERSION ||
+    undefined;
+
+  const sha =
+    process.env.GIT_SHA ||
+    process.env.COMMIT_SHA ||
+    undefined;
+
+  const version = envVersion ?? readPkgVersion() ?? "unknown";
+  res.json({ version, sha });
+}


### PR DESCRIPTION
## Summary
- make the backend version handler prefer environment variables and fall back to package.json without crashing when the manifest is absent
- copy package.json into the container dist bundle and verify it is present after build

## Testing
- not run (not requested)

## Notes
- alternatively we could set APP_VERSION (or BACKEND_VERSION) during the Docker build instead of copying package.json, but this change keeps the build minimal

------
https://chatgpt.com/codex/tasks/task_e_68d905a81590832a90f6664341842962