### PR TITLE
PR9: release polish and workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Typecheck workspaces
+        run: npm run typecheck
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test
+      - name: Smoke tests
+        run: npm run -w @workbuoy/backend test:smoke
+        env:
+          FF_PERSISTENCE: "0"
+      - name: Build @workbuoy/ui package
+        run: npx tsc -p packages/ui/tsconfig.json
+      - name: Build backend container
+        run: docker build -f apps/backend/Dockerfile -t workbuoy/backend:ci .
+      - name: Publish (dry run)
+        run: echo "publish step"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,17 @@
+## PR9 – Release & polish
+
+### Features
+- apps/backend: Exposed `/api/health` and `/api/version` endpoints with optional route guards to simplify status probes.
+- packages/ui: Shipped `FlipCard` and `ProactivitySwitch` components for shared UX patterns.
+
+### Fixes
+- apps/backend: Hardened database seeding and role bootstrap for repeatable environments.
+
+### Chores
+- apps/backend: Added smoke tests that exercise health, metrics, and CRM integrations during CI.
+
+### Docs
+- Monorepo: Documented quickstart workflows and release highlights for the PR9 cut.
+
 ## PR AV
 - Added AI smoke, Desktop conflict/load E2E, SQLCipher probe, dev onboarding, samples.

--- a/README.md
+++ b/README.md
@@ -13,21 +13,18 @@ What’s here
 - deploy/ — Helm charts & k8s manifests
 - docs/ — guides, ADRs, policies
 
-Quick start
------------
+Quickstart
+----------
 
-```
-git clean -fdx         # clean workspace (removes old node_modules, builds)
-npm ci                 # install for the workspace
-npm run typecheck      # types across apps
-npm test               # tests across apps
-# (optional) generate prisma client + seed baseline roles/features
-npm run prisma:generate -w @workbuoy/backend
-npm run prisma:migrate:deploy -w @workbuoy/backend
-npm run seed:dry-run   -w @workbuoy/backend  # CI-safe
-# run apps
-npm run -w @workbuoy/backend start  # adjust if start script exists
-npm run -w @workbuoy/frontend dev   # dev server
+- Install dependencies: `npm ci`
+- Run backend smoke tests to verify core routes: `npm run -w @workbuoy/backend test:smoke`
+- Persistence workflow:
+  1. `npm run db:prepare -w @workbuoy/backend` (generate Prisma client → deploy migrations)
+  2. `npm run db:seed -w @workbuoy/backend` to load baseline data
+- Run the backend locally with optional routes disabled:
+
+```bash
+WB_SKIP_OPTIONAL_ROUTES=1 node --import tsx apps/backend/src/index.ts
 ```
 
 ### Backend metrics
@@ -55,6 +52,11 @@ Docs
 - [CI Notes](docs/CI_NOTES.md)
 - [Governance](docs/GOVERNANCE.md)
 - [Workbuoy Architecture (Core/Flex/Secure + Navi/Buoy AI/Roles/Proactivity)](docs/architecture/workbuoy-architecture.md)
+
+UI components
+-------------
+
+- [@workbuoy/ui component library](packages/ui/README.md)
 
 Governance
 ----------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,17 @@
-# WorkBuoy CRM MVP – Release Notes (v0.1.0)
+# WorkBuoy Suite – Release Notes (PR9)
 
 ## Highlights
-- **Policy v2 guard** now enforces `x-autonomy-level >= 2` on all write routes with explicit 400 errors for missing or invalid headers.
-- **Request context + correlation IDs** wired globally so every request emits structured logs with masked fields.
-- **Persistence** for CRM contacts, tasks, logs and deals now uses the shared `selectRepo<T>` layer (default `PERSIST_MODE=file`) so data survives restarts.
-- **Operability endpoints** exposed at `/status`, `/metrics`, and `/_debug/bus` together with append-only audit trail (`/api/audit`, `/api/audit/verify`).
-- **Frontend bridge** routes all fetches through `@/api` with automatic `x-autonomy-level`/`x-role` headers; CRM panel import is stable for Navi.
+- Backend now exposes `/api/health` and `/api/version` endpoints backed by optional route guards, making it easy to trim the API surface with `WB_SKIP_OPTIONAL_ROUTES=1` during local runs.
+- Database bootstrap is steadier thanks to updated Prisma seeds and new smoke tests validating health, metrics, and CRM routes in CI.
+- Shared UI library ships new `FlipCard` and `ProactivitySwitch` components used across proactive workflows.
 
-## Upgrade notes
-1. Install dependencies: `npm install --prefix backend && npm install --prefix frontend`.
-2. Launch the API via `docker compose up app` (or `NODE_PATH=backend/node_modules node -r ts-node/register src/bin/www.ts`).
-3. Verify `/status` and `/metrics`, then seed demo data via the documented `curl` commands.
+## How to upgrade
+- Install dependencies from the repo root: `npm ci`.
+- Prepare persistence: `npm run db:prepare -w @workbuoy/backend` followed by `npm run db:seed -w @workbuoy/backend` if you need demo data.
+- Optional routes can be disabled during local development with `WB_SKIP_OPTIONAL_ROUTES=1 node --import tsx apps/backend/src/index.ts`.
+- Run smoke tests before cutting a tag: `npm run -w @workbuoy/backend test:smoke`.
 
-## Known considerations
-- Metrics are served in Prometheus text format at `/metrics` and include queue gauges (`eventbus_queue_high|med|low`, `eventbus_dlq_size`).
-- Audit entries persist to `data/audit_log.json`; avoid editing this file manually to preserve the hash chain.
+## Workspace docs
+- [apps/backend README](apps/backend/README.md)
+- [@workbuoy/ui README](packages/ui/README.md)
+- [Frontend README](apps/frontend/README_frontend.md)

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -1,0 +1,11 @@
+## PR9 – Release & polish
+
+### Features
+- Added `/api/health` and `/api/version` endpoints for lightweight availability checks.
+- Gated optional CRM routes behind feature flags so WB_SKIP_OPTIONAL_ROUTES=1 produces a lean surface.
+
+### Fixes
+- Reworked Prisma seed ordering to avoid duplicate inserts and ensure idempotent bootstrap runs.
+
+### Chores
+- Added Node-based smoke tests covering health, metrics, version, and CRM readiness endpoints.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workbuoy/backend",
-  "version": "1.0.0-pr-an",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
     },
     "apps/backend": {
       "name": "@workbuoy/backend",
-      "version": "1.0.0-pr-an",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "6.16.2",
@@ -27911,7 +27911,7 @@
     },
     "packages/ui": {
       "name": "@workbuoy/ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@storybook/react": "^8.3.5",
         "@testing-library/jest-dom": "^6.4.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bootstrap": "npm install --workspaces --include-workspace-root",
     "bootstrap:light": "npm ci --workspaces --include-workspace-root --omit=optional",
     "build": "npm run build -w @workbuoy/backend && npm run build -w @workbuoy/frontend",
-    "typecheck": "npm run typecheck -w @workbuoy/backend && npm run typecheck -w @workbuoy/frontend",
+    "typecheck": "npm run typecheck -w @workbuoy/backend && npm run typecheck -w @workbuoy/frontend && npm run typecheck -w @workbuoy/ui",
     "test": "npm run -w @workbuoy/backend test && npm run -w @workbuoy/frontend test --if-present",
     "test:ci": "npm test --workspaces --if-present",
     "prisma:generate": "npm -w @workbuoy/backend run prisma:generate",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,0 +1,8 @@
+## PR9 – Release & polish
+
+### Features
+- Introduced `FlipCard` for animated two-sided content reveals.
+- Added `ProactivitySwitch` with controlled and uncontrolled modes for navigation between proactive/reactive workflows.
+
+### Docs
+- Documented component usage patterns directly in the package README.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -2,19 +2,64 @@
 
 Shared UI components for Workbuoy applications.
 
-## Usage
+## ProactivitySwitch
+
+### Controlled toggle
 
 ```tsx
 import { useState } from "react";
 import { ProactivitySwitch } from "@workbuoy/ui";
 
-export function Example() {
+export function ControlledSwitch() {
   const [mode, setMode] = useState<"proactive" | "reactive">("reactive");
   return (
     <ProactivitySwitch
       value={mode}
       onChange={setMode}
       labels={{ proactive: "Proaktiv", reactive: "Reaktiv" }}
+    />
+  );
+}
+```
+
+### Uncontrolled toggle
+
+```tsx
+import { ProactivitySwitch } from "@workbuoy/ui";
+
+export function DefaultSwitch() {
+  return <ProactivitySwitch defaultValue="proactive" aria-label="Mode" />;
+}
+```
+
+## FlipCard
+
+### Uncontrolled flip
+
+```tsx
+import { FlipCard } from "@workbuoy/ui";
+
+export function InlineFlip() {
+  return (
+    <FlipCard front={<span>Hover me</span>} back={<span>Surprise!</span>} />
+  );
+}
+```
+
+### Controlled flip
+
+```tsx
+import { useState } from "react";
+import { FlipCard } from "@workbuoy/ui";
+
+export function ControlledFlip() {
+  const [flipped, setFlipped] = useState(false);
+  return (
+    <FlipCard
+      isFlipped={flipped}
+      onFlip={() => setFlipped((value) => !value)}
+      front={<span>Team KPIs</span>}
+      back={<span>Up 18% 🚀</span>}
     />
   );
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@workbuoy/ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {
     "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
     "framer-motion": "^11.11.17",

--- a/packages/ui/src/components/FlipCard.stories.tsx
+++ b/packages/ui/src/components/FlipCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 
 import FlipCard from "./FlipCard";
+import type { FlipCardProps } from "./FlipCard";
 
 const meta: Meta<typeof FlipCard> = {
   title: "Components/FlipCard",
@@ -43,11 +44,11 @@ export default meta;
 type Story = StoryObj<typeof FlipCard>;
 
 export const Default: Story = {
-  render: (args) => <FlipCard {...args} />,
+  render: (args: FlipCardProps) => <FlipCard {...args} />,
 };
 
 export const Controlled: Story = {
-  render: (args) => {
+  render: (args: FlipCardProps) => {
     const [isFlipped, setIsFlipped] = useState(false);
 
     return (

--- a/packages/ui/src/components/ProactivitySwitch.stories.tsx
+++ b/packages/ui/src/components/ProactivitySwitch.stories.tsx
@@ -36,11 +36,11 @@ export default meta;
 type Story = StoryObj<ProactivitySwitchProps>;
 
 export const Default: Story = {
-  render: (args) => <ProactivitySwitch {...args} />,
+  render: (args: ProactivitySwitchProps) => <ProactivitySwitch {...args} />,
 };
 
 export const Controlled: Story = {
-  render: (args) => {
+  render: (args: ProactivitySwitchProps) => {
     const [mode, setMode] = useState<Mode>("reactive");
 
     return (

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,8 +4,19 @@
     "outDir": "dist",
     "rootDir": "src",
     "jsx": "react-jsx",
-    "types": ["vitest/globals", "vitest/importMeta", "@testing-library/jest-dom"]
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "@testing-library/jest-dom"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
   },
-  "include": ["src"],
-  "exclude": ["dist", "node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- bump @workbuoy/backend to 1.0.1 and @workbuoy/ui to 0.2.0 while wiring workspace typecheck coverage
- document PR9 highlights across the repo with updated CHANGELOGs, release notes, and README quickstart guidance
- add a tag-triggered release workflow that runs lint/typecheck/test, backend smoke tests, UI build, and backend container build

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68da4c305500832a9c3dac94b07e4e1e