### PR TITLE
test(observability): assert JSON content-type headers

### DIFF
--- a/apps/backend/src/observability/logs/router.spec.ts
+++ b/apps/backend/src/observability/logs/router.spec.ts
@@ -32,7 +32,7 @@ describe('observability logs router', () => {
       .send({ level: 'info', message: 'hello world' });
 
     expect(response.status).toBe(202);
-    expect(response.headers['content-type']).toContain('application/json');
+    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(response.headers['trace-id']).toBe(traceId);
     expect(response.body.id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
@@ -50,6 +50,7 @@ describe('observability logs router', () => {
       .send({ level: 'debug', message: '' });
 
     expect(response.status).toBe(400);
+    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(response.body).toEqual({ error: 'invalid_payload' });
   });
 

--- a/apps/backend/src/observability/telemetry/router.spec.ts
+++ b/apps/backend/src/observability/telemetry/router.spec.ts
@@ -32,7 +32,7 @@ describe('observability telemetry router', () => {
       .send({ resourceSpans: [{}] });
 
     expect(response.status).toBe(202);
-    expect(response.headers['content-type']).toContain('application/json');
+    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(response.body).toEqual({ accepted: 1 });
     expect(response.headers['trace-id']).toBe(traceId);
   });
@@ -47,6 +47,7 @@ describe('observability telemetry router', () => {
       .send({});
 
     expect(response.status).toBe(400);
+    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(response.body).toEqual({ error: 'invalid_payload' });
   });
 


### PR DESCRIPTION
## Summary
- tighten telemetry and log router specs to require the JSON content-type header
- confirm error responses also emit the expected JSON header alongside validation failures

## Testing
- TELEMETRY_ENABLED=true LOGGING_ENABLED=true npm run -w @workbuoy/backend test:observability *(fails: jest binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db9dac1a84832ab3e0090295ca2f64