### PR TITLE
feat(ui): introduce ProactivitySwitch component

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,21 @@
+# @workbuoy/ui
+
+Shared UI components for Workbuoy applications.
+
+## Usage
+
+```tsx
+import { useState } from "react";
+import { ProactivitySwitch } from "@workbuoy/ui";
+
+export function Example() {
+  const [mode, setMode] = useState<"proactive" | "reactive">("reactive");
+  return (
+    <ProactivitySwitch
+      value={mode}
+      onChange={setMode}
+      labels={{ proactive: "Proaktiv", reactive: "Reaktiv" }}
+    />
+  );
+}
+```

--- a/packages/ui/src/components/ProactivitySwitch.stories.tsx
+++ b/packages/ui/src/components/ProactivitySwitch.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import type { Mode, ProactivitySwitchProps } from "./ProactivitySwitch";
+import { ProactivitySwitch } from "./ProactivitySwitch";
+
+const meta: Meta<ProactivitySwitchProps> = {
+  title: "Components/ProactivitySwitch",
+  component: ProactivitySwitch,
+  args: {
+    size: "md",
+    disabled: false,
+  },
+  argTypes: {
+    size: {
+      control: { type: "radio" },
+      options: ["sm", "md"],
+    },
+    disabled: {
+      control: { type: "boolean" },
+    },
+    labels: {
+      control: "object",
+    },
+    value: {
+      control: false,
+    },
+    onChange: {
+      action: "changed",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<ProactivitySwitchProps>;
+
+export const Default: Story = {
+  render: (args) => <ProactivitySwitch {...args} />,
+};
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [mode, setMode] = useState<Mode>("reactive");
+
+    return (
+      <div className="flex flex-col items-start gap-4">
+        <ProactivitySwitch
+          {...args}
+          value={mode}
+          onChange={(next) => {
+            setMode(next);
+            args.onChange?.(next);
+          }}
+        />
+        <p className="text-sm text-muted-foreground">Current mode: {mode}</p>
+      </div>
+    );
+  },
+  args: {
+    labels: {
+      proactive: "Proactive",
+      reactive: "Reactive",
+    },
+  },
+};

--- a/packages/ui/src/components/ProactivitySwitch.test.tsx
+++ b/packages/ui/src/components/ProactivitySwitch.test.tsx
@@ -1,0 +1,114 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProactivitySwitch } from "./ProactivitySwitch";
+
+describe("ProactivitySwitch", () => {
+  it("renders with default reactive value", () => {
+    render(<ProactivitySwitch />);
+
+    const reactiveButton = screen.getByRole("button", { name: /reactive/i });
+    const proactiveButton = screen.getByRole("button", { name: /proactive/i });
+
+    expect(reactiveButton).toHaveAttribute("aria-pressed", "true");
+    expect(proactiveButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("toggles to proactive on click and calls onChange", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<ProactivitySwitch onChange={handleChange} />);
+
+    const proactiveButton = screen.getByRole("button", { name: /proactive/i });
+
+    await act(async () => {
+      await user.click(proactiveButton);
+    });
+
+    expect(proactiveButton).toHaveAttribute("aria-pressed", "true");
+    expect(handleChange).toHaveBeenCalledWith("proactive");
+  });
+
+  it("handles keyboard arrow navigation", async () => {
+    const user = userEvent.setup();
+
+    render(<ProactivitySwitch />);
+
+    await act(async () => {
+      await user.tab();
+    });
+    const reactiveButton = screen.getByRole("button", { name: /reactive/i });
+    expect(reactiveButton).toHaveFocus();
+
+    await act(async () => {
+      await user.keyboard("{ArrowRight}");
+    });
+    const proactiveButton = screen.getByRole("button", { name: /proactive/i });
+    expect(proactiveButton).toHaveAttribute("aria-pressed", "true");
+    expect(proactiveButton).toHaveFocus();
+
+    await act(async () => {
+      await user.keyboard("{ArrowLeft}");
+    });
+    expect(reactiveButton).toHaveAttribute("aria-pressed", "true");
+    expect(reactiveButton).toHaveFocus();
+  });
+
+  it("toggles with space and enter", async () => {
+    const user = userEvent.setup();
+
+    render(<ProactivitySwitch />);
+
+    await act(async () => {
+      await user.tab();
+    });
+    const reactiveButton = screen.getByRole("button", { name: /reactive/i });
+
+    await act(async () => {
+      await user.keyboard(" ");
+    });
+    const proactiveButton = screen.getByRole("button", { name: /proactive/i });
+    expect(proactiveButton).toHaveAttribute("aria-pressed", "true");
+
+    await act(async () => {
+      await user.keyboard("{Enter}");
+    });
+    expect(reactiveButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("notifies change in controlled mode without updating selection", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<ProactivitySwitch value="reactive" onChange={handleChange} />);
+
+    const proactiveButton = screen.getByRole("button", { name: /proactive/i });
+
+    await act(async () => {
+      await user.click(proactiveButton);
+    });
+
+    expect(handleChange).toHaveBeenCalledWith("proactive");
+    expect(proactiveButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("sets appropriate accessibility attributes", () => {
+    render(<ProactivitySwitch />);
+
+    const group = screen.getByRole("group", { name: /proactivity mode/i });
+    const reactiveButton = screen.getByRole("button", { name: /reactive/i });
+    const proactiveButton = screen.getByRole("button", { name: /proactive/i });
+
+    expect(group).toBeInTheDocument();
+    expect(reactiveButton).toHaveAttribute("aria-pressed", "true");
+    expect(proactiveButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("matches snapshot", () => {
+    const { asFragment } = render(<ProactivitySwitch />);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/ui/src/components/ProactivitySwitch.tsx
+++ b/packages/ui/src/components/ProactivitySwitch.tsx
@@ -1,0 +1,195 @@
+import type { KeyboardEvent } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { motion } from "framer-motion";
+
+export type Mode = "proactive" | "reactive";
+
+export interface ProactivitySwitchProps {
+  value?: Mode;
+  defaultValue?: Mode;
+  onChange?: (value: Mode) => void;
+  disabled?: boolean;
+  labels?: { proactive?: string; reactive?: string };
+  size?: "sm" | "md";
+  "aria-label"?: string;
+  className?: string;
+  id?: string;
+}
+
+const LABEL_DEFAULTS: Record<Mode, string> = {
+  proactive: "Proactive",
+  reactive: "Reactive",
+};
+
+const SIZE_STYLES: Record<NonNullable<ProactivitySwitchProps["size"]>, { container: string; button: string; text: string }> = {
+  sm: {
+    container: "p-0.5 text-sm",
+    button: "px-2 py-1 text-xs",
+    text: "text-xs",
+  },
+  md: {
+    container: "p-1",
+    button: "px-3 py-1.5 text-sm",
+    text: "text-sm",
+  },
+};
+
+const HIGHLIGHT_TRANSITION = {
+  type: "spring" as const,
+  stiffness: 500,
+  damping: 35,
+  mass: 0.8,
+};
+
+export function ProactivitySwitch({
+  value,
+  defaultValue = "reactive",
+  onChange,
+  disabled = false,
+  labels,
+  size = "md",
+  className,
+  id,
+  "aria-label": ariaLabel,
+}: ProactivitySwitchProps) {
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState<Mode>(defaultValue);
+  const resolvedValue = isControlled ? (value as Mode) : internalValue;
+
+  const reactiveRef = useRef<HTMLButtonElement>(null);
+  const proactiveRef = useRef<HTMLButtonElement>(null);
+
+  const mergedLabels = useMemo(
+    () => ({
+      ...LABEL_DEFAULTS,
+      ...labels,
+    }),
+    [labels],
+  );
+
+  const currentSize = SIZE_STYLES[size];
+
+  const containerClassName = useMemo(() => {
+    const base = "inline-flex items-center rounded-full border border-border bg-muted/50";
+    const disabledClasses = disabled ? " opacity-60 cursor-not-allowed" : "";
+    return [base, currentSize.container, "gap-1", "transition", className, disabledClasses]
+      .filter(Boolean)
+      .join(" ");
+  }, [className, currentSize.container, disabled]);
+
+  const selectMode = useCallback(
+    (next: Mode, options?: { focus?: boolean }) => {
+      if (disabled || resolvedValue === next) {
+        if (options?.focus) {
+          const ref = next === "reactive" ? reactiveRef.current : proactiveRef.current;
+          ref?.focus();
+        }
+        return;
+      }
+
+      if (!isControlled) {
+        setInternalValue(next);
+      }
+
+      onChange?.(next);
+
+      if (options?.focus) {
+        const ref = next === "reactive" ? reactiveRef.current : proactiveRef.current;
+        ref?.focus();
+      }
+    },
+    [disabled, isControlled, onChange, resolvedValue],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) {
+        return;
+      }
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        selectMode("proactive", { focus: true });
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        selectMode("reactive", { focus: true });
+      }
+    },
+    [disabled, selectMode],
+  );
+
+  const handleSegmentKeyDown = useCallback(
+    (segment: Mode) => (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (disabled) {
+        event.preventDefault();
+        return;
+      }
+
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        const next = segment === "reactive" ? "proactive" : "reactive";
+        selectMode(next, { focus: true });
+      }
+    },
+    [disabled, selectMode],
+  );
+
+  const renderButton = (segment: Mode) => {
+    const isSelected = resolvedValue === segment;
+    const ref = segment === "reactive" ? reactiveRef : proactiveRef;
+    const label = mergedLabels[segment];
+    const buttonClasses = [
+      "relative flex-1 rounded-full font-medium transition",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      "overflow-hidden text-center disabled:pointer-events-none",
+      currentSize.button,
+      isSelected ? "text-primary-foreground" : "text-muted-foreground",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <button
+        key={segment}
+        ref={ref}
+        type="button"
+        className={buttonClasses}
+        aria-pressed={isSelected}
+        aria-label={label}
+        data-selected={isSelected ? true : undefined}
+        disabled={disabled}
+        tabIndex={isSelected ? 0 : -1}
+        onClick={() => selectMode(segment, { focus: true })}
+        onKeyDown={handleSegmentKeyDown(segment)}
+      >
+        {isSelected && (
+          <motion.span
+            layoutId="proactivity-switch-highlight"
+            className="absolute inset-0 z-0 rounded-full bg-primary shadow"
+            transition={HIGHLIGHT_TRANSITION}
+            aria-hidden
+          />
+        )}
+        <span className={`relative z-10 ${currentSize.text}`}>{label}</span>
+      </button>
+    );
+  };
+
+  const groupLabel = ariaLabel ?? "Proactivity mode";
+
+  return (
+    <div
+      role="group"
+      aria-label={groupLabel}
+      className={containerClassName}
+      id={id}
+      data-disabled={disabled ? "true" : undefined}
+      onKeyDown={handleKeyDown}
+    >
+      {renderButton("reactive")}
+      {renderButton("proactive")}
+    </div>
+  );
+}
+
+export default ProactivitySwitch;

--- a/packages/ui/src/components/__snapshots__/ProactivitySwitch.test.tsx.snap
+++ b/packages/ui/src/components/__snapshots__/ProactivitySwitch.test.tsx.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ProactivitySwitch > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Proactivity mode"
+    class="inline-flex items-center rounded-full border border-border bg-muted/50 p-1 gap-1 transition"
+    role="group"
+  >
+    <button
+      aria-label="Reactive"
+      aria-pressed="true"
+      class="relative flex-1 rounded-full font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background overflow-hidden text-center disabled:pointer-events-none px-3 py-1.5 text-sm text-primary-foreground"
+      data-selected="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="absolute inset-0 z-0 rounded-full bg-primary shadow"
+      />
+      <span
+        class="relative z-10 text-sm"
+      >
+        Reactive
+      </span>
+    </button>
+    <button
+      aria-label="Proactive"
+      aria-pressed="false"
+      class="relative flex-1 rounded-full font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background overflow-hidden text-center disabled:pointer-events-none px-3 py-1.5 text-sm text-muted-foreground"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class="relative z-10 text-sm"
+      >
+        Proactive
+      </span>
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,5 @@
 export { default as FlipCard } from "./components/FlipCard";
 export type { FlipCardProps } from "./components/FlipCard";
+
+export { default as ProactivitySwitch } from "./components/ProactivitySwitch";
+export * from "./components/ProactivitySwitch";


### PR DESCRIPTION
## Summary
- add a reusable ProactivitySwitch with controlled and uncontrolled proactivity modes and keyboard support
- document usage and add Storybook demos for the new switch
- cover the component with vitest/RTL tests and export it from the ui package

## Testing
- npm run lint -w @workbuoy/ui
- npm run test -w @workbuoy/ui

------
https://chatgpt.com/codex/tasks/task_e_68da48005fac832aaa57a707438b168f