### PR TITLE
feat(frontend): dashboard-shell med tilgjengelighetsfokus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## PR18 – Dashboard-shell (frontend, a11y-first)
+
+### Added – dashboard-shell.
+- apps/frontend: Ny `/dashboard`-rute med tilgjengelige tiles, ProactivitySwitch og FlipCard med skjelettlasting.
+
 ## PR16 – Frontend demo-app (FlipCard + ProactivitySwitch)
 
 ### Added

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -20,4 +20,11 @@ Tilgjengelige demovyer er tilgjengelige direkte i Vite-devserveren:
 - `/demo` – viser `FlipCard` og `ProactivitySwitch` sammen. Bruk Tab for fokus, Enter/Space for å endre modus og flippe kortet. Live-statusen annonserer "Proactive mode enabled" / "Reactive mode enabled".
 - `/dock-demo` – demonstrerer DockHost-komponenten med fokusfelle og tastaturnavigasjon.
 
+## Dashboard route
+
+- `/dashboard` – lett dashboard med proaktiv/reaktiv prioritering. Åpne `npm run dev` og naviger til `/dashboard`.
+- ProactivitySwitch prioriterer tiles og annonserer status i aria-live-sonen.
+- Tab flytter fokus mellom kontrollene i hver tile i rekkefølge, og Enter/Space kan brukes på knappene.
+- Skjelettlasting indikeres via `aria-busy` på seksjonen frem til innholdet er klart.
+
 Alle demoer er tilgjengelige uten ekstra avhengigheter og deler byggeoppsettet til hovedappen.

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { useConnections } from "./navi/useConnections";
 import ModeSwitcher from "./proactivity/ModeSwitcher";
 import { ActiveContextProvider } from "./core/ActiveContext";
 import { IntrospectionBadge } from "./components/IntrospectionBadge";
+import { PrimaryNav } from "./components/PrimaryNav";
 import DockWidget from "@/features/dock/DockWidget";
 
 function HealthBadge() {
@@ -49,34 +50,7 @@ function Shell() {
             </div>
           </div>
           <ModeSwitcher />
-          <nav aria-label="Demo routes" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            <a
-              href="/demo"
-              style={{
-                padding: "6px 12px",
-                borderRadius: 999,
-                background: "var(--surface, rgba(15,23,42,0.08))",
-                color: "inherit",
-                textDecoration: "none",
-                border: "1px solid rgba(148, 163, 184, 0.5)",
-              }}
-            >
-              Controls demo
-            </a>
-            <a
-              href="/dock-demo"
-              style={{
-                padding: "6px 12px",
-                borderRadius: 999,
-                background: "var(--surface, rgba(15,23,42,0.08))",
-                color: "inherit",
-                textDecoration: "none",
-                border: "1px solid rgba(148, 163, 184, 0.5)",
-              }}
-            >
-              Dock demo
-            </a>
-          </nav>
+          <PrimaryNav aria-label="Demo routes" />
         </header>
         <FlipCard
           front={<BuoyPanel onQuickConnect={addConnection} />}

--- a/apps/frontend/src/components/PrimaryNav.tsx
+++ b/apps/frontend/src/components/PrimaryNav.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+const linkStyles: React.CSSProperties = {
+  padding: "6px 12px",
+  borderRadius: 999,
+  background: "var(--surface, rgba(15,23,42,0.08))",
+  color: "inherit",
+  textDecoration: "none",
+  border: "1px solid rgba(148, 163, 184, 0.5)",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+};
+
+const containerStyles: React.CSSProperties = {
+  display: "flex",
+  gap: 8,
+  flexWrap: "wrap",
+};
+
+type LinkMatch = (path: string) => boolean;
+
+type NavLink = {
+  href: string;
+  label: string;
+  match: LinkMatch;
+};
+
+const NAV_LINKS: NavLink[] = [
+  {
+    href: "/dashboard",
+    label: "Dashboard",
+    match: (path) => path === "/dashboard" || path.startsWith("/dashboard/"),
+  },
+  {
+    href: "/demo",
+    label: "Controls demo",
+    match: (path) => path === "/demo" || path.startsWith("/demo/"),
+  },
+  {
+    href: "/dock-demo",
+    label: "Dock demo",
+    match: (path) => path.includes("dock-demo"),
+  },
+];
+
+export interface PrimaryNavProps {
+  currentPath?: string;
+  "aria-label"?: string;
+}
+
+export function PrimaryNav({ currentPath, "aria-label": ariaLabel = "Primary" }: PrimaryNavProps) {
+  const resolvedPath = React.useMemo(() => {
+    if (currentPath) return currentPath;
+    if (typeof window === "undefined") return "";
+    return window.location.pathname;
+  }, [currentPath]);
+
+  return (
+    <nav aria-label={ariaLabel} style={containerStyles}>
+      {NAV_LINKS.map((link) => {
+        const isActive = link.match(resolvedPath);
+        return (
+          <a
+            key={link.href}
+            href={link.href}
+            className="wbui-focus-ring"
+            style={linkStyles}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {link.label}
+          </a>
+        );
+      })}
+    </nav>
+  );
+}
+
+export default PrimaryNav;

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import DockDemo from "./routes/dock-demo";
 import ControlsDemo from "./routes/demo/controls-demo";
+import DashboardRoute from "./routes/dashboard";
 import "./styles/tokens.css";
 import "./styles/base.css";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -16,7 +17,14 @@ if (!rootElement) {
 const path = window.location.pathname;
 const isDockDemo = path.includes("dock-demo");
 const isControlsDemo = path === "/demo" || path.startsWith("/demo/");
+const isDashboard = path === "/dashboard" || path.startsWith("/dashboard/");
 
-const element = isDockDemo ? <DockDemo /> : isControlsDemo ? <ControlsDemo /> : <App />;
+const element = isDockDemo
+  ? <DockDemo />
+  : isControlsDemo
+    ? <ControlsDemo />
+    : isDashboard
+      ? <DashboardRoute />
+      : <App />;
 
 createRoot(rootElement).render(element);

--- a/apps/frontend/src/routes/dashboard/dashboard.css
+++ b/apps/frontend/src/routes/dashboard/dashboard.css
@@ -1,0 +1,216 @@
+.dashboard {
+  min-height: 100vh;
+  padding: 24px 16px 64px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.02) 0%, rgba(15, 23, 42, 0.08) 100%);
+  color: var(--foreground, #0f172a);
+}
+
+.dashboard__layout {
+  margin: 0 auto;
+  max-width: 1120px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.dashboard__header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dashboard__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dashboard__heading h1 {
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  margin: 0;
+}
+
+.dashboard__heading p {
+  margin: 0;
+  color: var(--muted-foreground, rgba(71, 85, 105, 0.96));
+}
+
+.dashboard__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.dashboard__status {
+  font-size: 0.875rem;
+  color: var(--muted-foreground, rgba(71, 85, 105, 0.96));
+}
+
+.dashboard__switch {
+  display: inline-flex;
+}
+
+.dashboard__section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.76);
+  backdrop-filter: blur(8px);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.dashboard__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dashboard__section-header h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.6vw, 1.5rem);
+}
+
+.dashboard__section-header p {
+  margin: 0;
+  color: var(--muted-foreground, rgba(71, 85, 105, 0.96));
+}
+
+.dashboard__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.dashboard__tile {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: var(--surface, rgba(255, 255, 255, 0.92));
+  padding: 20px;
+  min-height: 196px;
+}
+
+.dashboard__tile-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dashboard__tile-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.dashboard__tile-header p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted-foreground, rgba(71, 85, 105, 0.96));
+}
+
+.dashboard__list {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--muted-foreground, rgba(71, 85, 105, 0.96));
+}
+
+.dashboard__tile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dashboard__action-button {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.9);
+  color: inherit;
+  font-size: 0.875rem;
+  padding: 8px 14px;
+  transition: background 0.2s ease;
+}
+
+.dashboard__action-button:hover,
+.dashboard__action-button:focus-visible {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.dashboard__flip {
+  display: grid;
+  place-items: center;
+}
+
+.dashboard__flip-card {
+  width: min(100%, 480px);
+}
+
+.dashboard__flip-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+}
+
+.dashboard__flip-surface h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.dashboard__flip-surface ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dashboard__skeleton-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.dashboard__skeleton-tile {
+  border-radius: 20px;
+  background: linear-gradient(90deg, rgba(226, 232, 240, 0.6) 0%, rgba(203, 213, 225, 0.85) 50%, rgba(226, 232, 240, 0.6) 100%);
+  height: 196px;
+  position: relative;
+  overflow: hidden;
+}
+
+.dashboard__skeleton-tile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.5) 50%, transparent 100%);
+  animation: dashboard-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes dashboard-skeleton-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (min-width: 768px) {
+  .dashboard__header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  .dashboard__controls {
+    justify-content: flex-end;
+  }
+}

--- a/apps/frontend/src/routes/dashboard/index.test.tsx
+++ b/apps/frontend/src/routes/dashboard/index.test.tsx
@@ -1,0 +1,87 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DashboardRoute from "./index";
+import { vi } from "vitest";
+
+describe("Dashboard route", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the main landmark and headings", async () => {
+    render(<DashboardRoute />);
+
+    expect(screen.getByRole("main")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: /priority overview/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: /activity highlights/i })).toBeInTheDocument();
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    const tileHeadings = await screen.findAllByRole("heading", { level: 3 });
+    expect(tileHeadings[0]).toHaveTextContent(/suggested next steps/i);
+  });
+
+  it("supports tab navigation between tile controls", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<DashboardRoute />);
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    const firstGroup = screen.getByRole("group", { name: /suggested next steps actions/i });
+    const firstButtons = within(firstGroup).getAllByRole("button");
+    firstButtons[0].focus();
+    expect(firstButtons[0]).toHaveFocus();
+
+    await user.tab();
+    expect(firstButtons[1]).toHaveFocus();
+
+    await user.tab();
+    const secondGroup = screen.getByRole("group", { name: /momentum boosts actions/i });
+    const secondButtons = within(secondGroup).getAllByRole("button");
+    expect(secondButtons[0]).toHaveFocus();
+  });
+
+  it("toggles content with the proactivity switch", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<DashboardRoute />);
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings[0]).toHaveTextContent(/suggested next steps/i);
+
+    const status = screen.getByTestId("dashboard-status");
+    expect(status).toHaveTextContent(/proactive view enabled/i);
+
+    const toggle = screen.getByRole("switch", { name: /dashboard proactivity mode/i });
+    await user.click(toggle);
+
+    const reorderedHeadings = screen.getAllByRole("heading", { level: 3 });
+    expect(reorderedHeadings[0]).toHaveTextContent(/customer escalations/i);
+    expect(status).toHaveTextContent(/reactive view enabled/i);
+  });
+
+  it("updates aria-busy once the skeleton finishes loading", async () => {
+    render(<DashboardRoute />);
+    const section = screen.getByRole("region", { name: /priority overview/i });
+    expect(section).toHaveAttribute("aria-busy", "true");
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    await screen.findAllByRole("heading", { level: 3 });
+    expect(section).toHaveAttribute("aria-busy", "false");
+  });
+});

--- a/apps/frontend/src/routes/dashboard/index.tsx
+++ b/apps/frontend/src/routes/dashboard/index.tsx
@@ -1,0 +1,247 @@
+import React from "react";
+import { FlipCard, type FlipCardProps, ProactivitySwitch, type Mode } from "@workbuoy/ui";
+import { IntrospectionBadge } from "@/components/IntrospectionBadge";
+import { PrimaryNav } from "@/components/PrimaryNav";
+import "./dashboard.css";
+
+type TileDefinition = {
+  id: string;
+  title: string;
+  description: string;
+  highlights: string[];
+  actions: string[];
+};
+
+const PROACTIVE_TILES: TileDefinition[] = [
+  {
+    id: "next-steps",
+    title: "Suggested next steps",
+    description: "Signals from account health and planner",
+    highlights: [
+      "Schedule outreach with Northwind — response overdue by 2 days",
+      "Share KPI summary with Phoenix Solar ahead of renewals",
+      "Review the auto-generated brief for the newly assigned region",
+    ],
+    actions: ["Plan outreach", "Open planner"],
+  },
+  {
+    id: "momentum",
+    title: "Momentum boosts",
+    description: "Keep successful threads moving forward",
+    highlights: [
+      "Acknowledge Beacon Corp pilot launch success",
+      "Offer next-step workshop to Delta Analytics champions",
+      "Queue a follow-up for partners flagged as high potential",
+    ],
+    actions: ["Share update", "Celebrate wins"],
+  },
+];
+
+const REACTIVE_TILES: TileDefinition[] = [
+  {
+    id: "escalations",
+    title: "Customer escalations",
+    description: "Requires attention today",
+    highlights: [
+      "Critical: Beacon Corp requesting pricing adjustments",
+      "High: Ticket #4821 waiting on solution validation",
+      "Reminder: Support rotation handoff due before 14:00",
+    ],
+    actions: ["View escalation", "Reply now"],
+  },
+  {
+    id: "inbox",
+    title: "Inbox queue",
+    description: "Items assigned directly to you",
+    highlights: [
+      "5 new requests in the shared inbox",
+      "3 follow-ups due by 17:00",
+      "Auto-generated summary ready for tomorrow's sync",
+    ],
+    actions: ["Open inbox", "Mark blockers"],
+  },
+];
+
+const TODAY_ITEMS = [
+  "Daily stand-up summary posted",
+  "Renewal risk alerts updated",
+  "Two opportunities flagged for quick review",
+];
+
+const WEEK_ITEMS = [
+  "Three renewals closing this week",
+  "Workflow automation report ready",
+  "Team retro scheduled for Thursday",
+];
+
+const SKELETON_TILES = 4;
+const SKELETON_DELAY = 900;
+
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(query.matches);
+
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", listener);
+    } else if (typeof query.addListener === "function") {
+      query.addListener(listener);
+    }
+
+    return () => {
+      if (typeof query.removeEventListener === "function") {
+        query.removeEventListener("change", listener);
+      } else if (typeof query.removeListener === "function") {
+        query.removeListener(listener);
+      }
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+function DashboardTile({ tile }: { tile: TileDefinition }) {
+  return (
+    <article className="dashboard__tile" aria-labelledby={`${tile.id}-title`}>
+      <div className="dashboard__tile-header">
+        <h3 id={`${tile.id}-title`}>{tile.title}</h3>
+        <p>{tile.description}</p>
+      </div>
+      <ul className="dashboard__list">
+        {tile.highlights.map((highlight) => (
+          <li key={highlight}>{highlight}</li>
+        ))}
+      </ul>
+      <div role="group" className="dashboard__tile-actions" aria-label={`${tile.title} actions`}>
+        {tile.actions.map((action) => (
+          <button key={action} type="button" className="wbui-focus-ring dashboard__action-button">
+            {action}
+          </button>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export default function DashboardRoute() {
+  const [mode, setMode] = React.useState<Mode>("proactive");
+  const [status, setStatus] = React.useState("Proactive view enabled");
+  const [loading, setLoading] = React.useState(true);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setLoading(false), SKELETON_DELAY);
+    return () => clearTimeout(timer);
+  }, []);
+
+  React.useEffect(() => {
+    setStatus(mode === "proactive" ? "Proactive view enabled" : "Reactive view enabled");
+  }, [mode]);
+
+  const orderedTiles = React.useMemo(() => {
+    return mode === "proactive"
+      ? [...PROACTIVE_TILES, ...REACTIVE_TILES]
+      : [...REACTIVE_TILES, ...PROACTIVE_TILES];
+  }, [mode]);
+
+  const flipCardProps = React.useMemo<Partial<FlipCardProps>>(
+    () => ({
+      motionProfile: prefersReducedMotion ? "calm" : "default",
+      allowedSizes: ["sm", "md", "lg"],
+      size: "md",
+    }),
+    [prefersReducedMotion],
+  );
+
+  return (
+    <main role="main" className="dashboard">
+      <div className="dashboard__layout">
+        <header className="dashboard__header">
+          <div className="dashboard__heading">
+            <h1>Dashboard</h1>
+            <p>Prioritise what matters across proactive and reactive work.</p>
+          </div>
+          <div className="dashboard__controls">
+            <IntrospectionBadge />
+            <PrimaryNav currentPath="/dashboard" aria-label="Primary navigation" />
+            <ProactivitySwitch
+              value={mode}
+              onChange={setMode}
+              aria-label="Dashboard proactivity mode"
+              className="dashboard__switch"
+            />
+            <span className="dashboard__status" aria-live="polite" data-testid="dashboard-status">
+              {status}
+            </span>
+          </div>
+        </header>
+
+        <section className="dashboard__section" aria-labelledby="dashboard-priority-heading" aria-busy={loading}>
+          <div className="dashboard__section-header">
+            <h2 id="dashboard-priority-heading">Priority overview</h2>
+            <p>Tiles reorder based on the selected mode so the right work stays first.</p>
+          </div>
+          {loading ? (
+            <div className="dashboard__skeleton-grid" aria-hidden="true">
+              {Array.from({ length: SKELETON_TILES }).map((_, index) => (
+                <div key={index} className="dashboard__skeleton-tile" />
+              ))}
+            </div>
+          ) : (
+            <div className="dashboard__grid">
+              {orderedTiles.map((tile) => (
+                <DashboardTile key={tile.id} tile={tile} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="dashboard__section" aria-labelledby="dashboard-activity-heading">
+          <div className="dashboard__section-header">
+            <h2 id="dashboard-activity-heading">Activity highlights</h2>
+            <p>Flip between what is happening today and the rest of the week.</p>
+          </div>
+          <div className="dashboard__flip">
+            <div className="dashboard__flip-card">
+              <FlipCard
+                front={
+                  <div className="dashboard__flip-surface" aria-label="Today">
+                    <h3>Today</h3>
+                    <ul>
+                      {TODAY_ITEMS.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                }
+                back={
+                  <div className="dashboard__flip-surface" aria-label="This week">
+                    <h3>This week</h3>
+                    <ul>
+                      {WEEK_ITEMS.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                }
+                ariaLabelFront="Today"
+                ariaLabelBack="This week"
+                {...flipCardProps}
+              />
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable PrimaryNav with dashboard entry and aria-current handling for active routes
- introduce /dashboard route with accessible tiles, aria-live status, skeleton loading and FlipCard highlights
- cover dashboard with RTL tests plus docs and changelog updates

## Testing
- npm run lint -w @workbuoy/frontend
- npm run typecheck -w @workbuoy/frontend
- npm run test -w @workbuoy/frontend

------
https://chatgpt.com/codex/tasks/task_e_68dbac2ac5fc832a832acba9b5de3587