### PR TITLE
feat(frontend/dashboard): state views with live status and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## PR20 – Dashboard state views (empty/error/partial)
+
+### Added
+- apps/frontend: `/dashboard` har nye tom-, feil- og delvis-lastede visninger med aria-live-status, aria-busy og fokusbevaring på "Prøv igjen".
+- apps/frontend: Partial-visning viser N av M paneler med tydelig chip og beskrivelser som kobles via `aria-describedby`.
+- apps/frontend: Nye Vitest-tester dekker empty/error/partial/ready, tastaturretry og live-region-oppdateringer.
+
+### Docs
+- README/CHANGELOG oppdatert med "State views".
+
 ## PR19 – Dashboard UI-polish (a11y, fokus, semantikk)
 
 ### Improved

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ What’s here
 
 - apps/backend — API & services
 - apps/frontend — Web app
-  - `/dashboard` har semantiske landmarks, tydelige fokusringer og tastaturnavigasjon.
+  - `/dashboard` har semantiske landmarks, tydelige fokusringer, tastaturnavigasjon og state views (tom/delvis/feil) med live-status.
 - types/ — shared ambient types
 - tools/ — repo guards, scripts
 - deploy/ — Helm charts & k8s manifests
@@ -64,6 +64,7 @@ Dashboard accessibility
 -----------------------
 
 - `/dashboard` fokuserer hovedinnholdet ved rute-aktivering, har live-status for proaktiv/reaktiv visning og skjermleservennlig skjelettlasting.
+- Nye state views for tom, feil og delvis-lastet innhold annonseres via egen aria-live-region og støtter tastaturdrevet retry.
 
 Governance
 ----------

--- a/apps/frontend/src/routes/dashboard/dashboard.css
+++ b/apps/frontend/src/routes/dashboard/dashboard.css
@@ -91,6 +91,12 @@
   gap: 6px;
 }
 
+.dashboard__section-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .dashboard__section-header h2 {
   margin: 0;
   font-size: clamp(1.25rem, 1.6vw, 1.5rem);
@@ -105,6 +111,99 @@
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.dashboard__state {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-radius: 16px;
+  padding: 16px 20px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+}
+
+.dashboard__state-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dashboard__state-content h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.dashboard__state-content p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-foreground, rgba(71, 85, 105, 0.96));
+}
+
+.dashboard__state--empty {
+  background: rgba(226, 232, 240, 0.35);
+}
+
+.dashboard__state--error {
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(254, 226, 226, 0.6);
+}
+
+.dashboard__retry-button {
+  border-radius: 999px;
+  border: 1px solid rgba(248, 113, 113, 0.8);
+  background: rgba(248, 113, 113, 0.14);
+  color: #b91c1c;
+  font-weight: 600;
+  padding: 8px 18px;
+  cursor: pointer;
+}
+
+.dashboard__retry-button:hover,
+.dashboard__retry-button:focus-visible {
+  background: rgba(248, 113, 113, 0.24);
+}
+
+.dashboard__link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 8px 18px;
+  border: 1px solid rgba(37, 99, 235, 0.45);
+  background: rgba(37, 99, 235, 0.14);
+  color: rgba(37, 99, 235, 0.95);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dashboard__link-button:hover,
+.dashboard__link-button:focus-visible {
+  background: rgba(37, 99, 235, 0.24);
+}
+
+.dashboard__state-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted-foreground, rgba(71, 85, 105, 0.96));
+}
+
+.dashboard__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.dashboard__chip--partial {
+  background: rgba(250, 204, 21, 0.25);
+  color: #92400e;
+  border: 1px solid rgba(250, 204, 21, 0.4);
 }
 
 .dashboard__tile {

--- a/apps/frontend/src/routes/dashboard/index.a11y.test.tsx
+++ b/apps/frontend/src/routes/dashboard/index.a11y.test.tsx
@@ -4,11 +4,15 @@ import DashboardRoute from "./index";
 import { vi } from "vitest";
 
 describe("Dashboard route accessibility", () => {
+  let randomSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.useFakeTimers();
+    randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.95);
   });
 
   afterEach(() => {
+    randomSpy.mockRestore();
     vi.useRealTimers();
   });
 

--- a/apps/frontend/src/routes/dashboard/index.stateviews.test.tsx
+++ b/apps/frontend/src/routes/dashboard/index.stateviews.test.tsx
@@ -1,0 +1,135 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import DashboardRoute from "./index";
+
+const advanceLoading = async () => {
+  await act(async () => {
+    vi.advanceTimersByTime(900);
+  });
+};
+
+describe("Dashboard state views", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the empty state when no tiles are returned", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValueOnce(0.1);
+
+    try {
+      render(<DashboardRoute />);
+
+      await advanceLoading();
+
+      const priorityRegion = screen.getByRole("region", { name: /priority overview/i });
+      expect(priorityRegion).toHaveAttribute("aria-busy", "false");
+
+      const emptyStatus = within(priorityRegion).getByRole("status");
+      expect(emptyStatus).toHaveTextContent(/ingen paneler ennå/i);
+
+      const addPanels = within(priorityRegion).getByRole("button", { name: /legg til paneler/i });
+      addPanels.focus();
+      expect(addPanels).toHaveFocus();
+
+      expect(screen.getByTestId("dash-live")).toHaveTextContent(/tomt dashboard/i);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("announces errors and supports retry via keyboard", async () => {
+    const randomSpy = vi
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0.3)
+      .mockReturnValueOnce(0.3)
+      .mockReturnValueOnce(0.95);
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    try {
+      render(<DashboardRoute />);
+
+      await advanceLoading();
+
+      const priorityRegion = screen.getByRole("region", { name: /priority overview/i });
+      expect(priorityRegion).toHaveAttribute("aria-busy", "false");
+
+      const errorStatus = within(priorityRegion).getByRole("status");
+      expect(errorStatus).toHaveTextContent(/kunne ikke laste panelene/i);
+      expect(screen.getByTestId("dash-live")).toHaveTextContent(/feil ved lasting/i);
+
+      const retry = within(priorityRegion).getByRole("button", { name: /prøv igjen/i });
+      retry.focus();
+      expect(retry).toHaveFocus();
+
+      await user.keyboard("{Enter}");
+      expect(priorityRegion).toHaveAttribute("aria-busy", "true");
+
+      await advanceLoading();
+
+      const errorStatusAgain = within(priorityRegion).getByRole("status");
+      expect(errorStatusAgain).toHaveTextContent(/kunne ikke laste panelene/i);
+      expect(retry).toHaveFocus();
+
+      await user.keyboard("{Space}");
+      expect(priorityRegion).toHaveAttribute("aria-busy", "true");
+
+      await advanceLoading();
+
+      expect(priorityRegion).toHaveAttribute("aria-busy", "false");
+      expect(priorityRegion).not.toHaveAttribute("aria-describedby");
+      expect(within(priorityRegion).queryByRole("status")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /suggested next steps/i })).toBeInTheDocument();
+      expect(screen.getByTestId("dash-live")).toHaveTextContent(/alle dashboard-paneler klare/i);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("renders the partial state with live updates", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValueOnce(0.55);
+
+    try {
+      render(<DashboardRoute />);
+
+      await advanceLoading();
+
+      const priorityRegion = screen.getByRole("region", { name: /priority overview/i });
+      expect(priorityRegion).toHaveAttribute("aria-busy", "false");
+      expect(priorityRegion).toHaveAttribute("aria-describedby", expect.stringContaining("dashboard-priority-partial"));
+
+      expect(screen.getByText(/3 av 4 paneler klare/i)).toBeInTheDocument();
+      expect(screen.getByTestId("dash-live")).toHaveTextContent(/3 av 4 paneler klare/i);
+
+      const tiles = screen.getAllByRole("article");
+      expect(tiles).toHaveLength(3);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("renders the ready state when all tiles load", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValueOnce(0.95);
+
+    try {
+      render(<DashboardRoute />);
+
+      await advanceLoading();
+
+      const priorityRegion = screen.getByRole("region", { name: /priority overview/i });
+      expect(priorityRegion).toHaveAttribute("aria-busy", "false");
+      expect(priorityRegion).not.toHaveAttribute("aria-describedby");
+
+      const tiles = screen.getAllByRole("article");
+      expect(tiles).toHaveLength(4);
+      expect(screen.getByTestId("dash-live")).toHaveTextContent(/alle dashboard-paneler klare/i);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a local dashboard data model that cycles empty/error/partial/ready outcomes, updates aria-live status, and restores retry focus
- surface empty/error/partial UI affordances with live announcements, busy indicators, and partial chip styling for accessibility
- add Vitest coverage for state views, update existing a11y tests for deterministic loads, and document the new state views in README/CHANGELOG

## Testing
- npm run -w @workbuoy/frontend typecheck
- npm run -w @workbuoy/frontend test
- npm run -w @workbuoy/frontend lint *(fails: shared eslint config is missing @typescript-eslint/parser in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb635f684832a81550b25dc143ac8