### PR TITLE
Default to stdout logging by default

### DIFF
--- a/docs/Infra.md
+++ b/docs/Infra.md
@@ -57,8 +57,9 @@ Denne siden beskriver hvor Workbuoy-suite lagrer data (“WB-ting”), hvilke ek
    - Legg inn Prometheus scrape-jobb mot backend `/metrics`.  
    - Opprett Grafana dashboards/alerts.
 
-4. **Logging**  
-   - Send stdout til sentralt logg-lager.  
+4. **Logging**
+   - Send stdout til sentralt logg-lager.
+   - JSON-strukturerte logger sendes alltid til stdout; sett `WB_LOG_FILE=/path/til/loggfil.log` for å i tillegg skrive til fil.
    - Lag bevarings- og tilgangspolicyer.
 
 5. **Secrets**  

--- a/src/core/logging/logger.ts
+++ b/src/core/logging/logger.ts
@@ -1,17 +1,17 @@
-
 import fs from 'fs';
-import path from 'path';
 import { maskPII } from './maskPII';
 
 export type Level = 'debug'|'info'|'warn'|'error';
 export type LogFields = Record<string, any> & { correlationId?: string };
 
-const LOG_FILE = process.env.WB_LOG_FILE || path.join(process.cwd(), 'workbuoy.log');
+const LOG_FILE = process.env.WB_LOG_FILE;
 
 function write(fields: Record<string, any>) {
   const rec = { ts: new Date().toISOString(), ...fields };
   const line = JSON.stringify(rec);
-  try { fs.appendFileSync(LOG_FILE, line + '\n', 'utf8'); } catch {}
+  if (LOG_FILE) {
+    try { fs.appendFileSync(LOG_FILE, line + '\n', 'utf8'); } catch {}
+  }
   // dev stdout
   console.log(line);
 }


### PR DESCRIPTION
## Summary
- avoid creating a default `workbuoy.log` file by requiring `WB_LOG_FILE`
- ensure structured logs continue to stream to stdout while optionally appending to a configured file
- document the optional `WB_LOG_FILE` environment variable in the infra logging guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db8b6af64c832aa9c0ac28d5bd75a0