### PR TITLE
feat(ui): add BuoyDock widget with expand and accessibility updates

### DIFF
--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Unreleased
+
+- Demo: `dock-demo` route now embeds the `BuoyDock` widget with chat frontside and Navi backside, showcasing flip/expand behaviour.

--- a/apps/frontend/src/routes/dock-demo.tsx
+++ b/apps/frontend/src/routes/dock-demo.tsx
@@ -1,102 +1,204 @@
 import React from "react";
-import { DockHost, useFocusReturn } from "@/features/dock";
+import { BuoyDock } from "@workbuoy/ui";
 
-export default function DockDemo() {
-  const [open, setOpen] = React.useState(false);
-  const [liveMessage, setLiveMessage] = React.useState("");
-  const approveRef = React.useRef<HTMLButtonElement>(null);
-  const focusReturnRef = useFocusReturn(open);
+const chatMessages = [
+  { id: 1, author: "Buoy", text: "Hei! Hvordan kan jeg hjelpe deg i dag?" },
+  {
+    id: 2,
+    author: "Du",
+    text: "Vis meg de viktigste navigasjonskortene for denne uken.",
+  },
+  {
+    id: 3,
+    author: "Buoy",
+    text: "Klart! Navi har tre anbefalinger og to varsler du bør se på.",
+  },
+];
 
-  const handleApprove = () => {
-    setLiveMessage("Approved");
-  };
+const naviSections = [
+  {
+    id: "alerts",
+    title: "Varsler",
+    description: "Oppdater SLA for team Beta og sjekk nye risikomeldinger.",
+  },
+  {
+    id: "insights",
+    title: "Innsikt",
+    description: "Pipeline-konvertering opp 14% siden forrige uke.",
+  },
+  {
+    id: "actions",
+    title: "Handlinger",
+    description: "Planlegg kvartalsmøte og bekreft nye dashboards.",
+  },
+  {
+    id: "reports",
+    title: "Rapporter",
+    description: "Q2 status er klar med detaljerte segmentanalyser.",
+  },
+  {
+    id: "team",
+    title: "Team",
+    description: "3 nye medlemmer trenger onboarding i Navi.",
+  },
+  {
+    id: "roadmap",
+    title: "Roadmap",
+    description: "Oppgaver for juli sprinten er klare til sign-off.",
+  },
+];
 
-  const handleCancel = () => {
-    setOpen(false);
-  };
+function ChatPanel() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        height: "100%",
+      }}
+    >
+      <ul
+        style={{
+          listStyle: "none",
+          margin: 0,
+          padding: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+          overflowY: "auto",
+          flex: 1,
+        }}
+      >
+        {chatMessages.map((message) => (
+          <li
+            key={message.id}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "4px",
+              background: "rgba(15, 23, 42, 0.65)",
+              borderRadius: "12px",
+              padding: "12px 14px",
+              border: "1px solid rgba(148, 163, 184, 0.25)",
+            }}
+          >
+            <span style={{ fontSize: "0.75rem", opacity: 0.7 }}>{message.author}</span>
+            <span style={{ fontSize: "0.95rem" }}>{message.text}</span>
+          </li>
+        ))}
+      </ul>
+      <form
+        aria-label="Send melding"
+        style={{
+          display: "flex",
+          gap: "8px",
+          alignItems: "center",
+          background: "rgba(15, 23, 42, 0.7)",
+          borderRadius: "12px",
+          padding: "8px 12px",
+          border: "1px solid rgba(148, 163, 184, 0.25)",
+        }}
+        onSubmit={(event) => event.preventDefault()}
+      >
+        <input
+          type="text"
+          placeholder="Skriv en melding..."
+          aria-label="Meldingsfelt"
+          style={{
+            flex: 1,
+            background: "transparent",
+            border: "none",
+            color: "inherit",
+            fontSize: "0.95rem",
+            outline: "none",
+          }}
+        />
+        <button
+          type="submit"
+          className="wbui-focus-ring"
+          style={{
+            border: "1px solid rgba(148, 163, 184, 0.35)",
+            background: "rgba(148, 163, 184, 0.16)",
+            color: "inherit",
+            borderRadius: "999px",
+            padding: "6px 16px",
+            fontSize: "0.85rem",
+            cursor: "pointer",
+          }}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function NaviPanel({ expanded }: { expanded: boolean }) {
+  const visibleSections = expanded ? naviSections : naviSections.slice(0, 3);
 
   return (
     <div
       style={{
-        minHeight: "100vh",
-        background: "linear-gradient(135deg, #0f172a, #1e293b)",
-        color: "#f8fafc",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: "24px",
-        padding: "32px",
+        display: "grid",
+        gridTemplateColumns: expanded ? "repeat(2, minmax(0, 1fr))" : "1fr",
+        gap: "12px",
+        paddingBottom: "4px",
       }}
     >
-      <div style={{ textAlign: "center", maxWidth: 480 }}>
-        <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>Dock Host Demo</h1>
-        <p style={{ margin: 0, opacity: 0.72 }}>
-          Press the button below to open the DockHost modal and explore the accessible focus trap.
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        style={{
-          fontSize: "1rem",
-          padding: "12px 20px",
-          borderRadius: "999px",
-          border: "1px solid rgba(148, 163, 184, 0.6)",
-          background: "rgba(15, 23, 42, 0.6)",
-          color: "inherit",
-          cursor: "pointer",
-        }}
-      >
-        Open Dock
-      </button>
-      {open ? (
-        <DockHost
-          open={open}
-          onClose={() => setOpen(false)}
-          title="Dock Host"
-          description="Stay focused inside this dialog. Tab and Shift+Tab cycle within the action buttons."
-          liveMessage={liveMessage}
-          initialFocusRef={approveRef}
-          lastActiveElement={focusReturnRef.current}
+      {visibleSections.map((section) => (
+        <article
+          key={section.id}
+          style={{
+            background: "rgba(15, 23, 42, 0.65)",
+            borderRadius: "16px",
+            padding: "16px",
+            border: "1px solid rgba(148, 163, 184, 0.25)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+          }}
         >
-          <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
-            <button
-              ref={approveRef}
-              type="button"
-              onClick={handleApprove}
-              style={{
-                padding: "10px 16px",
-                borderRadius: "8px",
-                border: "none",
-                background: "#22d3ee",
-                color: "#0f172a",
-                fontWeight: 600,
-                cursor: "pointer",
-              }}
-            >
-              Approve
-            </button>
-            <button
-              type="button"
-              onClick={handleCancel}
-              style={{
-                padding: "10px 16px",
-                borderRadius: "8px",
-                border: "1px solid rgba(148, 163, 184, 0.6)",
-                background: "transparent",
-                color: "inherit",
-                cursor: "pointer",
-              }}
-            >
-              Cancel
-            </button>
-          </div>
-          {liveMessage ? (
-            <p style={{ margin: 0, fontSize: "0.9rem", opacity: 0.85 }}>Status: {liveMessage}</p>
-          ) : null}
-        </DockHost>
-      ) : null}
+          <h3 style={{ margin: 0, fontSize: "1rem" }}>{section.title}</h3>
+          <p style={{ margin: 0, fontSize: "0.9rem", opacity: 0.8 }}>
+            {section.description}
+          </p>
+        </article>
+      ))}
     </div>
+  );
+}
+
+export default function DockDemo() {
+  const [expanded, setExpanded] = React.useState(false);
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "radial-gradient(circle at top right, #1e293b, #020617)",
+        color: "#f8fafc",
+        padding: "48px",
+      }}
+    >
+      <section style={{ maxWidth: 720 }}>
+        <h1 style={{ fontSize: "2.5rem", marginBottom: "12px" }}>
+          BuoyDock widget
+        </h1>
+        <p style={{ margin: 0, opacity: 0.75, fontSize: "1.05rem" }}>
+          En kompakt chatflate foran og Navi på baksiden. Bruk flip for å bytte
+          flate, og utvid for større innsikt når du trenger mer plass.
+        </p>
+      </section>
+      <BuoyDock
+        titleFront="buoy ai"
+        titleBack="Navi"
+        expanded={expanded}
+        onExpandedChange={setExpanded}
+        childrenFront={<ChatPanel />}
+        childrenBack={<NaviPanel expanded={expanded} />}
+        ariaLabel="BuoyDock widget"
+      />
+    </main>
   );
 }

--- a/apps/frontend/src/types/ui.d.ts
+++ b/apps/frontend/src/types/ui.d.ts
@@ -1,0 +1,3 @@
+declare module "@workbuoy/ui" {
+  export { BuoyDock, type BuoyDockProps } from "../../../packages/ui/src/BuoyDock/BuoyDock";
+}

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -9,8 +9,8 @@
     "rootDirs": ["./src", "../../packages/ui/src"],
     "paths": {
       "@/*": ["./*"],
-      "@workbuoy/ui": ["../../packages/ui/src/index.ts"],
-      "@workbuoy/ui/*": ["../../packages/ui/src/*"]
+      "@workbuoy/ui": ["../../../packages/ui/src/index.ts"],
+      "@workbuoy/ui/*": ["../../../packages/ui/src/*"]
     },
     "types": ["vitest", "node", "@testing-library/jest-dom"]
   },

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Fix: Ensure `ROLLUP_SKIP_NODEJS_NATIVE`/`ROLLUP_SKIP_NATIVE` are set before Vitest and Storybook load Rollup to prefer the JS fallback.
 - Fix: Vitest/Storybook use Rollup JS fallback in CI; add framer-motion devDependency.
 - Improved: FlipCard and ProactivitySwitch expose richer accessibility affordances (roles, focus rings, reduced motion) and ship matching Storybook docs.
+- Feat: Added `BuoyDock`, a fixed dock widget combining chat (front) and Navi (back) with accessible flip/expand controls and reduced-motion aware animations.
+- Docs: Storybook + README document the BuoyDock keyboard model, focus trap, and usage as a chat/Navi launcher.
 
 ## PR9 – Release & polish
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -14,6 +14,32 @@ Shared UI components for Workbuoy applications.
 - All interactive components ship with a shared `.wbui-focus-ring` style (imported via `@workbuoy/ui/index.css`) so keyboard users get a consistent, high-contrast outline via `:focus-visible`.
 - `FlipCard` behaves like a toggle button (`role="button"`, `aria-pressed`) and reacts to <kbd>Enter</kbd> and <kbd>Space</kbd>. If users request reduced motion, the flip completes instantly.
 - `ProactivitySwitch` maps to `role="switch"` with `aria-checked` and an optional `aria-label`/`aria-labelledby`. Pressing <kbd>Enter</kbd> or <kbd>Space</kbd> toggles the mode, and a polite `aria-live` announcement confirms the current state for assistive tech users.
+- `BuoyDock` acts as `role="complementary"` by default and upgrades to a `role="dialog"` with focus-fencing when expanded. The flip/expand controls expose clear keyboard bindings, while a polite `aria-live` region announces state changes and reduced-motion users get 0–100 ms transitions.
+
+## BuoyDock – widget nederst til høyre
+
+```tsx
+import { useState } from "react";
+import { BuoyDock } from "@workbuoy/ui";
+
+function DockWidget() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <BuoyDock
+      titleFront="buoy ai"
+      titleBack="Navi"
+      expanded={expanded}
+      onExpandedChange={setExpanded}
+      ariaLabel="BuoyDock widget"
+      childrenFront={<div>Chat-innhold</div>}
+      childrenBack={<div>Navi-flater</div>}
+    />
+  );
+}
+```
+
+`BuoyDock` henter FlipCard internt, men låser seg til en fast posisjon nederst til høyre (`position: fixed`). Når brukeren trykker `Expand` går widgeten over til et større panel med fokusfelle, `aria-modal="true"` og `Escape` for å lukke. `onExpandedChange` gjør det enkelt å synkronisere «utvidet» tilstand med resten av appen.
 
 ## ProactivitySwitch
 

--- a/packages/ui/src/BuoyDock/BuoyDock.a11y.test.tsx
+++ b/packages/ui/src/BuoyDock/BuoyDock.a11y.test.tsx
@@ -1,0 +1,154 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BuoyDock } from "./BuoyDock.js";
+
+const originalMatchMedia = window.matchMedia;
+
+function mockMatchMedia(matches: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: (_event: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_event: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    },
+    addListener: (listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    },
+    removeListener: (listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    },
+    dispatchEvent: (event: MediaQueryListEvent) => {
+      listeners.forEach((listener) => listener(event));
+      return true;
+    },
+  }));
+}
+
+function getNamedButton(name: RegExp) {
+  const elements = screen.getAllByRole("button", { name });
+  const button = elements.find((element) => element.tagName === "BUTTON");
+  if (!button) {
+    throw new Error(`Button with name ${name} not found`);
+  }
+  return button as HTMLButtonElement;
+}
+
+async function findNamedButton(name: RegExp) {
+  const elements = await screen.findAllByRole("button", { name });
+  const button = elements.find((element) => element.tagName === "BUTTON");
+  if (!button) {
+    throw new Error(`Button with name ${name} not found`);
+  }
+  return button as HTMLButtonElement;
+}
+
+describe("BuoyDock accessibility", () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("flips and expands with keyboard control while managing focus", async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <BuoyDock
+        titleFront="buoy ai"
+        titleBack="Navi"
+        ariaLabel="BuoyDock widget"
+        childrenFront={<div>Chat content</div>}
+        childrenBack={
+          <div>
+            <button type="button">Handling</button>
+          </div>
+        }
+      />,
+    );
+
+    const dock = screen.getByRole("complementary", { name: /buoydock widget/i });
+    expect(dock).toHaveAttribute("data-expanded", "false");
+    expect(dock).toHaveAccessibleName("BuoyDock widget");
+
+    const flipToBack = getNamedButton(/flip to navi/i);
+
+    await act(async () => {
+      await user.click(flipToBack);
+    });
+
+    const flipToFront = await findNamedButton(/flip to buoy ai/i);
+    expect(flipToFront).toBeVisible();
+    expect(dock).toHaveAttribute("data-expanded", "false");
+
+    const expandButton = await findNamedButton(/expand/i);
+
+    await act(async () => {
+      await user.click(expandButton);
+    });
+
+    const dialog = await screen.findByRole("dialog", { name: /navi/i });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("data-expanded", "true");
+
+    const backHeader = within(dialog).getByText("Navi");
+    expect(backHeader).toHaveFocus();
+
+    const liveRegion = container.querySelector(".wbui-buoydock__live-region");
+    expect(liveRegion?.textContent).toBe("Navi expanded");
+
+    await act(async () => {
+      await user.keyboard("{Escape}");
+    });
+
+    const collapsedDock = await screen.findByRole("complementary", { name: /buoydock widget/i });
+    expect(collapsedDock).toHaveAttribute("data-expanded", "false");
+    expect(liveRegion?.textContent).toBe("Navi collapsed");
+    expect(expandButton).toHaveFocus();
+  });
+
+  it("respects reduced motion preferences", async () => {
+    mockMatchMedia(true);
+    const user = userEvent.setup();
+
+    render(
+      <BuoyDock
+        titleFront="buoy ai"
+        titleBack="Navi"
+        ariaLabel="BuoyDock widget"
+        childrenFront={<div>Chat</div>}
+        childrenBack={<div>Navi</div>}
+      />,
+    );
+
+    const dock = screen.getByRole("complementary", { name: /buoydock widget/i });
+
+    await waitFor(() => {
+      expect(dock).toHaveAttribute("data-reduced-motion", "true");
+    });
+
+    const flipToBack = getNamedButton(/flip to navi/i);
+
+    await act(async () => {
+      flipToBack.focus();
+      await user.keyboard("{Enter}");
+    });
+
+    const expandButton = await findNamedButton(/expand/i);
+
+    await act(async () => {
+      await user.click(expandButton);
+    });
+
+    expect(await screen.findByRole("dialog", { name: /navi/i })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/BuoyDock/BuoyDock.stories.tsx
+++ b/packages/ui/src/BuoyDock/BuoyDock.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useMemo, useState } from "react";
+
+import { BuoyDock, type BuoyDockProps } from "./BuoyDock.js";
+
+type StoryArgs = Pick<
+  BuoyDockProps,
+  "initialSide" | "defaultExpanded" | "titleFront" | "titleBack"
+> & {
+  ariaLabel: string;
+};
+
+const chatLog = [
+  "Hei! Jeg er Buoy – klar for spørsmål?",
+  "Gi meg de viktigste Navi-flisene for denne uken.",
+  "Selvsagt! Jeg har tre anbefalinger klare.",
+];
+
+const naviItems = [
+  { title: "Varsler", description: "Oppdater SLA og sjekk nye risikoer." },
+  { title: "Handlinger", description: "Planlegg neste kvartalsmøte." },
+  { title: "Dashboards", description: "Tre nye dashboards trenger godkjenning." },
+  { title: "Innsikt", description: "Konvertering opp 12% siden forrige uke." },
+  { title: "Team", description: "To nye medlemmer klar for onboarding." },
+  { title: "Rapporter", description: "Månedlig status er klar for review." },
+];
+
+function StoryChat() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px", height: "100%" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "8px",
+          padding: "12px 16px",
+          background: "rgba(15, 23, 42, 0.65)",
+          borderRadius: "16px",
+          border: "1px solid rgba(148, 163, 184, 0.3)",
+        }}
+      >
+        {chatLog.map((line, index) => (
+          <p key={line} style={{ margin: 0, fontSize: "0.95rem", opacity: index === 0 ? 0.9 : 0.75 }}>
+            {line}
+          </p>
+        ))}
+      </div>
+      <button
+        type="button"
+        className="wbui-focus-ring"
+        style={{
+          alignSelf: "flex-end",
+          borderRadius: "999px",
+          border: "1px solid rgba(148, 163, 184, 0.4)",
+          background: "rgba(148, 163, 184, 0.16)",
+          color: "inherit",
+          padding: "8px 16px",
+          fontSize: "0.85rem",
+        }}
+      >
+        Send forslag
+      </button>
+    </div>
+  );
+}
+
+function StoryNavi({ expanded }: { expanded: boolean }) {
+  const visible = useMemo(() => (expanded ? naviItems : naviItems.slice(0, 3)), [expanded]);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "12px",
+        gridTemplateColumns: expanded ? "repeat(2, minmax(0, 1fr))" : "1fr",
+      }}
+    >
+      {visible.map((item) => (
+        <article
+          key={item.title}
+          style={{
+            padding: "16px",
+            borderRadius: "16px",
+            border: "1px solid rgba(148, 163, 184, 0.3)",
+            background: "rgba(15, 23, 42, 0.65)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+          }}
+        >
+          <h3 style={{ margin: 0, fontSize: "1rem" }}>{item.title}</h3>
+          <p style={{ margin: 0, fontSize: "0.9rem", opacity: 0.8 }}>{item.description}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+const meta = {
+  title: "Dock/BuoyDock",
+  component: BuoyDock,
+  args: {
+    initialSide: "front",
+    defaultExpanded: false,
+    titleFront: "buoy ai",
+    titleBack: "Navi",
+    ariaLabel: "BuoyDock widget",
+  },
+  argTypes: {
+    initialSide: {
+      control: "inline-radio",
+      options: ["front", "back"],
+      description: "Velg hvilken side som vises først når docken monteres.",
+    },
+    defaultExpanded: {
+      control: "boolean",
+      description: "Starter docken i utvidet dialog-modus.",
+    },
+    titleFront: { control: "text" },
+    titleBack: { control: "text" },
+    ariaLabel: { control: "text" },
+  },
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "BuoyDock fungerer som en fast widget nederst til høyre. Forsiden viser en kompakt Buoy-chat, mens baksiden holder Navi. Bruk flip-kontrollen for å bytte side og `Expand` for å gå inn i et dialog-lignende panel med fokusfelle. Reduced motion respekteres automatisk.",
+      },
+    },
+  },
+} satisfies Meta<StoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<StoryArgs>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [expanded, setExpanded] = useState(args.defaultExpanded ?? false);
+
+    useEffect(() => {
+      setExpanded(args.defaultExpanded ?? false);
+    }, [args.defaultExpanded]);
+
+    const { defaultExpanded, ...rest } = args;
+
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          background: "radial-gradient(circle at top right, #1e293b, #020617)",
+          color: "#f8fafc",
+          padding: "48px",
+        }}
+      >
+        <section style={{ maxWidth: 680 }}>
+          <h1 style={{ fontSize: "2.25rem", marginBottom: "12px" }}>BuoyDock</h1>
+          <p style={{ margin: 0, opacity: 0.75 }}>
+            Flip for å bytte mellom chat og Navi, og utvid når du trenger mer plass.
+          </p>
+        </section>
+        <BuoyDock
+          {...rest}
+          expanded={expanded}
+          onExpandedChange={(value) => {
+            setExpanded(value);
+          }}
+          childrenFront={<StoryChat />}
+          childrenBack={<StoryNavi expanded={expanded} />}
+        />
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/BuoyDock/BuoyDock.tsx
+++ b/packages/ui/src/BuoyDock/BuoyDock.tsx
@@ -1,0 +1,320 @@
+import type { ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { motion } from "framer-motion";
+import FlipCard from "../components/FlipCard.js";
+import type { FlipCardProps } from "../components/FlipCard.js";
+
+import "./buoydock.css";
+
+export type BuoyDockProps = {
+  initialSide?: "front" | "back";
+  expanded?: boolean;
+  defaultExpanded?: boolean;
+  onExpandedChange?: (value: boolean) => void;
+  titleFront?: string;
+  titleBack?: string;
+  childrenFront: ReactNode;
+  childrenBack: ReactNode;
+  ariaLabel?: string;
+};
+
+const focusableSelectors =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function BuoyDock({
+  initialSide = "front",
+  expanded,
+  defaultExpanded = false,
+  onExpandedChange,
+  titleFront = "buoy ai",
+  titleBack = "Navi",
+  childrenFront,
+  childrenBack,
+  ariaLabel = "BuoyDock widget",
+}: BuoyDockProps) {
+  const [isBack, setIsBack] = useState(() => initialSide === "back");
+  const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const isExpanded = expanded ?? internalExpanded;
+
+  const panelRef = useRef<HTMLElement | null>(null);
+  const frontHeaderRef = useRef<HTMLDivElement | null>(null);
+  const backHeaderRef = useRef<HTMLDivElement | null>(null);
+  const expandButtonRef = useRef<HTMLButtonElement | null>(null);
+  const prevExpandedRef = useRef(isExpanded);
+  const liveRegionRef = useRef<HTMLDivElement | null>(null);
+  const hasAnnouncedRef = useRef(false);
+
+  const frontTitleId = useId();
+  const backTitleId = useId();
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mediaQueryList.matches);
+
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    if (typeof mediaQueryList.addEventListener === "function") {
+      mediaQueryList.addEventListener("change", listener);
+    } else if (typeof mediaQueryList.addListener === "function") {
+      mediaQueryList.addListener(listener);
+    }
+
+    return () => {
+      if (typeof mediaQueryList.removeEventListener === "function") {
+        mediaQueryList.removeEventListener("change", listener);
+      } else if (typeof mediaQueryList.removeListener === "function") {
+        mediaQueryList.removeListener(listener);
+      }
+    };
+  }, []);
+
+  const toggleExpand = useCallback(
+    (next?: boolean) => {
+      const resolved = next ?? !isExpanded;
+
+      if (expanded === undefined) {
+        setInternalExpanded(resolved);
+      }
+
+      onExpandedChange?.(resolved);
+    },
+    [expanded, isExpanded, onExpandedChange],
+  );
+
+  useEffect(() => {
+    if (prevExpandedRef.current === isExpanded) {
+      return;
+    }
+
+    prevExpandedRef.current = isExpanded;
+
+    if (isExpanded) {
+      queueMicrotask(() => {
+        backHeaderRef.current?.focus();
+      });
+    } else {
+      queueMicrotask(() => {
+        expandButtonRef.current?.focus();
+      });
+    }
+  }, [isExpanded]);
+
+  useEffect(() => {
+    const node = panelRef.current;
+    if (!isExpanded || !node) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        toggleExpand(false);
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusable = Array.from(
+        node.querySelectorAll<HTMLElement>(focusableSelectors),
+      ).filter((element) => !element.hasAttribute("data-focus-guard"));
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        backHeaderRef.current?.focus();
+        return;
+      }
+
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (active === first || !node.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    node.addEventListener("keydown", handleKeyDown);
+    return () => {
+      node.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isExpanded, toggleExpand]);
+
+  useEffect(() => {
+    const liveNode = liveRegionRef.current;
+    if (!liveNode) {
+      return;
+    }
+
+    if (!hasAnnouncedRef.current) {
+      hasAnnouncedRef.current = true;
+      return;
+    }
+
+    liveNode.textContent = `${titleBack} ${isExpanded ? "expanded" : "collapsed"}`;
+  }, [isExpanded, titleBack]);
+
+  const handleFlip = useCallback(() => {
+    setIsBack((value) => !value);
+  }, []);
+
+  const dockRole = isExpanded ? "dialog" : "complementary";
+  const dockAriaProps = isExpanded
+    ? {
+        role: dockRole,
+        "aria-modal": "true" as const,
+        "aria-labelledby": backTitleId,
+      }
+    : { role: dockRole };
+
+  const transition = useMemo(
+    () => ({
+      duration: prefersReducedMotion ? 0.1 : 0.22,
+      ease: prefersReducedMotion ? "linear" : [0.16, 0.84, 0.44, 1],
+    }),
+    [prefersReducedMotion],
+  );
+
+  const flipCardProps: Pick<FlipCardProps, "isFlipped"> = useMemo(
+    () => ({
+      isFlipped: isBack,
+    }),
+    [isBack],
+  );
+
+  const front = (
+    <div
+      className="wbui-buoydock__face"
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+          event.stopPropagation();
+        }
+      }}
+    >
+      <header className="wbui-buoydock__header">
+        <div
+          className="wbui-buoydock__title"
+          id={frontTitleId}
+          ref={frontHeaderRef}
+          tabIndex={-1}
+        >
+          {titleFront}
+        </div>
+        <button
+          type="button"
+          className="wbui-buoydock__control wbui-focus-ring"
+          onClick={handleFlip}
+        >
+          Flip to {titleBack}
+        </button>
+      </header>
+      <div className="wbui-buoydock__content" aria-label={ariaLabel}>
+        {childrenFront}
+      </div>
+    </div>
+  );
+
+  const back = (
+    <div
+      className="wbui-buoydock__face"
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+          event.stopPropagation();
+        }
+      }}
+    >
+      <header className="wbui-buoydock__header">
+        <div
+          className="wbui-buoydock__title"
+          id={backTitleId}
+          ref={backHeaderRef}
+          tabIndex={-1}
+        >
+          {titleBack}
+        </div>
+        <div className="wbui-buoydock__actions">
+          <button
+            type="button"
+            className="wbui-buoydock__control wbui-focus-ring"
+            onClick={handleFlip}
+          >
+            Flip to {titleFront}
+          </button>
+          <button
+            type="button"
+            ref={expandButtonRef}
+            className="wbui-buoydock__control wbui-focus-ring"
+            aria-expanded={isExpanded}
+            onClick={() => toggleExpand()}
+          >
+            {isExpanded ? "Collapse" : "Expand"}
+          </button>
+        </div>
+      </header>
+      <div className="wbui-buoydock__content" aria-label={ariaLabel}>
+        {childrenBack}
+      </div>
+    </div>
+  );
+
+  return (
+    <motion.section
+      {...dockAriaProps}
+      aria-label={ariaLabel}
+      className="wbui-buoydock"
+      data-expanded={isExpanded ? "true" : "false"}
+      data-reduced-motion={prefersReducedMotion ? "true" : "false"}
+      animate={{
+        width: `var(${isExpanded ? "--wbui-dock-w-expanded" : "--wbui-dock-w"})`,
+        height: `var(${isExpanded ? "--wbui-dock-h-expanded" : "--wbui-dock-h"})`,
+      }}
+      initial={false}
+      transition={transition}
+      ref={panelRef}
+    >
+      <FlipCard
+        {...flipCardProps}
+        front={front}
+        back={back}
+        onFlip={handleFlip}
+        className="wbui-buoydock__card"
+      />
+      <div
+        className="wbui-buoydock__live-region"
+        aria-live="polite"
+        aria-atomic="true"
+        ref={liveRegionRef}
+      />
+    </motion.section>
+  );
+}
+
+export default BuoyDock;

--- a/packages/ui/src/BuoyDock/buoydock.css
+++ b/packages/ui/src/BuoyDock/buoydock.css
@@ -1,0 +1,113 @@
+:root {
+  --wbui-dock-w: 420px;
+  --wbui-dock-h: 560px;
+  --wbui-dock-w-expanded: 900px;
+  --wbui-dock-h-expanded: 680px;
+  --wbui-dock-radius: 20px;
+  --wbui-dock-shadow: 0 24px 60px rgba(15, 23, 42, 0.32);
+  --wbui-dock-surface: var(--wbui-color-surface, #0f172a);
+  --wbui-dock-surface-alt: var(--wbui-color-surface-alt, #111827);
+  --wbui-dock-border: rgba(148, 163, 184, 0.2);
+}
+
+.wbui-buoydock {
+  position: fixed;
+  inset: auto var(--wbui-space-4) var(--wbui-space-4) auto;
+  width: var(--wbui-dock-w);
+  height: var(--wbui-dock-h);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  background: var(--wbui-dock-surface);
+  border-radius: var(--wbui-dock-radius);
+  box-shadow: var(--wbui-dock-shadow);
+  overflow: hidden;
+  border: 1px solid var(--wbui-dock-border);
+  color: var(--wbui-color-text-on-surface, #f8fafc);
+}
+
+.wbui-buoydock[data-expanded="true"] {
+  z-index: 60;
+}
+
+.wbui-buoydock__card {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  cursor: default;
+}
+
+.wbui-buoydock__card .wbui-flip-card__face {
+  pointer-events: auto;
+}
+
+.wbui-buoydock__face {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--wbui-dock-surface-alt);
+}
+
+.wbui-buoydock__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--wbui-space-2, 0.5rem);
+  padding: var(--wbui-space-3, 0.75rem) var(--wbui-space-4, 1rem);
+  background: transparent;
+}
+
+.wbui-buoydock__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  outline: none;
+}
+
+.wbui-buoydock__actions {
+  display: flex;
+  gap: var(--wbui-space-2, 0.5rem);
+}
+
+.wbui-buoydock__control {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  line-height: 1.2;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.wbui-buoydock__control:hover,
+.wbui-buoydock__control:focus-visible {
+  background: rgba(148, 163, 184, 0.16);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.wbui-buoydock__content {
+  flex: 1;
+  overflow: auto;
+  padding: var(--wbui-space-4, 1rem);
+  background: transparent;
+}
+
+.wbui-buoydock__live-region {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wbui-buoydock {
+    transition: width 0.1s linear, height 0.1s linear;
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,5 +3,8 @@ import "./index.css";
 export { default as FlipCard } from "./components/FlipCard.js";
 export type { FlipCardProps } from "./components/FlipCard.js";
 
+export { default as BuoyDock } from "./BuoyDock/BuoyDock.js";
+export type { BuoyDockProps } from "./BuoyDock/BuoyDock.js";
+
 export { default as ProactivitySwitch } from "./components/ProactivitySwitch.js";
 export * from "./components/ProactivitySwitch.js";


### PR DESCRIPTION
## Summary
- add a BuoyDock component that wraps FlipCard into a fixed dock with flip/expand controls, focus trap, reduced motion support, stories, and a11y tests
- export and document BuoyDock in the UI package and tune styles for the dock layout
- update the frontend dock demo to consume BuoyDock, adjust TypeScript paths, and declare the module for local builds

## Testing
- `npx vitest run`
- `npm run -w @workbuoy/ui typecheck`
- `npm run -w @workbuoy/frontend typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68dbbaaee2c0832a8ab0a17015128c4b