### PR TITLE
ci: fix frontend unit workflow paths

### DIFF
--- a/.github/workflows/frontend-unit.yml
+++ b/.github/workflows/frontend-unit.yml
@@ -3,7 +3,7 @@ name: frontend-unit
 on:
   pull_request:
     paths:
-      - 'frontend/**'
+      - 'apps/frontend/**'
       - '.github/workflows/frontend-unit.yml'
   push:
     branches: [ main ]
@@ -11,11 +11,11 @@ on:
 jobs:
   unit:
     # Skip job hvis frontend-workspace ikke finnes i denne PR-en
-    if: ${{ hashFiles('frontend/package.json') != '' }}
+    if: ${{ hashFiles('apps/frontend/package.json') != '' }}
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: frontend
+        working-directory: apps/frontend
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
       CI: 'true'
@@ -29,17 +29,17 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: apps/frontend/package-lock.json
 
       - name: Cache SWC artifacts
         uses: actions/cache@v4
         with:
-          path: frontend/node_modules/.cache/swc
-          key: ${{ runner.os }}-swc-${{ hashFiles('frontend/package-lock.json') }}
+          path: apps/frontend/node_modules/.cache/swc
+          key: ${{ runner.os }}-swc-${{ hashFiles('apps/frontend/package-lock.json') }}
 
       - name: Sanitize npm proxy config (legacy http-proxy)
         shell: bash
-        working-directory: ..
+        working-directory: ../..
         run: scripts/ci/sanitize-npm-proxy.sh
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- update the frontend unit workflow to watch and operate in apps/frontend
- adjust npm cache configuration to target the apps/frontend lockfile and packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db794c5924832a8b989ed44d1a0322