### PR TITLE
Add UI Storybook CI preview and Pages deploy

### DIFF
--- a/.github/workflows/deploy-ui-storybook.yml
+++ b/.github/workflows/deploy-ui-storybook.yml
@@ -1,0 +1,72 @@
+name: deploy-ui-storybook
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/ui/**'
+      - '.github/workflows/ui-storybook.yml'
+      - '.github/workflows/deploy-ui-storybook.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: deploy-ui-storybook
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    env:
+      CI: 'true'
+      ROLLUP_SKIP_NODEJS_NATIVE: '1'
+      ROLLUP_SKIP_NATIVE: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
+
+      - name: Install dependencies
+        run: npm ci --omit=optional --no-audit --fund=false
+
+      - name: Build Storybook
+        run: npm run storybook:check -w @workbuoy/ui
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/ui/storybook-static
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ui-storybook.yml
+++ b/.github/workflows/ui-storybook.yml
@@ -1,0 +1,47 @@
+name: ui-storybook
+
+on:
+  pull_request:
+    paths:
+      - 'packages/ui/**'
+      - '.github/workflows/ui-storybook.yml'
+
+jobs:
+  build-storybook:
+    name: Build Storybook preview
+    runs-on: ubuntu-latest
+    env:
+      CI: 'true'
+      ROLLUP_SKIP_NODEJS_NATIVE: '1'
+      ROLLUP_SKIP_NATIVE: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Cache SWC artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('package-lock.json') }}
+
+      - name: Sanitize npm proxy config (legacy http-proxy)
+        shell: bash
+        run: scripts/ci/sanitize-npm-proxy.sh
+
+      - name: Install dependencies
+        run: npm ci --omit=optional --no-audit --fund=false
+
+      - name: Build Storybook
+        run: npm run storybook:check -w @workbuoy/ui
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-preview
+          path: packages/ui/storybook-static

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -2,6 +2,13 @@
 
 Shared UI components for Workbuoy applications.
 
+## Storybook
+
+- Local dev server: `npm run -w @workbuoy/ui storybook`
+- Production build check: `npm run -w @workbuoy/ui storybook:check`
+- Pull request preview: every PR touching `packages/ui/**` runs the **ui-storybook** workflow in GitHub Actions and uploads a `storybook-preview` artifact containing the static build.
+- Production deploy: merges to `main` trigger the **deploy-ui-storybook** workflow, which publishes the latest static build to GitHub Pages.
+
 ## ProactivitySwitch
 
 ### Controlled toggle
@@ -45,10 +52,6 @@ export function InlineFlip() {
   );
 }
 ```
-
-### Storybook
-- Start: `npm run -w @workbuoy/ui storybook`
-- Build: `npm run -w @workbuoy/ui build:storybook`
 
 ### Controlled flip
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,8 @@
     "test:watch": "node ./tools/run-vitest.mjs --watch",
     "typecheck": "tsc --noEmit",
     "storybook": "ROLLUP_SKIP_NODEJS_NATIVE=1 node ./scripts/run-storybook.cjs dev -p 6006",
-    "build:storybook": "ROLLUP_SKIP_NODEJS_NATIVE=1 node ./scripts/run-storybook.cjs build",
+    "build:storybook": "ROLLUP_SKIP_NODEJS_NATIVE=1 ROLLUP_SKIP_NATIVE=1 node ./scripts/run-storybook.cjs build",
+    "storybook:check": "npm run build:storybook",
     "test:storybook": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- add a dedicated `ui-storybook` workflow to build Storybook with native rollup binaries skipped and upload the static site as an artifact on PRs
- add an optional `deploy-ui-storybook` workflow that publishes the Storybook build to GitHub Pages when `main` is updated
- document Storybook usage in the UI package and add a `storybook:check` script alias for CI reuse

## Testing
- npm run storybook:check -w @workbuoy/ui *(fails locally: esbuild host 0.21.5 vs binary 0.25.10 mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68dab8acc69c832a90fb68e5abe6bb2b