### PR TITLE
feat(frontend): connect Buoy chat to /buoy/complete with graceful fallback

### DIFF
--- a/apps/frontend/src/features/buoy/useBuoy.ts
+++ b/apps/frontend/src/features/buoy/useBuoy.ts
@@ -1,6 +1,49 @@
 import { useEffect, useState } from "react";
 import type { AssistantMessage, Suggestion, UserMessage } from "./types";
 import { setBuoyTyping } from "./useBuoyStatus";
+import { apiFetch } from "@/api";
+
+type BuoyExplanation = {
+  reasoning?: string;
+  basis?: string;
+  impact?: { summary?: string };
+  alternatives?: string[];
+};
+
+type BuoyCompletionResponse = {
+  result?: unknown;
+  explanations?: BuoyExplanation[];
+  confidence?: number;
+};
+
+function formatOutcome(result: unknown): string {
+  if (result == null) return "Jeg fant ingen konkrete handlinger i svaret.";
+  if (typeof result === "string") return result;
+  if (Array.isArray(result)) {
+    return result.length
+      ? `Jeg fant ${result.length} forslag du kan jobbe videre med.`
+      : "Jeg fant ingen konkrete treff denne gangen.";
+  }
+
+  if (typeof result === "object") {
+    const typed = result as { ok?: boolean; message?: string };
+    if (typed.message) return typed.message;
+    if (typed.ok === true) return "Forslaget er klart for gjennomgang.";
+    if (typed.ok === false) return "Forslaget ble stoppet av policy eller validering.";
+  }
+
+  return "Forslaget er behandlet.";
+}
+
+function suggestionFromAlternative(alt: string) {
+  const normalized = alt.replace(/[_-]+/g, " ").trim();
+  const label = normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  return {
+    id: `alt-${alt}`,
+    label: `Kjør: ${label}`,
+    proposal: { intent: normalized },
+  };
+}
 
 export function useBuoy() {
   const [messages, setMessages] = useState<(UserMessage | AssistantMessage)[]>([
@@ -15,20 +58,39 @@ export function useBuoy() {
     setIsTyping(true);
     setBuoyTyping(true);
 
-    const assistantMessage: AssistantMessage = {
-      id: crypto.randomUUID(),
-      role: "assistant",
-      text: "Her er et forslag basert på meldingen din.",
-      why: ["Kilde: demo-datasett", "Mønster: stub response"],
-      viz: { type: "spark", values: [1, 3, 2, 5, 4] },
-      actions: [{ id: "1", label: "Godkjenn forslag" }],
-    };
+    try {
+      const body = await apiFetch<BuoyCompletionResponse>("/buoy/complete", {
+        method: "POST",
+        body: JSON.stringify({ text }),
+      });
 
-    setTimeout(() => {
+      const explanations = body.explanations ?? [];
+      const assistantMessage: AssistantMessage = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        text: formatOutcome(body.result),
+        why: explanations.flatMap((item) => [item.reasoning, item.basis, item.impact?.summary].filter(Boolean) as string[]),
+        viz: Array.isArray(body.result)
+          ? { type: "spark", values: [body.result.length, Math.max(1, Math.round((body.confidence ?? 0.5) * 10)), 5] }
+          : undefined,
+        actions: explanations[0]?.alternatives?.map(suggestionFromAlternative),
+      };
+
       setMessages((previous) => [...previous, assistantMessage]);
+    } catch {
+      setMessages((previous) => [
+        ...previous,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          text: "Jeg fikk ikke kontakt med backend. Prøv igjen om litt.",
+          why: ["Feil under kall til /buoy/complete"],
+        },
+      ]);
+    } finally {
       setIsTyping(false);
       setBuoyTyping(false);
-    }, 400);
+    }
   }
 
   function addSuggestion(suggestion: Suggestion) {


### PR DESCRIPTION
### Motivation

- Replace the hard-coded stub assistant response with real backend-driven completions so the Buoy chat shows real suggestions and explanations.
- Surface backend-provided explanations and alternatives as UI-friendly why bullets and action suggestions to make the chat product-ready.

### Description

- Replaced the stubbed assistant response in `apps/frontend/src/features/buoy/useBuoy.ts` with a POST call to `/buoy/complete` using `apiFetch` and typed the expected response as `BuoyCompletionResponse`.
- Added `formatOutcome` to map `result` into human-friendly assistant text, and `suggestionFromAlternative` to convert backend `alternatives` into action suggestions.
- Build `why` bullets from `explanations` (reasoning, basis, impact summary), show a small sparkline when `result` is a list, and expose `alternatives` as actionable suggestions.
- Added robust error fallback so the chat emits a clear retry message when the API call fails instead of silent stubs.

### Testing

- Attempted `npm run -w @workbuoy/frontend test -- --runInBand`, which failed because `vitest` is not available in the execution environment (command errored: `vitest: not found`).
- Attempted `npm run -w @workbuoy/frontend typecheck`, which failed due to missing type packages in the environment (TS errors for missing `@testing-library/jest-dom`, `node`, and `vitest` typings).
- Attempted `npm ci`, which could not complete because the repository `package-lock.json` is out of sync with `package.json` (install aborted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c3b72ce20832aacac7bcd35326e08)