### PR TITLE
Fix repo guard size report commenting for forks

### DIFF
--- a/.github/workflows/repo-guards.yml
+++ b/.github/workflows/repo-guards.yml
@@ -1,5 +1,10 @@
 name: repo-guards
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 on:
   pull_request:
   push:
@@ -62,17 +67,18 @@ jobs:
           name: repo-size-report
           path: size-report.json
           if-no-files-found: warn
-      - name: Comment PR with size report
+      - name: Prepare size report body
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        id: sizereport
+        uses: actions/github-script@v8
         env:
           SIZE_MAX_GB: ${{ env.SIZE_MAX_GB }}
           NODE_MODULES_MAX: ${{ env.NODE_MODULES_MAX }}
           FILES_MAX: ${{ env.FILES_MAX }}
         with:
           script: |
+            const core = require('@actions/core');
             const fs = require('node:fs');
-
             const tag = '<!-- size-report -->';
             const dataTagStart = '<!-- size-report:data ';
             const dataTagEnd = ' -->';
@@ -91,55 +97,37 @@ jobs:
               files: report.metrics.filesCount,
             };
 
-            const formatValue = (value, unit) => {
-              if (unit === 'GiB') {
-                return `${value.toFixed(2)} ${unit}`;
-              }
-              return value.toLocaleString('en-US');
-            };
+            const formatValue = (value, unit) => unit === 'GiB'
+              ? `${value.toFixed(2)} ${unit}`
+              : value.toLocaleString('en-US');
 
             const results = [
-              {
-                key: 'repoSizeGiB',
-                label: 'Repo size',
-                value: metrics.repoSizeGiB,
-                threshold: thresholds.sizeMax,
-                unit: 'GiB',
-              },
-              {
-                key: 'nodeModules',
-                label: 'node_modules directories',
-                value: metrics.nodeModules,
-                threshold: thresholds.nodeModules,
-                unit: '',
-              },
-              {
-                key: 'files',
-                label: 'Files',
-                value: metrics.files,
-                threshold: thresholds.files,
-                unit: '',
-              },
+              { key: 'repoSizeGiB', label: 'Repo size', value: metrics.repoSizeGiB, threshold: thresholds.sizeMax, unit: 'GiB' },
+              { key: 'nodeModules', label: 'node_modules directories', value: metrics.nodeModules, threshold: thresholds.nodeModules, unit: '' },
+              { key: 'files', label: 'Files', value: metrics.files, threshold: thresholds.files, unit: '' },
             ];
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.find((comment) => comment.body && comment.body.includes(tag));
-
             let baseline = {};
-            if (existing) {
-              const match = existing.body.match(/<!-- size-report:data (?<json>{.+}) -->/);
-              if (match?.groups?.json) {
-                try {
-                  baseline = JSON.parse(match.groups.json);
-                } catch (error) {
-                  core.warning(`Failed to parse size-report baseline: ${error.message}`);
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+              const existing = comments.find((comment) => comment.body && comment.body.includes(tag));
+              if (existing) {
+                const match = existing.body.match(/<!-- size-report:data (?<json>{.+}) -->/);
+                if (match?.groups?.json) {
+                  try {
+                    baseline = JSON.parse(match.groups.json);
+                  } catch (parseError) {
+                    core.warning(`Failed to parse size-report baseline: ${parseError.message}`);
+                  }
                 }
+                core.setOutput('existing_comment_id', String(existing.id));
               }
+            } catch (error) {
+              core.notice(`Skipping baseline fetch: ${error.message}`);
             }
 
             const formatDiff = (key, unit) => {
@@ -147,7 +135,8 @@ jobs:
               if (typeof previous !== 'number') {
                 return 'n/a';
               }
-              const diff = results.find((item) => item.key === key).value - previous;
+              const current = results.find((item) => item.key === key).value;
+              const diff = current - previous;
               if (unit === 'GiB') {
                 return `${diff > 0 ? '+' : ''}${diff.toFixed(2)} ${unit}`;
               }
@@ -158,9 +147,7 @@ jobs:
               return `${diff > 0 ? '+' : ''}${rounded.toLocaleString('en-US')}`;
             };
 
-            const rowStatus = (value, threshold) => {
-              return value > threshold ? '⚠️ Breach' : '✅ OK';
-            };
+            const rowStatus = (value, threshold) => (value > threshold ? '⚠️ Breach' : '✅ OK');
 
             const tableRows = results
               .map((result) => {
@@ -171,20 +158,81 @@ jobs:
               })
               .join('\n');
 
-            const body = `${tag}\n### Repository size report\n\n| Metric | Value | Threshold | Δ vs prev | Status |\n| --- | --- | --- | --- | --- |\n${tableRows}\n\nThreshold overrides: \`SIZE_MAX_GB\`, \`NODE_MODULES_MAX\`, \`FILES_MAX\`.\n\n${dataTagStart}${JSON.stringify(metrics)}${dataTagEnd}`;
+            const body = [
+              tag,
+              '### Repository size report',
+              '',
+              '| Metric | Value | Threshold | Δ vs prev | Status |',
+              '| --- | --- | --- | --- | --- |',
+              tableRows,
+              '',
+              'Threshold overrides: `SIZE_MAX_GB`, `NODE_MODULES_MAX`, `FILES_MAX`.',
+              '',
+              `${dataTagStart}${JSON.stringify(metrics)}${dataTagEnd}`,
+            ].join('\n');
 
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
+            core.setOutput('body', body);
+
+            const isSameRepo = Boolean(
+              context.payload.pull_request &&
+              context.payload.pull_request.head &&
+              context.payload.pull_request.head.repo &&
+              context.payload.pull_request.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`,
+            );
+
+            core.setOutput('can_comment', String(isSameRepo));
+
+      - name: Post size report as PR comment (or fallback to summary)
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v8
+        env:
+          BODY: ${{ steps.sizereport.outputs.body }}
+          EXISTING_ID: ${{ steps.sizereport.outputs.existing_comment_id }}
+          CAN_COMMENT: ${{ steps.sizereport.outputs.can_comment }}
+        with:
+          script: |
+            const core = require('@actions/core');
+            const body = process.env.BODY;
+            const canComment = process.env.CAN_COMMENT === 'true';
+            const existingId = process.env.EXISTING_ID;
+
+            async function writeSummary() {
+              await core.summary
+                .addHeading('Repository size report')
+                .addRaw(body ?? '', true)
+                .write();
+              core.notice('Posted size report to GITHUB_STEP_SUMMARY (no comment permissions).');
+            }
+
+            if (!body) {
+              core.warning('Size report body is empty; skipping comment and summary.');
+              return;
+            }
+
+            if (!canComment) {
+              await writeSummary();
+              return;
+            }
+
+            try {
+              if (existingId) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: Number(existingId),
+                  body,
+                });
+                core.info('Updated existing size-report comment.');
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+                core.info('Created new size-report comment.');
+              }
+            } catch (error) {
+              core.warning(`Could not post PR comment (${error.status}): ${error.message}`);
+              await writeSummary();
             }

--- a/.github/workflows/repo-guards.yml
+++ b/.github/workflows/repo-guards.yml
@@ -77,34 +77,27 @@ jobs:
           FILES_MAX: ${{ env.FILES_MAX }}
         with:
           script: |
-            const core = require('@actions/core');
             const fs = require('node:fs');
             const tag = '<!-- size-report -->';
             const dataTagStart = '<!-- size-report:data ';
             const dataTagEnd = ' -->';
 
-            const report = JSON.parse(fs.readFileSync('size-report.json', 'utf8'));
-
+            const report = JSON.parse(fs.readFileSync('size-report.json','utf8'));
             const thresholds = {
               sizeMax: Number(process.env.SIZE_MAX_GB ?? 2.6),
               nodeModules: Number(process.env.NODE_MODULES_MAX ?? 220),
               files: Number(process.env.FILES_MAX ?? 150000),
             };
-
             const metrics = {
               repoSizeGiB: report.metrics.workingTreeBytes / 1024 ** 3,
               nodeModules: report.metrics.nodeModulesCount,
               files: report.metrics.filesCount,
             };
-
-            const formatValue = (value, unit) => unit === 'GiB'
-              ? `${value.toFixed(2)} ${unit}`
-              : value.toLocaleString('en-US');
-
+            const formatValue = (value, unit) => unit === 'GiB' ? `${value.toFixed(2)} ${unit}` : value.toLocaleString('en-US');
             const results = [
-              { key: 'repoSizeGiB', label: 'Repo size', value: metrics.repoSizeGiB, threshold: thresholds.sizeMax, unit: 'GiB' },
-              { key: 'nodeModules', label: 'node_modules directories', value: metrics.nodeModules, threshold: thresholds.nodeModules, unit: '' },
-              { key: 'files', label: 'Files', value: metrics.files, threshold: thresholds.files, unit: '' },
+              { key:'repoSizeGiB', label:'Repo size', value:metrics.repoSizeGiB, threshold:thresholds.sizeMax, unit:'GiB' },
+              { key:'nodeModules', label:'node_modules directories', value:metrics.nodeModules, threshold:thresholds.nodeModules, unit:'' },
+              { key:'files', label:'Files', value:metrics.files, threshold:thresholds.files, unit:'' },
             ];
 
             let baseline = {};
@@ -114,76 +107,52 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
               });
-              const existing = comments.find((comment) => comment.body && comment.body.includes(tag));
+              const existing = comments.find(c => c.body && c.body.includes(tag));
               if (existing) {
-                const match = existing.body.match(/<!-- size-report:data (?<json>{.+}) -->/);
-                if (match?.groups?.json) {
-                  try {
-                    baseline = JSON.parse(match.groups.json);
-                  } catch (parseError) {
-                    core.warning(`Failed to parse size-report baseline: ${parseError.message}`);
-                  }
-                }
+                const m = existing.body.match(/<!-- size-report:data (?<json>{.+}) -->/);
+                if (m?.groups?.json) baseline = JSON.parse(m.groups.json);
                 core.setOutput('existing_comment_id', String(existing.id));
               }
-            } catch (error) {
-              core.notice(`Skipping baseline fetch: ${error.message}`);
+            } catch (e) {
+              core.notice(`Skipping baseline fetch: ${e.message}`);
             }
 
             const formatDiff = (key, unit) => {
-              const previous = baseline[key];
-              if (typeof previous !== 'number') {
-                return 'n/a';
-              }
-              const current = results.find((item) => item.key === key).value;
-              const diff = current - previous;
-              if (unit === 'GiB') {
-                return `${diff > 0 ? '+' : ''}${diff.toFixed(2)} ${unit}`;
-              }
+              const prev = baseline[key];
+              if (typeof prev !== 'number') return 'n/a';
+              const curr = results.find(r => r.key === key).value;
+              const diff = curr - prev;
+              if (unit === 'GiB') return `${diff > 0 ? '+' : ''}${diff.toFixed(2)} ${unit}`;
               const rounded = Math.round(diff);
-              if (rounded === 0) {
-                return '0';
-              }
-              return `${diff > 0 ? '+' : ''}${rounded.toLocaleString('en-US')}`;
+              return rounded === 0 ? '0' : `${diff > 0 ? '+' : ''}${rounded.toLocaleString('en-US')}`;
             };
+            const rowStatus = (value, threshold) => value > threshold ? '⚠️ Breach' : '✅ OK';
+            const tableRows = results.map(r => {
+              const thr = r.unit === 'GiB' ? `${r.threshold.toFixed(2)} ${r.unit}` : r.threshold.toLocaleString('en-US');
+              return `| ${r.label} | ${formatValue(r.value, r.unit)} | ${thr} | ${formatDiff(r.key, r.unit)} | ${rowStatus(r.value, r.threshold)} |`;
+            }).join('\n');
 
-            const rowStatus = (value, threshold) => (value > threshold ? '⚠️ Breach' : '✅ OK');
+            const body = `${tag}
+            ### Repository size report
 
-            const tableRows = results
-              .map((result) => {
-                const thresholdValue = result.unit === 'GiB'
-                  ? `${result.threshold.toFixed(2)} ${result.unit}`
-                  : result.threshold.toLocaleString('en-US');
-                return `| ${result.label} | ${formatValue(result.value, result.unit)} | ${thresholdValue} | ${formatDiff(result.key, result.unit)} | ${rowStatus(result.value, result.threshold)} |`;
-              })
-              .join('\n');
+            | Metric | Value | Threshold | Δ vs prev | Status |
+            | --- | --- | --- | --- | --- |
+            ${tableRows}
 
-            const body = [
-              tag,
-              '### Repository size report',
-              '',
-              '| Metric | Value | Threshold | Δ vs prev | Status |',
-              '| --- | --- | --- | --- | --- |',
-              tableRows,
-              '',
-              'Threshold overrides: `SIZE_MAX_GB`, `NODE_MODULES_MAX`, `FILES_MAX`.',
-              '',
-              `${dataTagStart}${JSON.stringify(metrics)}${dataTagEnd}`,
-            ].join('\n');
+            Threshold overrides: \`SIZE_MAX_GB\`, \`NODE_MODULES_MAX\`, \`FILES_MAX\`.
+
+            ${dataTagStart}${JSON.stringify(metrics)}${dataTagEnd}`;
 
             core.setOutput('body', body);
 
-            const isSameRepo = Boolean(
-              context.payload.pull_request &&
-              context.payload.pull_request.head &&
-              context.payload.pull_request.head.repo &&
-              context.payload.pull_request.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`,
-            );
-
+            const isSameRepo = !!(context.payload.pull_request &&
+                                  context.payload.pull_request.head &&
+                                  context.payload.pull_request.head.repo &&
+                                  context.payload.pull_request.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`);
             core.setOutput('can_comment', String(isSameRepo));
 
       - name: Post size report as PR comment (or fallback to summary)
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: always()
         uses: actions/github-script@v8
         env:
           BODY: ${{ steps.sizereport.outputs.body }}
@@ -191,22 +160,13 @@ jobs:
           CAN_COMMENT: ${{ steps.sizereport.outputs.can_comment }}
         with:
           script: |
-            const core = require('@actions/core');
             const body = process.env.BODY;
             const canComment = process.env.CAN_COMMENT === 'true';
             const existingId = process.env.EXISTING_ID;
 
             async function writeSummary() {
-              await core.summary
-                .addHeading('Repository size report')
-                .addRaw(body ?? '', true)
-                .write();
+              await core.summary.addRaw(body).write();
               core.notice('Posted size report to GITHUB_STEP_SUMMARY (no comment permissions).');
-            }
-
-            if (!body) {
-              core.warning('Size report body is empty; skipping comment and summary.');
-              return;
             }
 
             if (!canComment) {
@@ -232,7 +192,7 @@ jobs:
                 });
                 core.info('Created new size-report comment.');
               }
-            } catch (error) {
-              core.warning(`Could not post PR comment (${error.status}): ${error.message}`);
+            } catch (e) {
+              core.warning(`Could not post PR comment (${e.status}): ${e.message}`);
               await writeSummary();
             }


### PR DESCRIPTION
## Summary
- add explicit permissions and restructure the repo-guards size report workflow
- prepare the size report body separately and fall back to the step summary if posting a PR comment is forbidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad5088a20832aad6d979905f75d2f